### PR TITLE
Support matching reflected binding names

### DIFF
--- a/sdk/Sdk/FunctionMetadataGenerator.cs
+++ b/sdk/Sdk/FunctionMetadataGenerator.cs
@@ -607,19 +607,11 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             var attributeType = attribute.AttributeType.Name;
 
             // TODO: Should "webjob type" be a property of the "worker types" and come from there?
-            attributeType = attributeType
+            return attributeType
                     .Replace("TriggerAttribute", "Trigger")
                     .Replace("InputAttribute", string.Empty)
                     .Replace("OutputAttribute", string.Empty)
                     .Replace("Attribute", string.Empty);
-
-            // Ensure first letter is lowercase to match documentation
-            if (char.IsUpper(attributeType[0]))
-            {
-                attributeType = char.ToLowerInvariant(attributeType[0]) + attributeType.Substring(1);
-            }
-
-            return attributeType;
         }
 
         private static void AddHttpOutputBinding(IList<ExpandoObject> bindingMetadata, string name)

--- a/sdk/Sdk/FunctionMetadataGenerator.cs
+++ b/sdk/Sdk/FunctionMetadataGenerator.cs
@@ -607,10 +607,19 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             var attributeType = attribute.AttributeType.Name;
 
             // TODO: Should "webjob type" be a property of the "worker types" and come from there?
-            return attributeType
+            attributeType = attributeType
                     .Replace("TriggerAttribute", "Trigger")
                     .Replace("InputAttribute", string.Empty)
-                    .Replace("OutputAttribute", string.Empty);
+                    .Replace("OutputAttribute", string.Empty)
+                    .Replace("Attribute", string.Empty);
+
+            // Ensure first letter is lowercase to match documentation
+            if (char.IsUpper(attributeType[0]))
+            {
+                attributeType = char.ToLowerInvariant(attributeType[0]) + attributeType.Substring(1);
+            }
+
+            return attributeType;
         }
 
         private static void AddHttpOutputBinding(IList<ExpandoObject> bindingMetadata, string name)


### PR DESCRIPTION
## Context
I ran into an issue when trying to get Durable Functions triggers to work with the isolated worker.

The current rule for extensions is that the attribute name in Worker.Extensions.* must match the attribute name in the corresponding WebJobs.Extensions.*. However, this doesn't work when the WebJobs attribute doesn't end with "InputAttribute" or "OutputAttribute".  For example, when I created an attribute named `DurableClientAttribute` in the worker repo, the function.json that got generated looked like the following:

```json
  {
    "name": "json",
    "type": "DurableClientAttribute",
    "direction": "In",
    "dataType": "String"
  },
```

The `type` property value is obviously wrong and resulted in the function app not being able to start.

## Fix
I've updated the SDK build task to make my scenario work according to the naming guidelines in WebJobs.  I've also lowercased the first latter of the `type` value so that it matches the documentation (this is slightly vain since types appear to be case-insensitive, but I think it's going to be safer this way in case other tools/systems aren't case-insensitive).

The result was the following:

```json
  {
    "name": "json",
    "type": "durableClient",
    "direction": "In",
    "dataType": "String"
  },
```

With this change, the function app was able to start and invoke the binding correctly.