### PR TITLE
using exe for worker

### DIFF
--- a/sdk/FunctionMetadataLoaderExtension/Startup.cs
+++ b/sdk/FunctionMetadataLoaderExtension/Startup.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 [assembly: WebJobsStartup(typeof(Startup))]
 
@@ -15,11 +18,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader
 {
     internal class Startup : IWebJobsStartup2, IWebJobsConfigurationStartup
     {
+        private const string _workerConfigFile = "worker.config.json";
+        private const string _exePathPropertyName = "defaultExecutablePath";
+        private static readonly string _dotnetIsolatedWorkerConfigPath = ConfigurationPath.Combine("languageWorkers", "dotnet-isolated", "workerDirectory");
+        private static readonly string _dotnetIsolatedWorkerExePath = ConfigurationPath.Combine("languageWorkers", "dotnet-isolated", "defaultExecutablePath");
+
         public void Configure(WebJobsBuilderContext context, IWebJobsConfigurationBuilder builder)
         {
+            string appRootPath = context.ApplicationRootPath;
+
+            // We need to adjust the path to the worker exe based on the root.
+            string exePath = GetPathToExe(appRootPath);
+
             builder.ConfigurationBuilder.AddInMemoryCollection(new Dictionary<string, string>
             {
-                { "languageWorkers:dotnet-isolated:workerDirectory", context.ApplicationRootPath }
+                { _dotnetIsolatedWorkerConfigPath, appRootPath },
+                { _dotnetIsolatedWorkerExePath, exePath }
             });
         }
 
@@ -34,6 +48,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader
         public void Configure(IWebJobsBuilder builder)
         {
             // This will not be called.
+        }
+
+        internal static string GetPathToExe(string appRootPath)
+        {
+            string fullPathToWorkerConfig = Path.Combine(appRootPath, _workerConfigFile);
+
+            if (!File.Exists(fullPathToWorkerConfig))
+            {
+                throw new FileNotFoundException($"The file '{fullPathToWorkerConfig}' was not found.");
+            }
+
+            string? exePathString;
+
+            using (var fs = File.OpenText(fullPathToWorkerConfig))
+            {
+                using (var js = new JsonTextReader(fs))
+                {
+                    JObject workerDescription = (JObject)JToken.ReadFrom(js)["description"];
+                    if (!workerDescription.TryGetValue(_exePathPropertyName, out JToken exePathToken))
+                    {
+                        throw new InvalidOperationException($"The property '{_exePathPropertyName}' is required in '{fullPathToWorkerConfig}'.");
+                    }
+
+                    exePathString = Path.Combine(appRootPath, exePathToken.ToString());
+                }
+            }
+
+            if (string.IsNullOrEmpty(exePathString))
+            {
+                throw new InvalidOperationException($"The property '{_exePathPropertyName}' in '{fullPathToWorkerConfig}' cannot be null or empty.");
+            }
+
+            if (!File.Exists(exePathString))
+            {
+                throw new FileNotFoundException($"The file '{exePathString}' was not found.");
+            }
+
+            return exePathString;
         }
     }
 }

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -43,7 +43,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <WriteLinesToFile
         File="$(OutputFile)"
-        Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile)).Replace('$functionAssembly$', $(TargetFileName)))"
+        Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile)).Replace('$functionExe$', '$(TargetName).exe'))"
         Overwrite="true" />
   </Target>
 
@@ -175,7 +175,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <WriteLinesToFile
         File="$(OutputFile)"
-        Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile)).Replace('$functionAssembly$', $(TargetFileName)))"
+        Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile)).Replace('$functionExe$', '$(TargetName).exe'))"
         Overwrite="true" />
 
   </Target>

--- a/sdk/Sdk/worker.config.json
+++ b/sdk/Sdk/worker.config.json
@@ -2,7 +2,7 @@
   "description": {
     "language": "dotnet-isolated",
     "extensions": [ ".dll" ],
-    "defaultExecutablePath": "dotnet",
-    "defaultWorkerPath": "$functionAssembly$"
+    "defaultExecutablePath": "$functionExe$",
+    "defaultWorkerPath": "$functionExe$"
   }
 }


### PR DESCRIPTION
Changing from running `dotnet {app}.dll` to invoking the exe directly. This requires us to find the full path and overwrite it in the Startup, but it makes deploying a self-contained app much more straightforward.