### PR TITLE
Adding GuidConverter which will handle binding of Guid/Guid? type parameters

### DIFF
--- a/src/DotNetWorker.Core/Converters/GuidConverter.cs
+++ b/src/DotNetWorker.Core/Converters/GuidConverter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.Functions.Worker.Converters
+{
+    /// <summary>
+    /// Converter to bind Guid/Guid? type parameters.
+    /// </summary>
+    internal class GuidConverter : IConverter
+    {
+        public bool TryConvert(ConverterContext context, out object? target)
+        {
+            target = default;
+
+            if (context.Source is not string sourceString)
+            {
+                return false;
+            }
+
+            if (context.Parameter.Type == typeof(Guid) || context.Parameter.Type == typeof(Guid?))
+            {
+                if (Guid.TryParse(sourceString, out Guid parsedGuid))
+                {
+                    target = parsedGuid;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/DotNetWorker.Core/Converters/GuidConverter.cs
+++ b/src/DotNetWorker.Core/Converters/GuidConverter.cs
@@ -14,14 +14,9 @@ namespace Microsoft.Azure.Functions.Worker.Converters
         {
             target = default;
 
-            if (context.Source is not string sourceString)
-            {
-                return false;
-            }
-
             if (context.Parameter.Type == typeof(Guid) || context.Parameter.Type == typeof(Guid?))
             {
-                if (Guid.TryParse(sourceString, out Guid parsedGuid))
+                if (context.Source is string sourceString && Guid.TryParse(sourceString, out Guid parsedGuid))
                 {
                     target = parsedGuid;
                     return true;

--- a/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return services.AddSingleton<IConverter, FunctionContextConverter>()
                            .AddSingleton<IConverter, TypeConverter>()
+                           .AddSingleton<IConverter, GuidConverter>()
                            .AddSingleton<IConverter, MemoryConverter>()
                            .AddSingleton<IConverter, StringToByteConverter>()
                            .AddSingleton<IConverter, JsonPocoConverter>()

--- a/test/DotNetWorkerTests/Converters/GuidConverterTests.cs
+++ b/test/DotNetWorkerTests/Converters/GuidConverterTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests.Converters
+{
+    public class GuidConverterTests
+    {
+        private readonly GuidConverter _converter = new GuidConverter();
+        private readonly string _parameterName = "Id";
+
+        [Theory]
+        [InlineData("6cf8151848244ca78a169e14b4f13beb", typeof(Guid))]
+        [InlineData("6cf81518-4824-4ca7-8a16-9e14b4f13beb", typeof(Guid))]
+        [InlineData("{6cf81518-4824-4ca7-8a16-9e14b4f13beb}", typeof(Guid))]
+        [InlineData("(6cf81518-4824-4ca7-8a16-9e14b4f13beb)", typeof(Guid))]
+        [InlineData("6cf8151848244ca78a169e14b4f13beb", typeof(Guid?))]
+        [InlineData("6cf81518-4824-4ca7-8a16-9e14b4f13beb", typeof(Guid?))]
+        public void ConversionSuccessfulForValidSourceValue(object source, Type parameterType)
+        {
+            var context = new TestConverterContext(_parameterName, parameterType, source);
+            
+            var didConvert = _converter.TryConvert(context, out object target);
+
+            Assert.True(didConvert);
+            var convertedGuid = TestUtility.AssertIsTypeAndConvert<Guid>(target);
+            Assert.Equal(Guid.Parse(source.ToString()), convertedGuid);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("a-string-with-four-hyphens")]
+        [InlineData(12345)]
+        [InlineData(true)]
+        [InlineData("6cf81518-4824-4ca7-8a16")]
+        [InlineData("6cf81518-4824-4ca7-8a16_9e14b4f13beb")]
+        [InlineData("ValidGuidInsideAString6cf81518-4824-4ca7-8a16-9e14b4f13beb")]
+        public void ConversionFailedForInvalidSourceValue(object source)
+        {
+            var context = new TestConverterContext(_parameterName, typeof(Guid), source);
+            
+            var didConvert = _converter.TryConvert(context, out object target);
+
+            Assert.False(didConvert);
+            Assert.Null(target);
+        }
+                
+        [Theory]
+        [InlineData("6cf81518-4824-4ca7-8a16-9e14b4f13beb", typeof(string))]
+        [InlineData("6cf81518-4824-4ca7-8a16-9e14b4f13beb", typeof(int))]
+        [InlineData("6cf81518-4824-4ca7-8a16-9e14b4f13beb", typeof(bool))]
+        public void ConversionFailedForInvalidParameterType(object source, Type parameterType)
+        {
+            var context = new TestConverterContext(_parameterName, parameterType, source);
+            
+            var didConvert = _converter.TryConvert(context, out object target);
+
+            Assert.False(didConvert);
+            Assert.Null(target);
+        }
+    }
+}

--- a/test/DotNetWorkerTests/TestUtility.cs
+++ b/test/DotNetWorkerTests/TestUtility.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         }
 
         public static T AssertIsTypeAndConvert<T>(object target)
-            where T : class
         {
             if (target is not T converted)
             {


### PR DESCRIPTION
Fixes #521

Adding a new `IConverter` implementation to handle binding of `Guid` or `Guid?` type parameters. 


Sample usage for binding to `Guid?` parameter type.

    [Function("GetRecords")]
    public static HttpResponseData GetRecords(
        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post",Route = "records/{clientId}")] HttpRequestData req,
        Guid? clientId,
        FunctionContext executionContext)
    {
       // do something with clientId value.

        var response = req.CreateResponse(HttpStatusCode.OK);  
        response.WriteString($"ClientId nullable:{clientId}");

        return response;
    }