### PR TITLE
Sign Sdk.Analyzers.dll included in Worker.Sdk

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
     inputs:
       ConnectedServiceName: 'ESRP Service'
       FolderPath: 'sdk\sdk\bin\Release'
-      Pattern: Microsoft.Azure.Functions.Worker.Sdk.dll
+      Pattern: Microsoft.Azure.Functions.Worker.Sdk*.dll
       signConfigType: inlineSignParams
       inlineOperation: |
         [


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-dotnet-worker/issues/415

These files inside `Microsoft.Azure.Functions.Worker.Sdk.nupkg` were not authenticode signed :

- `Microsoft.Azure.Functions.Worker.Sdk.Analyzers.dll`
- `Mono.Cecil.dll`
- `Mono.Cecil.Mdb.dll`
- `Mono.Cecil.Pdb.dll`
- `Mono.Cecil.Rocks.dll`

This PR addresses only the first one as that's our dll. I am guessing we are Ok leaving `Mono.Cecil*` as is. 