### PR TITLE
moving grpc usage out of hostedservice

### DIFF
--- a/src/DotNetWorker/GrpcWorker.cs
+++ b/src/DotNetWorker/GrpcWorker.cs
@@ -2,14 +2,17 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Microsoft.Azure.Functions.Worker.Context;
 using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.Grpc.Messages;
 using Microsoft.Azure.Functions.Worker.Invocation;
 using Microsoft.Azure.Functions.Worker.OutputBindings;
-using static Microsoft.Azure.Functions.Worker.Grpc.Messages.StatusResult.Types;
+using Microsoft.Extensions.Options;
+using static Microsoft.Azure.Functions.Worker.Grpc.Messages.FunctionRpc;
 using MsgType = Microsoft.Azure.Functions.Worker.Grpc.Messages.StreamingMessage.ContentOneofCase;
 
 
@@ -17,26 +20,81 @@ namespace Microsoft.Azure.Functions.Worker
 {
     internal class GrpcWorker : IWorker
     {
+        private readonly ChannelReader<StreamingMessage> _outputReader;
         private readonly ChannelWriter<StreamingMessage> _outputWriter;
+
         private readonly IFunctionsApplication _application;
+        private readonly FunctionRpcClient _rpcClient;
         private readonly IInvocationFeaturesFactory _invocationFeaturesFactory;
         private readonly IOutputBindingsInfoProvider _outputBindingsInfoProvider;
         private readonly IMethodInfoLocator _methodInfoLocator;
+        private readonly IOptions<GrpcWorkerStartupOptions> _startupOptions;
+        private Task? _writerTask;
+        private Task? _readerTask;
 
-        public GrpcWorker(IFunctionsApplication application, FunctionsHostOutputChannel outputChannel, IInvocationFeaturesFactory invocationFeaturesFactory,
-            IOutputBindingsInfoProvider outputBindingsInfoProvider, IMethodInfoLocator methodInfoLocator)
+        public GrpcWorker(IFunctionsApplication application, FunctionRpcClient rpcClient, FunctionsHostOutputChannel outputChannel, IInvocationFeaturesFactory invocationFeaturesFactory,
+            IOutputBindingsInfoProvider outputBindingsInfoProvider, IMethodInfoLocator methodInfoLocator, IOptions<GrpcWorkerStartupOptions> startupOptions)
         {
             if (outputChannel == null)
             {
                 throw new ArgumentNullException(nameof(outputChannel));
             }
 
+            _outputReader = outputChannel.Channel.Reader;
             _outputWriter = outputChannel.Channel.Writer;
 
             _application = application ?? throw new ArgumentNullException(nameof(application));
+            _rpcClient = rpcClient ?? throw new ArgumentNullException(nameof(rpcClient));
             _invocationFeaturesFactory = invocationFeaturesFactory ?? throw new ArgumentNullException(nameof(invocationFeaturesFactory));
             _outputBindingsInfoProvider = outputBindingsInfoProvider ?? throw new ArgumentNullException(nameof(outputBindingsInfoProvider));
             _methodInfoLocator = methodInfoLocator ?? throw new ArgumentNullException(nameof(methodInfoLocator));
+            _startupOptions = startupOptions ?? throw new ArgumentNullException(nameof(startupOptions));
+        }
+
+        public Task StartAsync(CancellationToken token)
+        {
+            var eventStream = _rpcClient.EventStream();
+
+            _writerTask = StartWriterAsync(eventStream.RequestStream);
+            _readerTask = StartReaderAsync(eventStream.ResponseStream);
+
+            return SendStartStreamMessageAsync(eventStream.RequestStream);
+        }
+
+        public Task StopAsync(CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task SendStartStreamMessageAsync(IClientStreamWriter<StreamingMessage> requestStream)
+        {
+            StartStream str = new StartStream()
+            {
+                WorkerId = _startupOptions.Value.WorkerId
+            };
+
+            StreamingMessage startStream = new StreamingMessage()
+            {
+                StartStream = str
+            };
+
+            await requestStream.WriteAsync(startStream);
+        }
+
+        public async Task StartWriterAsync(IClientStreamWriter<StreamingMessage> requestStream)
+        {
+            await foreach (StreamingMessage rpcWriteMsg in _outputReader.ReadAllAsync())
+            {
+                await requestStream.WriteAsync(rpcWriteMsg);
+            }
+        }
+
+        public async Task StartReaderAsync(IAsyncStreamReader<StreamingMessage> responseStream)
+        {
+            while (await responseStream.MoveNext())
+            {
+                await ProcessRequestAsync(responseStream.Current);
+            }
         }
 
         public Task ProcessRequestAsync(StreamingMessage request)
@@ -107,7 +165,7 @@ namespace Microsoft.Azure.Functions.Worker
             var response = new FunctionLoadResponse
             {
                 FunctionId = loadRequest.FunctionId,
-                Result = new StatusResult { Status = Status.Success }
+                Result = new StatusResult { Status = StatusResult.Types.Status.Success }
             };
 
             var responseMessage = new StreamingMessage

--- a/src/DotNetWorker/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker/Hosting/ServiceCollectionExtensions.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
             // Request handling
-            services.AddSingleton<IWorker, GrpcWorker>();
             services.AddSingleton<IFunctionsApplication, FunctionsApplication>();
 
             // Execution
@@ -76,10 +75,11 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IOutputBindingsInfoProvider, DefaultOutputBindingsInfoProvider>();
 
             // gRpc
+            services.AddSingleton<IWorker, GrpcWorker>();
             services.AddSingleton<FunctionRpcClient>(p =>
             {
-                IOptions<WorkerStartupOptions> argumentsOptions = p.GetService<IOptions<WorkerStartupOptions>>();
-                WorkerStartupOptions arguments = argumentsOptions.Value;
+                IOptions<GrpcWorkerStartupOptions> argumentsOptions = p.GetService<IOptions<GrpcWorkerStartupOptions>>();
+                GrpcWorkerStartupOptions arguments = argumentsOptions.Value;
 
                 GrpcChannel grpcChannel = GrpcChannel.ForAddress($"http://{arguments.Host}:{arguments.Port}", new GrpcChannelOptions()
                 {
@@ -89,9 +89,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 return new FunctionRpcClient(grpcChannel);
             });
             services.AddSingleton<IHostedService, WorkerHostedService>();
-
-            // Options
-            services.AddOptions<WorkerStartupOptions>()
+            services.AddOptions<GrpcWorkerStartupOptions>()
                 .Configure<IConfiguration>((arguments, config) =>
                 {
                     config.Bind(arguments);

--- a/src/DotNetWorker/IWorker.cs
+++ b/src/DotNetWorker/IWorker.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Functions.Worker.Grpc.Messages;
 
 namespace Microsoft.Azure.Functions.Worker
 {
     internal interface IWorker
     {
-        Task ProcessRequestAsync(StreamingMessage request);
+        Task StartAsync(CancellationToken token);
+
+        Task StopAsync(CancellationToken token);
     }
 }

--- a/src/DotNetWorker/WorkerHostedService.cs
+++ b/src/DotNetWorker/WorkerHostedService.cs
@@ -4,77 +4,27 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Grpc.Core;
-using Microsoft.Azure.Functions.Worker.Grpc.Messages;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
-using static Microsoft.Azure.Functions.Worker.Grpc.Messages.FunctionRpc;
 
 namespace Microsoft.Azure.Functions.Worker
 {
     internal class WorkerHostedService : IHostedService
     {
-        private readonly WorkerStartupOptions _options;
-        private readonly FunctionRpcClient _rpcClient;
-        private readonly FunctionsHostOutputChannel _outputChannel;
         private readonly IWorker _worker;
 
-        private Task? _writerTask;
-        private Task? _readerTask;
-
-        public WorkerHostedService(FunctionRpcClient rpcClient, FunctionsHostOutputChannel outputChannel, IWorker worker, IOptions<WorkerStartupOptions> options)
+        public WorkerHostedService(IWorker worker)
         {
-            _rpcClient = rpcClient ?? throw new ArgumentNullException(nameof(rpcClient));
-            _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
             _worker = worker ?? throw new ArgumentNullException(nameof(worker));
-            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         }
 
-        public async Task StartAsync(CancellationToken cancellationToken)
+        public Task StartAsync(CancellationToken cancellationToken)
         {
-            var eventStream = _rpcClient.EventStream();
-
-            _writerTask = StartWriterAsync(eventStream.RequestStream);
-            _readerTask = StartReaderAsync(eventStream.ResponseStream);
-
-            await SendStartStreamMessageAsync(eventStream.RequestStream);
+            return _worker.StartAsync(cancellationToken);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            // TODO: Proper handling of shutdown.
-            return Task.CompletedTask;
-        }
-
-        public async Task SendStartStreamMessageAsync(IClientStreamWriter<StreamingMessage> requestStream)
-        {
-            StartStream str = new StartStream()
-            {
-                WorkerId = _options.WorkerId
-            };
-
-            StreamingMessage startStream = new StreamingMessage()
-            {
-                StartStream = str
-            };
-
-            await requestStream.WriteAsync(startStream);
-        }
-
-        public async Task StartWriterAsync(IClientStreamWriter<StreamingMessage> requestStream)
-        {
-            await foreach (StreamingMessage rpcWriteMsg in _outputChannel.Channel.Reader.ReadAllAsync())
-            {
-                await requestStream.WriteAsync(rpcWriteMsg);
-            }
-        }
-
-        public async Task StartReaderAsync(IAsyncStreamReader<StreamingMessage> responseStream)
-        {
-            while (await responseStream.MoveNext())
-            {
-                await _worker.ProcessRequestAsync(responseStream.Current);
-            }
+            return _worker.StopAsync(cancellationToken);
         }
     }
 }

--- a/src/DotNetWorker/WorkerStartupOptions.cs
+++ b/src/DotNetWorker/WorkerStartupOptions.cs
@@ -1,10 +1,10 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 
 namespace Microsoft.Azure.Functions.Worker
 {
-    internal class WorkerStartupOptions
+    internal class GrpcWorkerStartupOptions
     {
         public string? Host { get; set; }
 


### PR DESCRIPTION
This changes the `IWorker` interface to just have Start/Stop and moves all Grpc interaction from the hosted service into the worker.