### PR TITLE
Publishing Worker.Extensions.RabbitMQ package to 1.1.0

### DIFF
--- a/extensions/Worker.Extensions.RabbitMQ/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.RabbitMQ/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.RabbitMQ", "1.0.0-beta")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.RabbitMQ", "1.1.0")]

--- a/extensions/Worker.Extensions.RabbitMQ/Worker.Extensions.RabbitMQ.csproj
+++ b/extensions/Worker.Extensions.RabbitMQ/Worker.Extensions.RabbitMQ.csproj
@@ -6,8 +6,7 @@
     <Description>RabbitMQ extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <MajorProductVersion>1</MajorProductVersion>
-    <VersionSuffix>-beta</VersionSuffix>
+    <VersionPrefix>1.1.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
Publishing Worker.Extensions.RabbitMQ package to 1.1.0.

[Webjobs version 1.1.0 was released earlier today](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0).

