### PR TITLE
Add snippet tags to define doc snippets

### DIFF
--- a/samples/FunctionApp/Function1/Function1.cs
+++ b/samples/FunctionApp/Function1/Function1.cs
@@ -11,6 +11,7 @@ namespace FunctionApp
 {
     public static class Function1
     {
+        //<docsnippet_multiple_outputs>
         [Function("Function1")]
         public static MyOutputType Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequestData req,
@@ -30,6 +31,7 @@ namespace FunctionApp
                 HttpReponse = response
             };
         }
+        //</docsnippet_multiple_outputs>
 
         public class MyOutputType
         {

--- a/samples/FunctionApp/Program.cs
+++ b/samples/FunctionApp/Program.cs
@@ -17,6 +17,7 @@ namespace FunctionApp
 // #if DEBUG
 //          Debugger.Launch();
 // #endif
+            //<startup>
             var host = new HostBuilder()
                 .ConfigureAppConfiguration(c =>
                 {
@@ -31,8 +32,11 @@ namespace FunctionApp
                     s.AddSingleton<IHttpResponderService, DefaultHttpResponderService>();
                 })
                 .Build();
+            //</startup>
 
+            //<host_start>
             await host.RunAsync();
+            //</host_start>
         }
     }
 }

--- a/samples/FunctionApp/Program.cs
+++ b/samples/FunctionApp/Program.cs
@@ -19,18 +19,24 @@ namespace FunctionApp
 // #endif
             //<docsnippet_startup>
             var host = new HostBuilder()
+                //<docsnippet_configure_app>
                 .ConfigureAppConfiguration(c =>
                 {
                     c.AddCommandLine(args);
                 })
+                //</docsnippet_configure_app>
+                //<docsnippet_middleware>
                 .ConfigureFunctionsWorker((c, b) =>
                 {
                     b.UseFunctionExecutionMiddleware();
                 })
+                //</docsnippet_middleware>
+                //<docsnippet_dependency_injection>
                 .ConfigureServices(s =>
                 {
                     s.AddSingleton<IHttpResponderService, DefaultHttpResponderService>();
                 })
+                //</docsnippet_dependency_injection>
                 .Build();
             //</docsnippet_startup>
 

--- a/samples/FunctionApp/Program.cs
+++ b/samples/FunctionApp/Program.cs
@@ -17,7 +17,7 @@ namespace FunctionApp
 // #if DEBUG
 //          Debugger.Launch();
 // #endif
-            //<startup>
+            //<docsnippet_startup>
             var host = new HostBuilder()
                 .ConfigureAppConfiguration(c =>
                 {
@@ -32,11 +32,11 @@ namespace FunctionApp
                     s.AddSingleton<IHttpResponderService, DefaultHttpResponderService>();
                 })
                 .Build();
-            //</startup>
+            //</docsnippet_startup>
 
-            //<host_start>
+            //<docsnippet_host_run>
             await host.RunAsync();
-            //</host_start>
+            //</docsnippet_host_run>
         }
     }
 }

--- a/samples/SampleApp/Http/HttpFunction.cs
+++ b/samples/SampleApp/Http/HttpFunction.cs
@@ -10,12 +10,15 @@ namespace SampleApp
 {
     public static class HttpFunction
     {
+        //<docsnippet_http_trigger>
         [Function("HttpFunction")]
         public static HttpResponseData Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequestData req,
             FunctionContext executionContext)
         {
+            //<docsnippet_logging>
             var logger = executionContext.GetLogger("HttpFunction");
             logger.LogInformation("message logged");
+            //</docsnippet_logging>
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Date", "Mon, 18 Jul 2016 16:06:00 GMT");
@@ -25,5 +28,6 @@ namespace SampleApp
 
             return response;
         }
+        //</docsnippet_http_trigger>
     }
 }

--- a/samples/SampleApp/Queue/QueueFunction.cs
+++ b/samples/SampleApp/Queue/QueueFunction.cs
@@ -8,10 +8,13 @@ namespace SampleApp
 {
     public static class QueueFunction
     {
+        //<docsnippet_queue_output_binding>
+        //<docsnippet_queue_trigger>
         [Function("QueueFunction")]
         [QueueOutput("functionstesting2")]
         public static string Run([QueueTrigger("functionstesting2")] Book myQueueItem,
             FunctionContext context)
+        //</docsnippet_queue_trigger>
         {
             var logger = context.GetLogger("QueueFunction");
             logger.LogInformation($"Book name = {myQueueItem.Name}");
@@ -19,6 +22,7 @@ namespace SampleApp
             // Queue Output
             return "queue message";
         }
+        //</docsnippet_queue_output_binding>
     }
 
     public class Book


### PR DESCRIPTION
By using snippet XML tags, we can guarantee that the snippet tagged code stays in sync with the docs, even if changes are made to the file. Otherwise, if we use range values registration can get off.

You can verify in the staging build that this does in fact work correctly: https://review.docs.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide?branch=pr-en-us-149017  