### PR TITLE
Remove rpc collection and add test 

### DIFF
--- a/src/DotNetWorker/RpcExtensions.cs
+++ b/src/DotNetWorker/RpcExtensions.cs
@@ -127,64 +127,6 @@ namespace Microsoft.Azure.Functions.Worker
             return Task.FromResult(http);
         }
 
-        internal static TypedData ToRpcByteArray(this byte[][] arrBytes)
-        {
-            TypedData typedData = new TypedData();
-            CollectionBytes collectionBytes = new CollectionBytes();
-            foreach (byte[] element in arrBytes)
-            {
-                if (element != null)
-                {
-                    collectionBytes.Bytes.Add(ByteString.CopyFrom(element));
-                }
-            }
-            typedData.CollectionBytes = collectionBytes;
-
-            return typedData;
-        }
-
-        internal static TypedData ToRpcStringArray(this string[] arrString)
-        {
-            TypedData typedData = new TypedData();
-            CollectionString collectionString = new CollectionString();
-            foreach (string element in arrString)
-            {
-                if (!string.IsNullOrEmpty(element))
-                {
-                    collectionString.String.Add(element);
-                }
-            }
-            typedData.CollectionString = collectionString;
-
-            return typedData;
-        }
-
-        internal static TypedData ToRpcDoubleArray(this double[] arrDouble)
-        {
-            TypedData typedData = new TypedData();
-            CollectionDouble collectionDouble = new CollectionDouble();
-            foreach (double element in arrDouble)
-            {
-                collectionDouble.Double.Add(element);
-            }
-            typedData.CollectionDouble = collectionDouble;
-
-            return typedData;
-        }
-
-        internal static TypedData ToRpcLongArray(this long[] arrLong)
-        {
-            TypedData typedData = new TypedData();
-            CollectionSInt64 collectionLong = new CollectionSInt64();
-            foreach (long element in arrLong)
-            {
-                collectionLong.Sint64.Add(element);
-            }
-            typedData.CollectionSint64 = collectionLong;
-
-            return typedData;
-        }
-
         internal static FunctionDefinition ToFunctionDefinition(this FunctionLoadRequest loadRequest, IMethodInfoLocator methodInfoLocator)
         {
             return new GrpcFunctionDefinition(loadRequest, methodInfoLocator);

--- a/src/DotNetWorker/RpcExtensions.cs
+++ b/src/DotNetWorker/RpcExtensions.cs
@@ -41,10 +41,6 @@ namespace Microsoft.Azure.Functions.Worker
             {
                 typedData.String = str;
             }
-            else if (value.GetType().IsArray)
-            {
-                typedData = ToRpcCollection(value, serializer);
-            }
             else
             {
                 typedData = value.ToRpcDefault(serializer);
@@ -70,10 +66,6 @@ namespace Microsoft.Azure.Functions.Worker
             {
                 typedData.String = str;
             }
-            else if (value.GetType().IsArray)
-            {
-                typedData = ToRpcCollection(value, serializer);
-            }
             else
             {
                 typedData = value.ToRpcDefault(serializer);
@@ -93,33 +85,6 @@ namespace Microsoft.Azure.Functions.Worker
             catch
             {
                 typedData.String = value.ToString();
-            }
-
-            return typedData;
-        }
-
-        public static TypedData ToRpcCollection(this object value, ObjectSerializer serializer)
-        {
-            TypedData typedData;
-            if (value is byte[][] arrBytes)
-            {
-                typedData = arrBytes.ToRpcByteArray();
-            }
-            else if (value is string[] arrStr)
-            {
-                typedData = arrStr.ToRpcStringArray();
-            }
-            else if (value is double[] arrDouble)
-            {
-                typedData = arrDouble.ToRpcDoubleArray();
-            }
-            else if (value is long[] arrLong)
-            {
-                typedData = arrLong.ToRpcLongArray();
-            }
-            else
-            {
-                typedData = value.ToRpcDefault(serializer);
             }
 
             return typedData;

--- a/test/E2ETests/E2EApps/E2EApp/Queue/QueueTestFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Queue/QueueTestFunctions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp.Queue
             return message;
         }
 
-        [Function("QueueTriggerAndOutput")]
+        [Function("QueueTriggerAndArrayOutput")]
         [QueueOutput("test-output-array-dotnet-isolated")]
         public string[] QueueTriggerAndArrayOutput([QueueTrigger("test-input-array-dotnet-isolated")] string message,
             FunctionContext context)
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp.Queue
             };
         }
 
-        [Function("QueueTriggerAndOutput")]
+        [Function("QueueTriggerAndListOutput")]
         [QueueOutput("test-output-list-dotnet-isolated")]
         public List<string> QueueTriggerAndListOutput([QueueTrigger("test-input-list-dotnet-isolated")] string message,
             FunctionContext context)

--- a/test/E2ETests/E2EApps/E2EApp/Queue/QueueTestFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Queue/QueueTestFunctions.cs
@@ -33,8 +33,8 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp.Queue
             logger.LogInformation($"Message: {message}");
 
             return new string[] {
-                message + "-1",
-                message + "-2"
+                message + "|1",
+                message + "|2"
             };
         }
 
@@ -47,8 +47,8 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp.Queue
             logger.LogInformation($"Message: {message}");
 
             return new List<string>() {
-                message + "-1",
-                message + "-2"
+                message + "|1",
+                message + "|2"
             };
         }
 

--- a/test/E2ETests/E2EApps/E2EApp/Queue/QueueTestFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Queue/QueueTestFunctions.cs
@@ -24,6 +24,34 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp.Queue
             return message;
         }
 
+        [Function("QueueTriggerAndOutput")]
+        [QueueOutput("test-output-array-dotnet-isolated")]
+        public string[] QueueTriggerAndArrayOutput([QueueTrigger("test-input-array-dotnet-isolated")] string message,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger<QueueTestFunctions>();
+            logger.LogInformation($"Message: {message}");
+
+            return new string[] {
+                message + "-1",
+                message + "-2"
+            };
+        }
+
+        [Function("QueueTriggerAndOutput")]
+        [QueueOutput("test-output-list-dotnet-isolated")]
+        public List<string> QueueTriggerAndListOutput([QueueTrigger("test-input-list-dotnet-isolated")] string message,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger<QueueTestFunctions>();
+            logger.LogInformation($"Message: {message}");
+
+            return new List<string>() {
+                message + "-1",
+                message + "-2"
+            };
+        }
+
         [Function("QueueOutputPocoList")]
         public HttpAndQueue QueueOutputPocoList(
             [HttpTrigger()] HttpRequestData request,

--- a/test/E2ETests/E2ETests/Constants.cs
+++ b/test/E2ETests/E2ETests/Constants.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             public const string InputArrayBindingName = "test-input-array-dotnet-isolated";
             public const string OutputArrayBindingName = "test-output-array-dotnet-isolated";
             public const string InputListBindingName = "test-input-list-dotnet-isolated";
-            public const string OutputListBindingName = "test-input-list-dotnet-isolated";
+            public const string OutputListBindingName = "test-output-list-dotnet-isolated";
             public const string OutputBindingNamePOCO = "test-output-dotnet-isolated-poco";
             public const string InputBindingNamePOCO = "test-input-dotnet-isolated-poco";
             public const string InputBindingNameMetadata = "test-input-dotnet-isolated-metadata";

--- a/test/E2ETests/E2ETests/Constants.cs
+++ b/test/E2ETests/E2ETests/Constants.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
         {
             public const string OutputBindingName = "test-output-dotnet-isolated";
             public const string InputBindingName = "test-input-dotnet-isolated";
+            public const string InputArrayBindingName = "test-input-array-dotnet-isolated";
+            public const string OutputArrayBindingName = "test-output-array-dotnet-isolated";
+            public const string InputListBindingName = "test-input-list-dotnet-isolated";
+            public const string OutputListBindingName = "test-input-list-dotnet-isolated";
             public const string OutputBindingNamePOCO = "test-output-dotnet-isolated-poco";
             public const string InputBindingNamePOCO = "test-input-dotnet-isolated-poco";
             public const string InputBindingNameMetadata = "test-input-dotnet-isolated-metadata";

--- a/test/E2ETests/E2ETests/StorageEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/StorageEndToEndTests.cs
@@ -51,12 +51,12 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             await StorageHelpers.InsertIntoQueue(Constants.Queue.InputArrayBindingName, expectedQueueMessage);
 
             //Verify
-            string queueMessage1 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
+            string queueMessage1 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputArrayBindingName);
             string[] splitMessage1 = queueMessage1.Split("|");
             Assert.Equal(expectedQueueMessage, splitMessage1[0]);
             Assert.True(string.Equals("1", splitMessage1[1]) || string.Equals("2", splitMessage1[1]));
 
-            string queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
+            string queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputArrayBindingName);
             string[] splitMessage2 = queueMessage2.Split("|");
             Assert.Equal(expectedQueueMessage, splitMessage2[0]);
             Assert.True(string.Equals("1", splitMessage2[1]) || string.Equals("2", splitMessage2[1]));

--- a/test/E2ETests/E2ETests/StorageEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/StorageEndToEndTests.cs
@@ -51,10 +51,16 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             await StorageHelpers.InsertIntoQueue(Constants.Queue.InputArrayBindingName, expectedQueueMessage);
 
             //Verify
-            var queueMessage1 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputArrayBindingName);
-            Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage1) || string.Equals(expectedQueueMessage + "-2", queueMessage1));
-            var queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputArrayBindingName);
-            Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage2) || string.Equals(expectedQueueMessage + "-2", queueMessage2));
+            string queueMessage1 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
+            string[] splitMessage1 = queueMessage1.Split("|");
+            Assert.Equal(expectedQueueMessage, splitMessage1[0]);
+            Assert.True(string.Equals("1", splitMessage1[1]) || string.Equals("2", splitMessage1[1]));
+
+            string queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
+            string[] splitMessage2 = queueMessage2.Split("|");
+            Assert.Equal(expectedQueueMessage, splitMessage2[0]);
+            Assert.True(string.Equals("1", splitMessage2[1]) || string.Equals("2", splitMessage2[1]));
+
             Assert.NotEqual(queueMessage1, queueMessage2);
         }
 
@@ -71,10 +77,16 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             await StorageHelpers.InsertIntoQueue(Constants.Queue.InputListBindingName, expectedQueueMessage);
 
             //Verify
-            var queueMessage1 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
-            Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage1) || string.Equals(expectedQueueMessage + "-2", queueMessage1));
-            var queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
-            Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage2) || string.Equals(expectedQueueMessage + "-2", queueMessage2));
+            string queueMessage1 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
+            string[] splitMessage1 = queueMessage1.Split("|");
+            Assert.Equal(expectedQueueMessage, splitMessage1[0]);
+            Assert.True(string.Equals("1", splitMessage1[1]) || string.Equals("2", splitMessage1[1]));
+
+            string queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
+            string[] splitMessage2 = queueMessage2.Split("|");
+            Assert.Equal(expectedQueueMessage, splitMessage2[0]);
+            Assert.True(string.Equals("1", splitMessage2[1]) || string.Equals("2", splitMessage2[1]));
+
             Assert.NotEqual(queueMessage1, queueMessage2);
         }
 

--- a/test/E2ETests/E2ETests/StorageEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/StorageEndToEndTests.cs
@@ -39,6 +39,44 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
         }
 
         [Fact]
+        public async Task QueueTriggerAndArrayOutput_Succeeds()
+        {
+            string expectedQueueMessage = Guid.NewGuid().ToString();
+            //Clear queue
+            await StorageHelpers.ClearQueue(Constants.Queue.InputArrayBindingName);
+            await StorageHelpers.ClearQueue(Constants.Queue.OutputArrayBindingName);
+
+            //Set up and trigger            
+            await StorageHelpers.CreateQueue(Constants.Queue.OutputArrayBindingName);
+            await StorageHelpers.InsertIntoQueue(Constants.Queue.InputArrayBindingName, expectedQueueMessage);
+
+            //Verify
+            var queueMessage1 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputArrayBindingName);
+            Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage1) || string.Equals(expectedQueueMessage + "-2", queueMessage1));
+            var queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputArrayBindingName);
+            Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage2) || string.Equals(expectedQueueMessage + "-2", queueMessage2));
+        }
+
+        [Fact]
+        public async Task QueueTriggerAndListOutput_Succeeds()
+        {
+            string expectedQueueMessage = Guid.NewGuid().ToString();
+            //Clear queue
+            await StorageHelpers.ClearQueue(Constants.Queue.InputListBindingName);
+            await StorageHelpers.ClearQueue(Constants.Queue.OutputListBindingName);
+
+            //Set up and trigger            
+            await StorageHelpers.CreateQueue(Constants.Queue.OutputListBindingName);
+            await StorageHelpers.InsertIntoQueue(Constants.Queue.InputListBindingName, expectedQueueMessage);
+
+            //Verify
+            var queueMessage1 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
+            Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage1) || string.Equals(expectedQueueMessage + "-2", queueMessage1));
+            var queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
+            Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage2) || string.Equals(expectedQueueMessage + "-2", queueMessage2));
+        }
+
+        [Fact]
         public async Task QueueTrigger_BindToTriggerMetadata_Succeeds()
         {
             string inputQueueMessage = Guid.NewGuid().ToString();

--- a/test/E2ETests/E2ETests/StorageEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/StorageEndToEndTests.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage1) || string.Equals(expectedQueueMessage + "-2", queueMessage1));
             var queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputArrayBindingName);
             Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage2) || string.Equals(expectedQueueMessage + "-2", queueMessage2));
+            Assert.NotEqual(queueMessage1, queueMessage2);
         }
 
         [Fact]
@@ -74,6 +75,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage1) || string.Equals(expectedQueueMessage + "-2", queueMessage1));
             var queueMessage2 = await StorageHelpers.ReadFromQueue(Constants.Queue.OutputListBindingName);
             Assert.True(string.Equals(expectedQueueMessage + "-1", queueMessage2) || string.Equals(expectedQueueMessage + "-2", queueMessage2));
+            Assert.NotEqual(queueMessage1, queueMessage2);
         }
 
         [Fact]


### PR DESCRIPTION
RPC collection is not yet supported by host

Resolves https://github.com/Azure/azure-functions-dotnet-worker/issues/124

Fails with `Unknown RpcDataType`:
https://github.com/Azure/azure-functions-host/blob/9ac904e34b744d95a6f746921556235d4b2b3f0f/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs#L48