### PR TITLE
add code to fail build on sourcegeneration issues

### DIFF
--- a/SourceGenerator/FunctionProvider.cs
+++ b/SourceGenerator/FunctionProvider.cs
@@ -17,6 +17,30 @@ namespace SourceGenerator
 
         public void Execute(SourceGeneratorContext context)
         {
+            // Suggested here: https://github.com/dotnet/roslyn/issues/46084
+            // Though the underlying issue is fixed, the default severity set there is warning.
+            // This way allows us to throw an actual error on any failure.
+            try
+            {
+                ExecuteInternal(context);
+            }
+            catch (Exception e)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    new DiagnosticDescriptor(
+                        "AFG1001",
+                        "An exception was thrown by the Functions generator",
+                        "An exception was thrown by the Functions generator: '{0}'",
+                        "SourceGenerator",
+                        DiagnosticSeverity.Error,
+                        isEnabledByDefault: true),
+                    Location.None,
+                    e.ToString()));
+            }
+        }
+
+        private void ExecuteInternal(SourceGeneratorContext context)
+        {
             Compilation compilation = context.Compilation;
 
             // begin creating the source we'll inject into the users compilation


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-dotnet-worker/issues/25

Here's how the error would look like (for a say `System.InvalidOperationException`) --

```
2>CSC : error AFG1001: An exception was thrown by the Functions generator: 'System.InvalidOperationException: This is my Exception message that is thrown
```

VS right now where it only throws a generic warning and continues the build
```
2>CSC : warning CS8785: Generator 'FunctionProvider' failed to generate source. It will not contribute to the output and compilation errors may occur as a result.
```
