### PR TITLE
Add extra HttpTriggerAttribute constructors for OpenAPI extension

### DIFF
--- a/DotNetWorker.sln
+++ b/DotNetWorker.sln
@@ -93,6 +93,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "net-5-entity-framework", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Configuration", "samples\Configuration\Configuration.csproj", "{035AAD56-5F51-476C-8556-0F6CFD6EF1BF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtensionsTests", "test\ExtensionsTests\ExtensionsTests.csproj", "{E7663A94-44B2-4D45-8B7F-FEA96BF8F7EC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -219,6 +221,10 @@ Global
 		{035AAD56-5F51-476C-8556-0F6CFD6EF1BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{035AAD56-5F51-476C-8556-0F6CFD6EF1BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{035AAD56-5F51-476C-8556-0F6CFD6EF1BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7663A94-44B2-4D45-8B7F-FEA96BF8F7EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7663A94-44B2-4D45-8B7F-FEA96BF8F7EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7663A94-44B2-4D45-8B7F-FEA96BF8F7EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7663A94-44B2-4D45-8B7F-FEA96BF8F7EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -257,6 +263,7 @@ Global
 		{2A72383A-9C00-41FB-9D29-909EE5E6BFB9} = {9D6603BD-7EA2-4D11-A69C-0D9E01317FD6}
 		{C4C0CE7E-6A34-473E-A8FB-7D8FBA765779} = {9D6603BD-7EA2-4D11-A69C-0D9E01317FD6}
 		{035AAD56-5F51-476C-8556-0F6CFD6EF1BF} = {9D6603BD-7EA2-4D11-A69C-0D9E01317FD6}
+		{E7663A94-44B2-4D45-8B7F-FEA96BF8F7EC} = {FD7243E4-BF18-43F8-8744-BA1D17ACF378}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {497D2ED4-A13E-4BCA-8D29-F30CA7D0EA4A}

--- a/extensions/Worker.Extensions.Http/HttpTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Http/HttpTriggerAttribute.cs
@@ -92,32 +92,27 @@ namespace Microsoft.Azure.Functions.Worker
         /// </summary>
         public AuthorizationLevel AuthLevel { get; private set; }
 
-        private static AuthorizationLevel GetAuthorizationLevel(string authLevel)
+        private static AuthorizationLevel GetAuthorizationLevel(string authLevelKey)
         {
-            if (string.IsNullOrWhiteSpace(authLevel))
+            if (string.IsNullOrWhiteSpace(authLevelKey))
             {
                 return AuthorizationLevel.Function;
             }
 
-            var trimmed = authLevel.Trim();
+            var trimmed = authLevelKey.Trim();
             if (string.IsNullOrWhiteSpace(trimmed))
             {
                 return AuthorizationLevel.Function;
             }
 
-            if (!trimmed.StartsWith("%"))
-            {
-                return AuthorizationLevel.Function;
-            }
-
-            if (!trimmed.EndsWith("%"))
+            if ((trimmed.StartsWith("%") && trimmed.EndsWith("%")) == false)
             {
                 return AuthorizationLevel.Function;
             }
 
             trimmed = trimmed.Trim('%');
-            var authLevelKey = Environment.GetEnvironmentVariable(trimmed);
-            var authorizationLevel = Enum.TryParse<AuthorizationLevel>(authLevelKey, ignoreCase: true, out var result)
+            var authLevel = Environment.GetEnvironmentVariable(trimmed);
+            var authorizationLevel = Enum.TryParse<AuthorizationLevel>(authLevel, ignoreCase: true, out var result)
                                      ? result
                                      : AuthorizationLevel.Function;
 

--- a/extensions/Worker.Extensions.Http/HttpTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Http/HttpTriggerAttribute.cs
@@ -41,6 +41,17 @@ namespace Microsoft.Azure.Functions.Worker
 
         /// <summary>
         /// Creates an instance of the <see cref="HttpTriggerAttribute"/>, specifying the
+        /// required <see cref="AuthorizationLevel"/> in string.
+        /// </summary>
+        /// <param name="authLevelKey">The environment variable key to get the string representation of the <see cref="AuthorizationLevel"/> value to apply.</param>
+        /// <remarks>The authLevelKey value MUST be wrapped with "%"; otherwise the <see cref="AuthorizationLevel"/> is set to default to <see cref="AuthorizationLevel.Function"/>.</remarks>
+        public HttpTriggerAttribute(string authLevelKey)
+        {
+            AuthLevel = GetAuthorizationLevel(authLevelKey);
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="HttpTriggerAttribute"/>, specifying the
         /// required <see cref="AuthorizationLevel"/> and supported HTTP methods.
         /// </summary>
         /// <param name="authLevel">The <see cref="AuthorizationLevel"/> to apply.</param>
@@ -48,6 +59,19 @@ namespace Microsoft.Azure.Functions.Worker
         public HttpTriggerAttribute(AuthorizationLevel authLevel, params string[] methods)
         {
             AuthLevel = authLevel;
+            Methods = methods;
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="HttpTriggerAttribute"/>, specifying the
+        /// required <see cref="AuthorizationLevel"/> and supported HTTP methods.
+        /// </summary>
+        /// <param name="authLevelKey">The environment variable key to get the string representation of the <see cref="AuthorizationLevel"/> value to apply.</param>
+        /// <param name="methods">The http methods to allow.</param>
+        /// <remarks>The authLevelKey value MUST be wrapped with "%"; otherwise the <see cref="AuthorizationLevel"/> is set to default to <see cref="AuthorizationLevel.Function"/>.</remarks>
+        public HttpTriggerAttribute(string authLevelKey, params string[] methods)
+        {
+            AuthLevel = GetAuthorizationLevel(authLevelKey);
             Methods = methods;
         }
 
@@ -67,5 +91,37 @@ namespace Microsoft.Azure.Functions.Worker
         /// Gets the authorization level for the function.
         /// </summary>
         public AuthorizationLevel AuthLevel { get; private set; }
+
+        private static AuthorizationLevel GetAuthorizationLevel(string authLevel)
+        {
+            if (string.IsNullOrWhiteSpace(authLevel))
+            {
+                return AuthorizationLevel.Function;
+            }
+
+            var trimmed = authLevel.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                return AuthorizationLevel.Function;
+            }
+
+            if (!trimmed.StartsWith("%"))
+            {
+                return AuthorizationLevel.Function;
+            }
+
+            if (!trimmed.EndsWith("%"))
+            {
+                return AuthorizationLevel.Function;
+            }
+
+            trimmed = trimmed.Trim('%');
+            var authLevelKey = Environment.GetEnvironmentVariable(trimmed);
+            var authorizationLevel = Enum.TryParse<AuthorizationLevel>(authLevelKey, ignoreCase: true, out var result)
+                                     ? result
+                                     : AuthorizationLevel.Function;
+
+            return authorizationLevel;
+        }
     }
 }

--- a/test/ExtensionsTests/ExtensionsTests.csproj
+++ b/test/ExtensionsTests/ExtensionsTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Tests</AssemblyName>
+    <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />    
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.Http\Worker.Extensions.Http.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/ExtensionsTests/Http/HttpTriggerTests.cs
+++ b/test/ExtensionsTests/Http/HttpTriggerTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Http
+{
+    public class HttpTriggerTests
+    {
+        [Fact]
+        public void Given_No_Parameter_When_HttpTrigger_Initialized_Then_It_Should_Return_Null()
+        {
+            var attr = new HttpTriggerAttribute();
+
+            attr.Methods.Should().BeNull();
+        }
+
+        [Fact]
+        public void Given_No_Method_When_HttpTrigger_Initialized_Then_It_Should_Return_Null()
+        {
+            var attr = new HttpTriggerAttribute(AuthorizationLevel.Anonymous);
+
+            attr.Methods.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData(AuthorizationLevel.Anonymous)]
+        [InlineData(AuthorizationLevel.User)]
+        [InlineData(AuthorizationLevel.Function)]
+        [InlineData(AuthorizationLevel.System)]
+        [InlineData(AuthorizationLevel.Admin)]
+        public void Given_AuthorizationLevel_When_HttpTrigger_Initialized_Then_It_Should_Return_Result(AuthorizationLevel authLevel)
+        {
+            var attr = new HttpTriggerAttribute(authLevel);
+
+            attr.AuthLevel.Should().Be(authLevel);
+        }
+
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("GET", "POST")]
+        public void Given_HttpMethod_When_HttpTrigger_Initialized_Then_It_Should_Return_Result(params string[] methods)
+        {
+            var attr = new HttpTriggerAttribute(methods);
+
+            attr.Methods.Should().HaveCount(methods.Length);
+            attr.Methods.First().Should().Be(methods.First());
+            attr.Methods.Last().Should().Be(methods.Last());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Given_AuthorizationLevelKey_OfNull_When_HttpTrigger_Initialized_Then_It_Should_Return_AuthLevelFunction(string authLevelKey)
+        {
+            var attr = new HttpTriggerAttribute(authLevelKey);
+
+            attr.AuthLevel.Should().Be(AuthorizationLevel.Function);
+        }
+
+        [Theory]
+        [InlineData("LoremIpsum", "Anonymous")]
+        [InlineData("LoremIpsum", "User")]
+        [InlineData("LoremIpsum", "Function")]
+        [InlineData("LoremIpsum", "System")]
+        [InlineData("LoremIpsum", "Admin")]
+        [InlineData("%LoremIpsum", "Anonymous")]
+        [InlineData("%LoremIpsum", "User")]
+        [InlineData("%LoremIpsum", "Function")]
+        [InlineData("%LoremIpsum", "System")]
+        [InlineData("%LoremIpsum", "Admin")]
+        public void Given_AuthorizationLevelKey_When_HttpTrigger_Initialized_Then_It_Should_Return_AuthLevelFunction(string authLevelKey, string authLevel)
+        {
+            Environment.SetEnvironmentVariable(authLevelKey.Trim('%'), authLevel);
+
+            var attr = new HttpTriggerAttribute(authLevelKey);
+
+            attr.AuthLevel.Should().Be(AuthorizationLevel.Function);
+        }
+
+        [Theory]
+        [InlineData("%LoremIpsum%", "Anonymous", AuthorizationLevel.Anonymous)]
+        [InlineData("%LoremIpsum%", "User", AuthorizationLevel.User)]
+        [InlineData("%LoremIpsum%", "Function", AuthorizationLevel.Function)]
+        [InlineData("%LoremIpsum%", "System", AuthorizationLevel.System)]
+        [InlineData("%LoremIpsum%", "Admin", AuthorizationLevel.Admin)]
+        [InlineData("%LoremIpsum%", "anonymous", AuthorizationLevel.Anonymous)]
+        [InlineData("%LoremIpsum%", "user", AuthorizationLevel.User)]
+        [InlineData("%LoremIpsum%", "function", AuthorizationLevel.Function)]
+        [InlineData("%LoremIpsum%", "system", AuthorizationLevel.System)]
+        [InlineData("%LoremIpsum%", "admin", AuthorizationLevel.Admin)]
+        public void Given_AuthorizationLevelKey_When_HttpTrigger_Initialized_Then_It_Should_Return_Result(string authLevelKey, string authLevel, AuthorizationLevel expected)
+        {
+            Environment.SetEnvironmentVariable(authLevelKey.Trim('%'), authLevel);
+
+            var attr = new HttpTriggerAttribute(authLevelKey);
+
+            attr.AuthLevel.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("%LoremIpsum%", "Anonymous", "GET", AuthorizationLevel.Anonymous)]
+        [InlineData("%LoremIpsum%", "User", "GET", AuthorizationLevel.User)]
+        [InlineData("%LoremIpsum%", "Function", "GET", AuthorizationLevel.Function)]
+        [InlineData("%LoremIpsum%", "System", "GET", AuthorizationLevel.System)]
+        [InlineData("%LoremIpsum%", "Admin", "GET", AuthorizationLevel.Admin)]
+        [InlineData("%LoremIpsum%", "anonymous", "GET", AuthorizationLevel.Anonymous)]
+        [InlineData("%LoremIpsum%", "user", "GET", AuthorizationLevel.User)]
+        [InlineData("%LoremIpsum%", "function", "GET", AuthorizationLevel.Function)]
+        [InlineData("%LoremIpsum%", "system", "GET", AuthorizationLevel.System)]
+        [InlineData("%LoremIpsum%", "admin", "GET", AuthorizationLevel.Admin)]
+        public void Given_AuthorizationLevelKey_And_Method_When_HttpTrigger_Initialized_Then_It_Should_Return_Result(string authLevelKey, string authLevel, string method, AuthorizationLevel expected)
+        {
+            Environment.SetEnvironmentVariable(authLevelKey.Trim('%'), authLevel);
+
+            var attr = new HttpTriggerAttribute(authLevelKey, method);
+
+            attr.AuthLevel.Should().Be(expected);
+            attr.Methods.Should().HaveCount(1);
+            attr.Methods.First().Should().Be(method);
+        }
+    }
+}


### PR DESCRIPTION
This PR is to allow `HttpTriggerAttribute` to set the `AuthorizationLevel` by reading an environment variable, like `%AuthLevel%`.

By accepting this PR, it will enable Azure Functions OpenAPI extension to dynamically set the Swagger UI and OpenAPI document access level in the isolated worker environment.

Reference: https://github.com/Azure/azure-functions-openapi-extension/issues/22

It follows the existing convention to read the connection string for Azure Service Bus trigger, Cosmos DB trigger, etc.

As a fallback, if invalid environment key is supplied, the `AuthorizationLevel` is set to `Function` as a default.

Example:

```csharp
[Function("MyFunction1")]
public HttpResponseData Run(
    [HttpTrigger("%AuthLevel%", "GET", "POST")] HttpRequestData req,
    FunctionContext context)
{
    ...
}
```