### PR TITLE
Sign extensions when releasing extensions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,11 @@ variables:
     buildNumberTemp: $(Build.BuildNumber)
   ${{ if contains(variables['Build.SourceBranch'], '/release/' ) }}:
     isReleaseBuildTemp: true
+  ${{ if contains(variables['Build.SourceBranch'], '/release/extensions' ) }}:
+    isExtensionsReleaseTemp: true
   buildNumber: $[variables.buildNumberTemp]
   isReleaseBuild: $[variables.isReleaseBuildTemp]
+  isExtensionsRelease: $[variables.isExtensionsReleaseTemp]
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
@@ -141,6 +144,39 @@ steps:
           "ToolVersion": "1.0"
         }
       ]
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'Extensions: ESRP CodeSigning - Authenticode'
+  condition: eq(variables.isExtensionsRelease, true)
+  inputs:
+    ConnectedServiceName: 'ESRP Service'
+    FolderPath: 'extensions\**\bin\Release'
+    Pattern: Microsoft.Azure.Functions.Worker.Extensions*.dll
+    signConfigType: inlineSignParams
+    inlineOperation: |
+      [
+        {
+          "KeyCode": "CP-230012",
+          "OperationCode": "SigntoolSign",
+          "Parameters": {
+            "OpusName": "Microsoft",
+            "OpusInfo": "http://www.microsoft.com",
+            "FileDigest": "/fd \"SHA256\"",
+            "PageHash": "/NPH",
+            "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+          },
+          "ToolName": "sign",
+          "ToolVersion": "1.0"
+        },
+        {
+          "KeyCode": "CP-230012",
+          "OperationCode": "SigntoolVerify",
+          "Parameters": {},
+          "ToolName": "sign",
+          "ToolVersion": "1.0"
+        }
+      ]
+
 - task: DeleteFiles@1
   displayName: 'Delete CodeSignSummary files'
   condition: eq(variables.isReleaseBuild, true)
@@ -156,6 +192,16 @@ steps:
     projects: |
       **\DotNetWorker.csproj
       **\Sdk.csproj
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build Extension packages'
+  condition: eq(variables.isExtensionsRelease, true)
+  inputs:
+    command: 'custom'
+    custom: 'pack'
+    arguments: '--no-build -c Release -o packages -p:BuildNumber=$(buildNumber) -p:CommitHash=$(Build.SourceVersion) -p:IsLocalBuild=False'
+    projects: |
+      **\Worker.Extensions.*.csproj
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP CodeSigning: Nupkg'
@@ -182,6 +228,7 @@ steps:
             "ToolVersion": "1.0"
           }
       ]
+
 - task: DeleteFiles@1
   displayName: 'Delete CodeSignSummary files'
   condition: eq(variables.isReleaseBuild, true)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,7 +150,7 @@ steps:
   condition: eq(variables.isExtensionsRelease, true)
   inputs:
     ConnectedServiceName: 'ESRP Service'
-    FolderPath: 'extensions\**\bin\Release'
+    FolderPath: 'extensions'
     Pattern: Microsoft.Azure.Functions.Worker.Extensions*.dll
     signConfigType: inlineSignParams
     inlineOperation: |


### PR DESCRIPTION
I set it up so if build is from `release/extension*` branch, it would package and sign new extensions.