### PR TITLE
Tweak extension samples

### DIFF
--- a/samples/CustomMiddleware/CustomMiddleware.csproj
+++ b/samples/CustomMiddleware/CustomMiddleware.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.1" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/CustomMiddleware/Program.cs
+++ b/samples/CustomMiddleware/Program.cs
@@ -19,7 +19,6 @@ namespace CustomMiddleware
                 })
                 .Build();
             //</docsnippet_middleware_register>
-            
             host.Run();
         }
     }

--- a/samples/CustomMiddleware/Program.cs
+++ b/samples/CustomMiddleware/Program.cs
@@ -19,7 +19,7 @@ namespace CustomMiddleware
                 })
                 .Build();
             //</docsnippet_middleware_register>
-
+            
             host.Run();
         }
     }

--- a/samples/Extensions/Blob/BlobFunction.cs
+++ b/samples/Extensions/Blob/BlobFunction.cs
@@ -20,7 +20,7 @@ namespace SampleApp
             logger.LogInformation($"Input Item = {myBlob}");
 
             // Blob Output
-            return "queue message";
+            return "blob-output content";
         }
     }
 }

--- a/samples/Extensions/DependencyInjection/DependencyInjectionFunction.cs
+++ b/samples/Extensions/DependencyInjection/DependencyInjectionFunction.cs
@@ -47,8 +47,7 @@ namespace SampleApp
             var response = httpRequest.CreateResponse(HttpStatusCode.OK);
 
             response.Headers.Add("Date", "Mon, 18 Jul 2016 16:06:00 GMT");
-            response.Headers.Add("Content", "Content - Type: text / html; charset = utf - 8");
-
+            response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             response.WriteString("Welcome to .NET 5!!");
 
             return response;

--- a/samples/Extensions/Extensions.csproj
+++ b/samples/Extensions/Extensions.csproj
@@ -14,19 +14,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="3.0.9" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="4.2.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Kafka" Version="3.2.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.RabbitMQ" Version="1.0.0-beta" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.SignalRService" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="4.0.4" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Warmup" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.1" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Warmup" Version="4.0.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>

--- a/samples/Extensions/Queue/QueueFunction.cs
+++ b/samples/Extensions/Queue/QueueFunction.cs
@@ -11,8 +11,8 @@ namespace SampleApp
         //<docsnippet_queue_output_binding>
         //<docsnippet_queue_trigger>
         [Function("QueueFunction")]
-        [QueueOutput("functionstesting2")]
-        public static string Run([QueueTrigger("functionstesting2")] Book myQueueItem,
+        [QueueOutput("myqueue-output")]
+        public static string Run([QueueTrigger("myqueue-items")] Book myQueueItem,
             FunctionContext context)
         //</docsnippet_queue_trigger>
         {

--- a/samples/Extensions/Table/TableFunction.cs
+++ b/samples/Extensions/Table/TableFunction.cs
@@ -4,28 +4,26 @@
 using System;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 
 namespace SampleApp
 {
     public static class TableFunction
     {
         [Function("TableFunction")]
-        [TableOutput("outputQueue", Connection = "ServiceBusConnection")]
+        [TableOutput("OutputTable", Connection = "AzureWebJobsStorage")]
         public static MyTableData Run([QueueTrigger("table-items")] string input,
-            [TableInput("MyTable", "MyPartition", "{queueTrigger}")] JObject tableItem,
+            [TableInput("MyTable", "MyPartition", "{queueTrigger}")] MyTableData tableInput,
             FunctionContext context)
         {
             var logger = context.GetLogger("TableFunction");
 
-            logger.LogInformation(tableItem.ToString());
+            logger.LogInformation($"PK={tableInput.PartitionKey}, RK={tableInput.RowKey}, Text={tableInput.Text}");
 
-            var message = $"Output message created at {DateTime.Now}";
             return new MyTableData()
             {
                 PartitionKey = "queue",
                 RowKey = Guid.NewGuid().ToString(),
-                Text = message
+                Text = $"Output record with rowkey {input} created at {DateTime.Now}"
             };
         }
     }

--- a/samples/Extensions/Timer/TimerFunction.cs
+++ b/samples/Extensions/Timer/TimerFunction.cs
@@ -10,27 +10,11 @@ namespace SampleApp
     public static class TimerFunction
     {
         [Function("TimerFunction")]
-        public static void Run([TimerTrigger("0 */5 * * * *")] MyInfo timerInfo,
+        public static void Run([TimerTrigger("0 */5 * * * *")] TimerInfo timerInfo,
             FunctionContext context)
         {
             var logger = context.GetLogger("TimerFunction");
             logger.LogInformation($"Function Ran. Next timer schedule = {timerInfo.ScheduleStatus.Next}");
         }
-    }
-
-    public class MyInfo
-    {
-        public MyScheduleStatus ScheduleStatus { get; set; }
-
-        public bool IsPastDue { get; set; }
-    }
-
-    public class MyScheduleStatus
-    {
-        public DateTime Last { get; set; }
-
-        public DateTime Next { get; set; }
-
-        public DateTime LastUpdated { get; set; }
     }
 }

--- a/samples/FunctionApp/Function1/Function1.cs
+++ b/samples/FunctionApp/Function1/Function1.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-
 using System.Net;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
@@ -21,7 +20,7 @@ namespace FunctionApp
             var response = req.CreateResponse(HttpStatusCode.OK);
 
             response.Headers.Add("Date", "Mon, 18 Jul 2016 16:06:00 GMT");
-            response.Headers.Add("Content", "Content - Type: text / html; charset = utf - 8");
+            response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             response.WriteString("Book Sent to Queue!");
 
             return new MyOutputType()

--- a/samples/FunctionApp/Function4/Function4.cs
+++ b/samples/FunctionApp/Function4/Function4.cs
@@ -20,8 +20,7 @@ namespace FunctionApp
             var response = req.CreateResponse(HttpStatusCode.OK);
 
             response.Headers.Add("Date", "Mon, 18 Jul 2016 16:06:00 GMT");
-            response.Headers.Add("Content", "Content - Type: text / html; charset = utf - 8");
-
+            response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             response.WriteString("Welcome to .NET 5!!");
 
             return response;

--- a/samples/FunctionApp/Function5/Function5.cs
+++ b/samples/FunctionApp/Function5/Function5.cs
@@ -45,8 +45,7 @@ namespace FunctionApp
             var response = httpRequest.CreateResponse(HttpStatusCode.OK);
            
             response.Headers.Add("Date", "Mon, 18 Jul 2016 16:06:00 GMT");
-            response.Headers.Add("Content", "Content - Type: text / html; charset = utf - 8");
-
+            response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             response.WriteString("Welcome to .NET 5!!");
 
             return response;


### PR DESCRIPTION
While testing out some of the samples I found a few things in that might be confusing to folks. 

- cleared up naming confusion (queue/table/blob/servicebus)
- fix format of http response headers
- update to the current version of the worker packages
- removed no longer needed custom timerinfo class (MyInfo)

I hope it is of any value.
