### PR TITLE
Cardinality many from array

### DIFF
--- a/sdk/Sdk/FunctionMetadataGenerator.cs
+++ b/sdk/Sdk/FunctionMetadataGenerator.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         private const string VoidType = "System.Void";
         private const string ReturnBindingName = "$return";
         private const string HttpTriggerBindingType = "HttpTrigger";
+        private const string StringType = "System.String";
+        private const string ByteArrayType = "System.Byte[]";
 
         private readonly IndentableLogger _logger;
 
@@ -491,7 +493,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         private static bool IsIterableCollection(TypeReference type, out DataType dataType)
         {
             // Array and not byte array 
-            bool isArray = type.IsArray && !string.Equals(type.FullName, typeof(byte[]).FullName, StringComparison.Ordinal);
+            bool isArray = type.IsArray && !string.Equals(type.FullName, ByteArrayType, StringComparison.Ordinal);
             if (isArray)
             {
                 TypeSpecification? typeSpecification = type as TypeSpecification;
@@ -522,12 +524,12 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
 
         private static bool IsStringType(string fullName)
         {
-            return string.Equals(fullName, typeof(string).FullName, StringComparison.Ordinal);
+            return string.Equals(fullName, StringType, StringComparison.Ordinal);
         }
 
         private static bool IsBinaryType(string fullName)
         {
-            return string.Equals(fullName, typeof(byte[]).FullName, StringComparison.Ordinal);
+            return string.Equals(fullName, ByteArrayType, StringComparison.Ordinal);
         }
 
         private enum DataType

--- a/src/DotNetWorker/Configuration/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker/Configuration/ServiceCollectionExtensions.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Extensions.DependencyInjection
                            .AddSingleton<IConverter, TypeConverter>()
                            .AddSingleton<IConverter, MemoryConverter>()
                            .AddSingleton<IConverter, StringToByteConverter>()
-                           .AddSingleton<IConverter, JsonPocoConverter>();
+                           .AddSingleton<IConverter, JsonPocoConverter>()
+                           .AddSingleton<IConverter, EnumerableConverter>();
         }
 
         internal static IServiceCollection RegisterOutputChannel(this IServiceCollection services)

--- a/src/DotNetWorker/Context/GrpcValueProvider.cs
+++ b/src/DotNetWorker/Context/GrpcValueProvider.cs
@@ -55,6 +55,12 @@ namespace Microsoft.Azure.Functions.Worker.Context
                 // This is guaranteed to be Json here -- we can use that.
                 TypedData.DataOneofCase.Json => value.Json,
                 TypedData.DataOneofCase.Bytes => value.Bytes.Memory,
+                TypedData.DataOneofCase.CollectionBytes => value.CollectionBytes.Bytes.Select(element => {
+                    return element.Memory.ToArray();
+                }),
+                TypedData.DataOneofCase.CollectionString => value.CollectionString.String,
+                TypedData.DataOneofCase.CollectionDouble => value.CollectionDouble.Double,
+                TypedData.DataOneofCase.CollectionSint64 => value.CollectionSint64.Sint64,
                 _ => throw new NotSupportedException($"{value.DataCase} is not supported yet."),
             };
         }

--- a/src/DotNetWorker/Converters/EnumerableConverter.cs
+++ b/src/DotNetWorker/Converters/EnumerableConverter.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Azure.Functions.Worker.Converters
+{
+    internal class EnumerableConverter : IConverter
+    {
+        // Converting IEnumerable<> to common types
+        // Currently, only to array but written to be extensible
+        public bool TryConvert(ConverterContext context, out object? target)
+        {
+            EnumerableTargetType? targetType = null;
+            // Array
+            if (context.Parameter.Type.IsArray)
+            {
+                targetType = EnumerableTargetType.Array;
+            }
+
+            // Only apply if user is requesting an array, list, or hashset
+            if (targetType is not null)
+            {
+                // Valid options from FunctionRpc.proto are string, byte, double and long collection
+                if (context.Source is IEnumerable<string> enumerableString)
+                {
+                    target = GetTarget(enumerableString, targetType);
+                    return true;
+                }
+                else if (context.Source is IEnumerable<byte[]> enumerableBytes)
+                {
+                    target = GetTarget(enumerableBytes, targetType);
+                    return true;
+                }
+                else if (context.Source is IEnumerable<double> enumerableDouble)
+                {
+                    target = GetTarget(enumerableDouble, targetType);
+                    return true;
+                }
+                else if (context.Source is IEnumerable<long> enumerableLong)
+                {
+                    target = GetTarget(enumerableLong, targetType);
+                    return true;
+                }
+            }
+
+            target = default;
+            return false;
+        }
+
+        // Dictionary and Lookup not handled because we don't know 
+        // what they keySelector and elementSelector should be.
+        private static object? GetTarget<T>(IEnumerable<T> source, EnumerableTargetType? targetType)
+        {
+            switch (targetType)
+            {
+                case EnumerableTargetType.Array:
+                    return source.ToArray();
+                default:
+                    return null;
+            }
+        }
+
+        private enum EnumerableTargetType
+        {
+            Array,
+            List,
+            Dictionary,
+            HashSet,
+            Lookup
+        }
+    }
+}

--- a/src/DotNetWorker/DefaultHostRequestHandler.cs
+++ b/src/DotNetWorker/DefaultHostRequestHandler.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Functions.Worker
             response.Capabilities.Add("RawHttpBodyBytes", bool.TrueString);
             response.Capabilities.Add("RpcHttpTriggerMetadataRemoved", bool.TrueString);
             response.Capabilities.Add("UseNullableValueDictionaryForHttp", bool.TrueString);
+            response.Capabilities.Add("TypedDataCollection", bool.TrueString);
 
             response.WorkerVersion = typeof(DefaultHostRequestHandler).Assembly.GetName().Version?.ToString();
 

--- a/test/DotNetWorkerTests/Converters/EnumerableConverterTests.cs
+++ b/test/DotNetWorkerTests/Converters/EnumerableConverterTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Google.Protobuf.Collections;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests.Converters
+{
+    public class EnumerableConverterTests
+    {
+        private const string _sourceString = "hello";
+        private static readonly byte[] _sourceBytes = Encoding.UTF8.GetBytes(_sourceString);
+        private EnumerableConverter _converter = new EnumerableConverter();
+
+        private static readonly IEnumerable<byte[]> _sourceMemoryEnumerable = new RepeatedField<byte[]>() { _sourceBytes };
+        private static readonly RepeatedField<string> _sourceStringEnumerable = new RepeatedField<string>() { _sourceString };
+        private static readonly RepeatedField<double> _sourceDoubleEnumerable = new RepeatedField<double>() { 1.0 };
+        private static readonly RepeatedField<long> _sourceLongEnumerable = new RepeatedField<long>() { 2000 };
+
+        [Fact]
+        public void ConvertCollectionBytesToByteDoubleArray()
+        {
+            var context = new TestConverterContext("output", typeof(byte[][]), _sourceMemoryEnumerable);
+            Assert.True(_converter.TryConvert(context, out object target));
+            TestUtility.AssertIsTypeAndConvert<byte[][]>(target);
+        }
+
+        [Fact]
+        public void ConvertCollectionStringToStringArray()
+        {
+            var context = new TestConverterContext("output", typeof(string[]), _sourceStringEnumerable);
+            Assert.True(_converter.TryConvert(context, out object target));
+            TestUtility.AssertIsTypeAndConvert<string[]>(target);
+        }
+
+        [Fact]
+        public void ConvertCollectionSint64ToLongArray()
+        {
+            var context = new TestConverterContext("output", typeof(long[]), _sourceLongEnumerable);
+            Assert.True(_converter.TryConvert(context, out object target));
+            TestUtility.AssertIsTypeAndConvert<long[]>(target);
+        }
+
+        [Fact]
+        public void ConvertCollectionDoubleToDoubleArray()
+        {
+            var context = new TestConverterContext("output", typeof(double[]), _sourceDoubleEnumerable);
+            Assert.True(_converter.TryConvert(context, out object target));
+            TestUtility.AssertIsTypeAndConvert<double[]>(target);
+        }
+
+        [Fact]
+        public void ConvertCollectionBytesToByteArrayListFails()
+        {
+            var context = new TestConverterContext("output", typeof(List<byte[]>), _sourceMemoryEnumerable);
+            Assert.False(_converter.TryConvert(context, out object target));
+        }
+
+    }
+}

--- a/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
@@ -168,6 +170,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                     { "Name", "queuePayload" },
                     { "Type", "QueueTrigger" },
                     { "Direction", "In" },
+                    { "DataType", "String" },
                     { "Connection", "MyConnection" },
                     { "queueName", "queueName" }
                 });
@@ -196,6 +199,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                     { "Name", "blob" },
                     { "Type", "BlobTrigger" },
                     { "Direction", "In" },
+                    { "DataType", "String" },
                     { "blobPath", "container2/%file%" }
                 });
             }
@@ -270,7 +274,8 @@ namespace Microsoft.Azure.Functions.SdkTests
                     { "Type", "QueueTrigger" },
                     { "Direction", "In" },
                     { "Connection", "MyConnection" },
-                    { "queueName", "queueName" }
+                    { "queueName", "queueName" },
+                    { "DataType", "String" }
                 });
             }
 
@@ -282,6 +287,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                     { "Type", "Blob" },
                     { "Direction", "Out" },
                     { "blobPath", "container1/hello.txt" },
+                    { "DataType", "String" },
                     { "Connection", "MyOtherConnection" }
                 });
             }
@@ -294,6 +300,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                     { "Type", "Queue" },
                     { "Direction", "Out" },
                     { "queueName", "queue2" },
+                    { "DataType", "String" }
                 });
             }
         }
@@ -328,7 +335,8 @@ namespace Microsoft.Azure.Functions.SdkTests
                     { "Name", "req" },
                     { "Type", "HttpTrigger" },
                     { "Direction", "In" },
-                    { "methods", new[] { "get" } }
+                    { "methods", new[] { "get" } },
+                    { "DataType", "String" }
                 });
             }
 
@@ -350,6 +358,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                     { "Type", "Queue" },
                     { "Direction", "Out" },
                     { "queueName", "queue2" },
+                    { "DataType", "String" }
                 });
             }
         }
@@ -380,7 +389,8 @@ namespace Microsoft.Azure.Functions.SdkTests
                     { "Name", "req" },
                     { "Type", "HttpTrigger" },
                     { "Direction", "In" },
-                    { "methods", new[] { "get" } }
+                    { "methods", new[] { "get" } },
+                    { "DataType", "String" }
                 });
             }
 
@@ -405,6 +415,76 @@ namespace Microsoft.Azure.Functions.SdkTests
             var exception = Assert.Throws<Exception>(() => generator.GenerateFunctionMetadata(typeDef));
 
             Assert.Contains($"Found multiple Output bindings on method", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("StringInputFunction", nameof(CardinalityMany.StringInputFunction), false, "String")]
+        [InlineData("StringArrayInputFunction", nameof(CardinalityMany.StringArrayInputFunction), true, "String")]
+        [InlineData("BinaryInputFunction", nameof(CardinalityMany.BinaryInputFunction), false, "Binary")]
+        [InlineData("BinaryArrayInputFunction", nameof(CardinalityMany.BinaryArrayInputFunction), true, "Binary")]
+        [InlineData("IntArrayInputFunction", nameof(CardinalityMany.IntArrayInputFunction), true, "")]
+        [InlineData("StringListInputFunction", nameof(CardinalityMany.StringListInputFunction), false, "")]
+        [InlineData("StringDoubleArrayInputFunction", nameof(CardinalityMany.StringDoubleArrayInputFunction), true, "")]
+        [InlineData("BinaryListInputFunction", nameof(CardinalityMany.BinaryListInputFunction), false, "")]
+        [InlineData("IntListInputFunction", nameof(CardinalityMany.IntListInputFunction), true, "")]
+        [InlineData("EnumerableClassInputFunction", nameof(CardinalityMany.EnumerableClassInputFunction), false, "")]
+        [InlineData("EnumerableStringClassInputFunction", nameof(CardinalityMany.EnumerableStringClassInputFunction), false, "")]
+        [InlineData("EnumerableBinaryClassInputFunction", nameof(CardinalityMany.EnumerableBinaryClassInputFunction), false, "")]
+        [InlineData("EnumerableGenericClassInputFunction", nameof(CardinalityMany.EnumerableGenericClassInputFunction), false, "")]
+        [InlineData("EnumerableNestedBinaryClassInputFunction", nameof(CardinalityMany.EnumerableNestedBinaryClassInputFunction), false, "")]
+        [InlineData("EnumerableNestedStringClassInputFunction", nameof(CardinalityMany.EnumerableNestedStringClassInputFunction), false, "")]
+        [InlineData("EnumerableNestedStringGenericClassInputFunction", nameof(CardinalityMany.EnumerableNestedStringGenericClassInputFunction), false, "")]
+        [InlineData("EnumerableNestedStringGenericClass2InputFunction", nameof(CardinalityMany.EnumerableNestedStringGenericClass2InputFunction), false, "")]
+        [InlineData("LookupInputFunction", nameof(CardinalityMany.LookupInputFunction), false, "")]
+        [InlineData("DictionaryInputFunction", nameof(CardinalityMany.DictionaryInputFunction), false, "")]
+        [InlineData("ConcurrentDictionaryInputFunction", nameof(CardinalityMany.ConcurrentDictionaryInputFunction), false, "")]
+        [InlineData("HashSetInputFunction", nameof(CardinalityMany.HashSetInputFunction), false, "")]
+        [InlineData("EnumerableInputFunction", nameof(CardinalityMany.EnumerableInputFunction), false, "")]
+        [InlineData("EnumerableStringInputFunction", nameof(CardinalityMany.EnumerableStringInputFunction), false, "")]
+        [InlineData("EnumerableBinaryInputFunction", nameof(CardinalityMany.EnumerableBinaryInputFunction), false, "")]
+        [InlineData("EnumerableGenericInputFunction", nameof(CardinalityMany.EnumerableGenericInputFunction), false, "")]
+        [InlineData("EnumerablePocoInputFunction", nameof(CardinalityMany.EnumerablePocoInputFunction), false, "")]
+        [InlineData("ListPocoInputFunction", nameof(CardinalityMany.ListPocoInputFunction), false, "")]
+        [InlineData("ArrayPocoInputFunction", nameof(CardinalityMany.ArrayPocoInputFunction), true, "")]
+        public void CardinalityManyFunctions(string functionName, string entryPoint, bool cardinalityMany, string dataType)
+        {
+            var generator = new FunctionMetadataGenerator();
+            var typeDef = TestUtility.GetTypeDefinition(typeof(CardinalityMany));
+            var functions = generator.GenerateFunctionMetadata(typeDef);
+            var extensions = generator.Extensions;
+
+            SdkFunctionMetadata metadata = functions.Where(a => string.Equals(a.Name, functionName, StringComparison.Ordinal)).Single();
+
+            ValidateFunction(metadata, functionName, GetEntryPoint(nameof(CardinalityMany), entryPoint),
+                b => ValidateTrigger(b, cardinalityMany));
+
+            AssertDictionary(extensions, new Dictionary<string, string>(){
+                { "Microsoft.Azure.WebJobs.Extensions.EventHubs", "4.2.0" }
+            });
+
+            void ValidateTrigger(ExpandoObject b, bool many)
+            {
+                var expected = new Dictionary<string, object>()
+                {
+                    { "Name", "input" },
+                    { "Type", "EventHubTrigger" },
+                    { "Direction", "In" },
+                    { "eventHubName", "test" },
+                    { "Connection", "EventHubConnectionAppSetting" }
+                };
+
+                if (many)
+                {
+                    expected.Add("Cardinality", "Many");
+                }
+
+                if (!string.IsNullOrEmpty(dataType))
+                {
+                    expected.Add("DataType", dataType);
+                }
+
+                AssertExpandoObject(b, expected);
+            }
         }
 
         private static string GetEntryPoint(string className, string methodName) => $"{typeof(FunctionMetadataGeneratorTests).FullName}+{className}.{methodName}";
@@ -567,6 +647,278 @@ namespace Microsoft.Azure.Functions.SdkTests
             {
                 throw new NotImplementedException();
             }
+        }
+
+        private class CardinalityMany
+        {
+            [Function("StringInputFunction")]
+            public static void StringInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] string input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("StringArrayInputFunction")]
+            public static void StringArrayInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] string[] input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("BinaryInputFunction")]
+            public static void BinaryInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] byte[] input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("BinaryArrayInputFunction")]
+            public static void BinaryArrayInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] byte[][] input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("IntArrayInputFunction")]
+            public static void IntArrayInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] int[] input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("StringListInputFunction")]
+            public static void StringListInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] List<string> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("StringDoubleArrayInputFunction")]
+            public static void StringDoubleArrayInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] string[][] input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("BinaryListInputFunction")]
+            public static void BinaryListInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] List<byte[]> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("IntListInputFunction")]
+            public static void IntListInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] int[] input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableClassInputFunction")]
+            public static void EnumerableClassInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] EnumerableTestClass input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableStringClassInputFunction")]
+            public static void EnumerableStringClassInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] EnumerableStringTestClass input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableBinaryClassInputFunction")]
+            public static void EnumerableBinaryClassInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] EnumerableBinaryTestClass input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableGenericClassInputFunction")]
+            public static void EnumerableGenericClassInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] EnumerableGenericTestClass input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableNestedBinaryClassInputFunction")]
+            public static void EnumerableNestedBinaryClassInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] EnumerableBinaryNestedTestClass input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableNestedStringClassInputFunction")]
+            public static void EnumerableNestedStringClassInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] EnumerableStringNestedTestClass input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableNestedStringGenericClassInputFunction")]
+            public static void EnumerableNestedStringGenericClassInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] EnumerableStringNestedGenericTestClass<string> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableNestedStringGenericClass2InputFunction")]
+            public static void EnumerableNestedStringGenericClass2InputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] EnumerableStringNestedGenericTestClass2<string, int> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("LookupInputFunction")]
+            public static void LookupInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] Lookup<string, int> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("DictionaryInputFunction")]
+            public static void DictionaryInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] Dictionary<string, string> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("ConcurrentDictionaryInputFunction")]
+            public static void ConcurrentDictionaryInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] ConcurrentDictionary<string, string> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("HashSetInputFunction")]
+            public static void HashSetInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] HashSet<string> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableInputFunction")]
+            public static void EnumerableInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] IEnumerable input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableStringInputFunction")]
+            public static void EnumerableStringInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] IEnumerable<string> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableBinaryInputFunction")]
+            public static void EnumerableBinaryInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] IEnumerable<byte[]> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerableGenericInputFunction")]
+            public static void EnumerableGenericInputFunction<T>([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] IEnumerable<T> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("EnumerablePocoInputFunction")]
+            public static void EnumerablePocoInputFunction<T>([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] IEnumerable<Poco> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("ListPocoInputFunction")]
+            public static void ListPocoInputFunction<T>([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] List<Poco> input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            [Function("ArrayPocoInputFunction")]
+            public static void ArrayPocoInputFunction([EventHubTrigger("test", Connection = "EventHubConnectionAppSetting")] Poco[] input,
+                FunctionContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class EnumerableTestClass : IEnumerable
+        {
+            public IEnumerator GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class EnumerableStringTestClass : IEnumerable<string>
+        {
+            public IEnumerator GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator<string> IEnumerable<string>.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class EnumerableBinaryTestClass : IEnumerable<byte[]>
+        {
+            public IEnumerator GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator<byte[]> IEnumerable<byte[]>.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class EnumerableStringTestClass<T> : List<T>
+        {
+        }
+
+        private class EnumerableBinaryNestedTestClass : EnumerableBinaryTestClass
+        {
+        }
+
+        private class EnumerableStringNestedTestClass : EnumerableStringTestClass
+        {
+        }
+
+        private class EnumerableStringNestedGenericTestClass2<T, V> : EnumerableStringNestedGenericTestClass<T>
+        {
+        }
+
+        private class EnumerableStringNestedGenericTestClass<TK> : EnumerableStringTestClass<TK>
+        {
+        }
+
+        private class EnumerableGenericTestClass : IEnumerable<int>
+        {
+            public IEnumerator GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator<int> IEnumerable<int>.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class Poco
+        {
+            public string Foo;
+            public string Bar;
         }
     }
 }

--- a/test/FunctionMetadataGeneratorTests/SdkTests.csproj
+++ b/test/FunctionMetadataGeneratorTests/SdkTests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\extensions\Worker.Extensions.Http\Worker.Extensions.Http.csproj" />
     <ProjectReference Include="..\..\extensions\Worker.Extensions.Storage\Worker.Extensions.Storage.csproj" />
     <ProjectReference Include="..\..\extensions\Worker.Extensions.Timer\Worker.Extensions.Timer.csproj" />
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.EventHubs\Worker.Extensions.EventHubs.csproj" />
     <ProjectReference Include="..\..\sdk\FunctionMetadataLoaderExtension\FunctionMetadataLoaderExtension.csproj" />
     <ProjectReference Include="..\..\sdk\Sdk\Sdk.csproj" />
     <ProjectReference Include="..\..\src\DotNetWorker\DotNetWorker.csproj" />

--- a/test/SdkE2ETests/Contents/functions.metadata
+++ b/test/SdkE2ETests/Contents/functions.metadata
@@ -22,6 +22,7 @@
         "name": "myBlob",
         "type": "Blob",
         "direction": "In",
+        "dataType":  "String",
         "blobPath": "test-samples/sample1.txt",
         "connection": "AzureWebJobsStorage"
       },
@@ -59,6 +60,7 @@
         "name": "myBlob",
         "type": "Blob",
         "direction": "In",
+        "dataType": "String",
         "blobPath": "test-samples/sample1.txt",
         "connection": "AzureWebJobsStorage"
       }

--- a/test/SdkE2ETests/Contents/functions.metadata
+++ b/test/SdkE2ETests/Contents/functions.metadata
@@ -89,6 +89,7 @@
         "name": "Name",
         "type": "Queue",
         "direction": "Out",
+        "dataType":  "String",
         "queueName": "functionstesting2",
         "connection": "AzureWebJobsStorage"
       },


### PR DESCRIPTION
Related to: https://github.com/Azure/azure-functions-dotnet-worker/pull/205 , which implements cardinality many for anything that is an IEnumerable. This is scoped down to array types, which is a more simple rule to follow on when data type is batched vs. isn't.

Also appears consistent with the current WebJobs contract for "cardinality": "many"
https://github.com/Azure/azure-functions-host/blob/v3.0.15417/src/WebJobs.Script/Binding/GeneralScriptBindingProvider.cs#L72-L77

Resolves https://github.com/Azure/azure-functions-dotnet-worker/issues/127
Resolves https://github.com/Azure/azure-functions-dotnet-worker/issues/115

### SDK Changes
- For inputs, try to set "dataType" if we know the requested payload is `string` or `byte[]`
- Try set "cardinality": "many" if we know that the requested payload implements IEnumerable or IEnumerable Generic
  - Set "dataType" if we know that the requested payload inside of the collection is `string` or `byte[]`

### .NET Worker Changes
- Enable capability to receive TypedData of:
  - collection bytes
  - collection string
  - collection double
  - collection long
- New converter which converts `IEnumerable<string>`, `IEnumerable<byte[]>`, `IEnumerable<double>`, and `IEnumerable<long>` (from above capability) to Array type
- _Observation: not all types the user requests (ex: "Queue" which implements IEnumerable) will be properly converted, although "cardinality": "many" will be set. Potentially worth surfacing some sort of warning or error if we are unable to convert. From user perspective seems difficult to debug._

