### PR TITLE
Throw if no converter

### DIFF
--- a/src/DotNetWorker/Context/Features/DefaultModelBindingFeature.cs
+++ b/src/DotNetWorker/Context/Features/DefaultModelBindingFeature.cs
@@ -1,4 +1,4 @@
-﻿g// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;

--- a/src/DotNetWorker/Context/Features/DefaultModelBindingFeature.cs
+++ b/src/DotNetWorker/Context/Features/DefaultModelBindingFeature.cs
@@ -1,9 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+﻿g// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Definition;
+using Microsoft.Azure.Functions.Worker.Diagnostics.Exceptions;
 
 namespace Microsoft.Azure.Functions.Worker.Context.Features
 {
@@ -31,6 +34,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
             _parameterValues = new object?[context.FunctionDefinition.Parameters.Length];
             _inputBound = true;
 
+            List<string>? errors = null;
             for (int i = 0; i < _parameterValues.Length; i++)
             {
                 FunctionParameter param = context.FunctionDefinition.Parameters[i];
@@ -51,8 +55,20 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                 }
                 else if (source is not null)
                 {
-                    throw new InvalidCastException($"Cannot convert input parameter '{param.Name}' for Function '{context.FunctionDefinition.Name}' to type '{param.Type.FullName}' from type '{source.GetType().FullName}'.");
+                    // Don't initialize this list unless we have to
+                    if (errors is null)
+                    {
+                        errors = new List<string>();
+                    }
+
+                    errors.Add($"Cannot convert input parameter '{param.Name}' to type '{param.Type.FullName}' from type '{source.GetType().FullName}'.");
                 }
+            }
+            
+            // found errors
+            if (errors is not null)
+            {
+                throw new FunctionInputConverterException($"Error converting {errors.Count} input parameters for Function '{context.FunctionDefinition.Name}': {string.Join(" ", errors)}");
             }
 
             return _parameterValues;

--- a/src/DotNetWorker/Context/Features/DefaultModelBindingFeature.cs
+++ b/src/DotNetWorker/Context/Features/DefaultModelBindingFeature.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
         public object?[]? InputArguments => _parameterValues;
 
-        public object?[] BindFunctionInput(FunctionContext context)
+        public object?[] TryBindFunctionInput(FunctionContext context)
         {
             if (_inputBound)
             {
@@ -48,7 +48,10 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                 if (TryConvert(converterContext, out object? target))
                 {
                     _parameterValues[i] = target;
-                    continue;
+                }
+                else if (source is not null)
+                {
+                    throw new InvalidCastException($"Cannot convert input parameter '{param.Name}' for Function '{context.FunctionDefinition.Name}' to type '{param.Type.FullName}' from type '{source.GetType().FullName}'.");
                 }
             }
 

--- a/src/DotNetWorker/Context/Features/DefaultModelBindingFeature.cs
+++ b/src/DotNetWorker/Context/Features/DefaultModelBindingFeature.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
         public object?[]? InputArguments => _parameterValues;
 
-        public object?[] TryBindFunctionInput(FunctionContext context)
+        public object?[] BindFunctionInput(FunctionContext context)
         {
             if (_inputBound)
             {

--- a/src/DotNetWorker/Context/Features/IModelBindingFeature.cs
+++ b/src/DotNetWorker/Context/Features/IModelBindingFeature.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
     {
         object?[]? InputArguments { get; }
 
-        object?[] BindFunctionInput(FunctionContext context);
+        object?[] TryBindFunctionInput(FunctionContext context);
     }
 }

--- a/src/DotNetWorker/Context/Features/IModelBindingFeature.cs
+++ b/src/DotNetWorker/Context/Features/IModelBindingFeature.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
     {
         object?[]? InputArguments { get; }
 
-        object?[] TryBindFunctionInput(FunctionContext context);
+        object?[] BindFunctionInput(FunctionContext context);
     }
 }

--- a/src/DotNetWorker/Diagnostics/Exceptions/FunctionInputConverterException.cs
+++ b/src/DotNetWorker/Diagnostics/Exceptions/FunctionInputConverterException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Functions.Worker.Diagnostics.Exceptions
+{
+    internal class FunctionInputConverterException : FunctionWorkerException
+    {
+        internal FunctionInputConverterException(string message) : base(message) { }
+
+        internal FunctionInputConverterException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/DotNetWorker/Diagnostics/Exceptions/FunctionWorkerException.cs
+++ b/src/DotNetWorker/Diagnostics/Exceptions/FunctionWorkerException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Functions.Worker.Diagnostics
+{
+    /// <summary>
+    /// Internal exception that is surfaced to the user
+    /// </summary>
+    internal class FunctionWorkerException : Exception
+    {
+        internal FunctionWorkerException(string message) : base(message) { }
+
+        internal FunctionWorkerException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}


### PR DESCRIPTION
Instead of keeping the input as null if we are unable to convert it, we should throw (or at least warn) why the input is null.

Example:
```
[2021-03-03T07:32:17.585Z] Executed 'Functions.HelloFromQuery' (Failed, Id=e2f3400d-23a8-4a1e-8bee-b3268a652376, Duration=195ms)
[2021-03-03T07:32:17.590Z] System.Private.CoreLib: Exception while executing function: Functions.HelloFromQuery. System.Private.CoreLib: Result: Failure
Exception: System.InvalidCastException: Cannot convert input parameter 'req' for Function 'HelloFromQuery' to type 'System.String' from type 'Microsoft.Azure.Functions.Worker.GrpcHttpRequestData'.
```