### PR TITLE
fixing command-line parsing in self-contained builds

### DIFF
--- a/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
+++ b/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Grpc</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Grpc</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>2</MinorProductVersion>
+    <MinorProductVersion>3</MinorProductVersion>
   </PropertyGroup>
 
   <Import Project="..\..\build\Common.props" />
@@ -38,9 +38,5 @@
     <Protobuf Update=".\protobuf\src\proto\FunctionRpc.proto" Access="Internal" />
     <Protobuf Update=".\protobuf\src\proto\identity\ClaimsIdentityRpc.proto" Access="Internal" />
     <Protobuf Update=".\protobuf\src\proto\shared\NullableTypes.proto" Access="Internal" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Binding\" />
   </ItemGroup>
 </Project>

--- a/src/DotNetWorker.Grpc/GrpcServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Grpc/GrpcServiceCollectionExtensions.cs
@@ -55,7 +55,13 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 GrpcWorkerStartupOptions arguments = argumentsOptions.Value;
 
-                GrpcChannel grpcChannel = GrpcChannel.ForAddress($"http://{arguments.Host}:{arguments.Port}", new GrpcChannelOptions()
+                string uriString = $"http://{arguments.Host}:{arguments.Port}";
+                if (!Uri.TryCreate(uriString, UriKind.Absolute, out Uri? grpcUri))
+                {
+                    throw new InvalidOperationException($"The gRPC channel URI '{uriString}' could not be parsed.");
+                }
+
+                GrpcChannel grpcChannel = GrpcChannel.ForAddress(grpcUri, new GrpcChannelOptions()
                 {
                     MaxReceiveMessageSize = arguments.GrpcMaxMessageLength,
                     MaxSendMessageSize = arguments.GrpcMaxMessageLength,

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>3</MinorProductVersion>
+    <MinorProductVersion>4</MinorProductVersion>
   </PropertyGroup>
 
   <Import Project="..\..\build\Common.props" />

--- a/src/DotNetWorker/Hosting/WorkerHostBuilderExtensions.cs
+++ b/src/DotNetWorker/Hosting/WorkerHostBuilderExtensions.cs
@@ -154,10 +154,24 @@ namespace Microsoft.Extensions.Hosting
 
         internal static void RegisterCommandLine(IConfigurationBuilder builder, string[] cmdLine)
         {
-            if (cmdLine.Length > 0 &&
-                !cmdLine[0].StartsWith("--"))
+            // If either of the first two arguments do not begin with '--', wrap them in
+            // quotes. On Linux, either of these first two arguments can be the path to the
+            // assembly, which begins with a '/' and is interpreted as a switch.
+            for (int i = 0; i <= 1; i++)
             {
-                cmdLine[0] = $"\"{cmdLine[0]}\"";
+                if (cmdLine.Length <= i)
+                {
+                    break;
+                }
+
+                string arg = cmdLine[i];
+
+                if (arg.StartsWith("--"))
+                {
+                    break;
+                }
+
+                cmdLine[i] = $"\"{arg}\"";
             }
 
             builder.AddCommandLine(cmdLine);


### PR DESCRIPTION
Fixes #464 

The functions host will always pass us the full assembly path as the first argument during startup. On Linux, this begins with `/`, which is interpreted as a switch by the dotnet `CommandLineConfigurationSource`. We had been wrapping this in quotes, which does work.

However, in self-contained scenarios, this argument gets passed to us twice. Once by dotnet, and once by the host. We need to wrap both of these in quotes or else you end up with the host argument being misinterpreted.