### PR TITLE
Fix sdk targets to support nobuild publish

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -23,6 +23,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <_FunctionsExtensionTargetFramework Condition=" '$(_FunctionsExtensionTargetFramework)'==''">netcoreapp3.1</_FunctionsExtensionTargetFramework>
     <_FunctionsExtensionsDirectory>.azurefunctions</_FunctionsExtensionsDirectory>
     <_FunctionsExtensionsJsonName>extensions.json</_FunctionsExtensionsJsonName>
+    <_FunctionsExtensionsFullPublish Condition="$(NoBuild) == '' And $(_FunctionsExtensionsFullPublish) == ''">True</_FunctionsExtensionsFullPublish>
+    <_FunctionsExtensionsFullPublish Condition="$(_FunctionsExtensionsFullPublish) == ''">!$(NoBuild)</_FunctionsExtensionsFullPublish>
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateFunctionMetadata"
@@ -256,7 +258,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   We need to copy all files from <build-out>/bin except for "runtimes" directory. The "runtimes" directory inside "bin" doesn't contain the binaries for all platforms.
   This is due to a bug in Functions SDK. Until that is fixed, we need to copy "runtimes" directly from build output, instead of copying from the "bin".
   -->
-  <Target Name ="_WorkerExtensionsPublishCopy" AfterTargets="_WorkerExtensionsPublish">
+  <Target Name ="_WorkerExtensionsPublishCopy">
     <ItemGroup>
       <ExtensionBinaries Include="$(ExtensionsCsProjFilePath)\publishout\bin\**\*.*"
                          Exclude="$(ExtensionsCsProjFilePath)\publishout\bin\runtimes\**\*.*"/>
@@ -267,24 +269,59 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Copy SourceFiles="@(ExtensionRuntimeBinaries)" DestinationFolder="$(PublishDir)\.azurefunctions\runtimes\%(RecursiveDir)" />
   </Target>
 
-  <Target Name ="_WorkerExtensionsPublish" AfterTargets="_WorkerExtensionsRestorePublish">
-    <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" RemoveProperties="DeployOnBuild" Targets="Build" Properties="Configuration=Release;OutputPath=$(ExtensionsCsProjFilePath)\publishout;CopyLocalLockFileAssemblies=true"/>
+  <Target Name ="_WorkerExtensionsFullPublish">
+    <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" RemoveProperties="DeployOnBuild" Targets="Publish" Properties="Configuration=Release;OutputPath=$(ExtensionsCsProjFilePath)\publishout;CopyLocalLockFileAssemblies=true"/>
   </Target>
 
-  <Target Name="_WorkerExtensionsRestorePublish" AfterTargets="_GenerateFunctionsAndCopyContentFiles">
+  <Target Name="_WorkerExtensionsRestorePublish">
     <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" Targets="Restore" Properties="IsRestoring=true"/>
   </Target>
+
+  <Target Name="_WorkerExtensionsPublish"
+        AfterTargets="_GenerateFunctionsAndCopyContentFiles"
+        DependsOnTargets="$(FunctionsWorkerExtensionsPublishDependsOn)">
+  </Target>
+
+  <PropertyGroup>
+    <FunctionsWorkerExtensionsPublishDependsOn Condition="$(_FunctionsExtensionsFullPublish)">
+      _GenerateFunctionsAndCopyContentFiles;
+      _WorkerExtensionsRestorePublish;
+      _WorkerExtensionsFullPublish;
+      _WorkerExtensionsPublishCopy;
+      _EnhanceFunctionsExtensionsMetadataPostPublish
+    </FunctionsWorkerExtensionsPublishDependsOn>
+    <FunctionsWorkerExtensionsPublishDependsOn Condition="!$(_FunctionsExtensionsFullPublish)">
+      _GenerateFunctionsAndCopyContentFiles;
+      _WorkerExtensionsPublishCopyNoBuild
+    </FunctionsWorkerExtensionsPublishDependsOn>
+  </PropertyGroup>
 
   <!-- 
   Add HintPath to references in "extensions.json"
   -->
-  <Target Name="_EnhanceFunctionsExtensionsMetadataPostPublish"
-          AfterTargets="_WorkerExtensionsPublishCopy">
+  <Target Name="_EnhanceFunctionsExtensionsMetadataPostPublish">
 
     <EnhanceExtensionsMetadata
       ExtensionsJsonPath="$(PublishDir)\$(_FunctionsExtensionsDirectory)\$(_FunctionsExtensionsJsonName)"
-      OutputPath="$(PublishDir)\$(_FunctionsExtensionsJsonName)"/>
+      OutputPath="$(PublishDir)\$(_FunctionsExtensionsJsonName)" />
 
+  </Target>
+
+  <!--
+  Copies the assemblies from build directory ("bin\...\net5.0\") to the publish directory ("bin\...\net5.0\publish")
+  This task is executed instead of full publish of WorkerExtensions when NoBuild property is set
+  -->
+  <Target Name ="_WorkerExtensionsPublishCopyNoBuild">
+    <ItemGroup>
+      <ExtensionBinaries Include="$(OutDir)\$(_FunctionsExtensionsDirectory)\**\*.*"
+                         Exclude="$(OutDir)\$(_FunctionsExtensionsDirectory)\runtimes\**\*.*"/>
+      <ExtensionRuntimeBinaries Include="$(OutDir)\.azurefunctions\runtimes\**\*.*" />
+      <ExtensionsJson Include="$(OutDir)\$(_FunctionsExtensionsJsonName)" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(ExtensionBinaries)" DestinationFolder="$(PublishDir)\$(_FunctionsExtensionsDirectory)\%(RecursiveDir)" />
+    <Copy SourceFiles="@(ExtensionRuntimeBinaries)" DestinationFolder="$(PublishDir)\$(_FunctionsExtensionsDirectory)\runtimes\%(RecursiveDir)" />
+    <Copy SourceFiles="@(ExtensionsJson)" DestinationFolder="$(PublishDir)\" />
   </Target>
 
 </Project>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -270,7 +270,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </Target>
 
   <Target Name ="_WorkerExtensionsFullPublish">
-    <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" RemoveProperties="DeployOnBuild" Targets="Publish" Properties="Configuration=Release;OutputPath=$(ExtensionsCsProjFilePath)\publishout;CopyLocalLockFileAssemblies=true"/>
+    <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" RemoveProperties="DeployOnBuild" Targets="Publish" Properties="Configuration=Release;PublishDir=$(ExtensionsCsProjFilePath)\publishout;OutputPath=$(ExtensionsCsProjFilePath)\publishout;CopyLocalLockFileAssemblies=true"/>
   </Target>
 
   <Target Name="_WorkerExtensionsRestorePublish">


### PR DESCRIPTION
Switching to "publish" for WorkerExtensions isn't trivial as when a user passes `--no-build`, the WorkerExtensions can't use the last build to generate the publish content. This is because WorkerExtensions build runs dynamically in a temporary directory.

So, we had two choices --
1. Ignore NoBuild and do a full publish even when "--no-build" is passed. But this goes against the argument semantics.
2. When NoBuild is passed, manually copy the binaries from user's built contents.

I went with 2. as it makes most sense to honor the `--no-build` flag. This behavior can be overwritten by passing a property `_FunctionsExtensionsFullPublish`. 

Fixes https://github.com/Azure/azure-functions-dotnet-worker/issues/420