### PR TITLE
Fix devops release task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,8 @@ pool:
 
 variables:
   ${{ if not(startswith(variables['Build.SourceBranchName'], 'release' )) }}:
-    versionSuffix: $(Build.BuildNumber)
+    versionSuffixTemp: $(Build.BuildNumber)
+  versionSuffix: $[variables.versionSuffixTemp]
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'


### PR DESCRIPTION
Ensure that the versionSuffix property exists on every build. Hiding
behind conditional was making it unavailable and treating it as a string
when running with release branches