### PR TITLE
Adding an analyzer & code fixer provider to prevent async void return types

### DIFF
--- a/docs/analyzer-rules/AZFW0002.md
+++ b/docs/analyzer-rules/AZFW0002.md
@@ -1,0 +1,51 @@
+# AZFW0002: Rule title
+
+| | Value |
+|-|-|
+| **Rule ID** |AZFW0002|
+| **Category** |[Usage]|
+| **Severity** |Error|
+
+
+## Cause
+
+This rule is triggered when an async method uses `void` as return type.
+
+## Rule description
+
+When an exception is thrown out of an `async Task` or `async Task<T>` method, that exception is captured and placed on the `Task` object. With `async void` methods, there is no `Task` object, so any exceptions thrown out of an async void method will be posted to thread pool. An unhandled exception on thread pool will cause the whole process to terminate.
+
+Please refer [Avoid Async Void section in Best Practices in Asynchronous Programming](https://docs.microsoft.com/en-us/archive/msdn-magazine/2013/march/async-await-best-practices-in-asynchronous-programming#avoid-async-void) for more info.
+
+## How to fix violations
+
+To fix violations, change the method return type from `async void` to `async Task`
+
+Sample code with violation, before the fix
+
+    [Function("Function1")]
+    public static async void Run([QueueTrigger("myqueue-items",
+                                  Connection = "connstr")] string myQueueItem,
+        FunctionContext context)
+    {
+        await Task.Delay(1);
+        var logger = context.GetLogger("Function1");
+        logger.LogInformation($"Queue trigger function processed: {myQueueItem}");
+    }
+
+Sample code, after the fix
+
+    [Function("Function1")]
+    public static async Task Run([QueueTrigger("myqueue-items",
+                                  Connection = "connstr")] string myQueueItem,
+        FunctionContext context)
+    {
+        await Task.Delay(1);
+        var logger = context.GetLogger("Function1");
+        logger.LogInformation($"Queue trigger function processed: {myQueueItem}");
+    }
+
+
+## When to suppress warnings
+
+This rule should not be suppressed, as the an exception thrown from the async void method would cause the application process to crash.

--- a/docs/analyzer-rules/AZFW0002.md
+++ b/docs/analyzer-rules/AZFW0002.md
@@ -1,4 +1,4 @@
-# AZFW0002: Rule title
+# AZFW0002: Avoid async void
 
 | | Value |
 |-|-|
@@ -13,7 +13,7 @@ This rule is triggered when an async method uses `void` as return type.
 
 ## Rule description
 
-When an exception is thrown out of an `async Task` or `async Task<T>` method, that exception is captured and placed on the `Task` object. With `async void` methods, there is no `Task` object, so any exceptions thrown out of an async void method will be posted to thread pool. An unhandled exception on thread pool will cause the whole process to terminate.
+When an exception is thrown out of an `async Task` or `async Task<T>` method, that exception is captured and placed on the `Task` object. With `async void` methods, there is no `Task` object, so any exceptions thrown out of an async void method will be posted to thread pool. An unhandled exception on the thread pool will cause the whole process to terminate.
 
 Please refer [Avoid Async Void section in Best Practices in Asynchronous Programming](https://docs.microsoft.com/en-us/archive/msdn-magazine/2013/march/async-await-best-practices-in-asynchronous-programming#avoid-async-void) for more info.
 

--- a/docs/analyzer-rules/AZFW0002.md
+++ b/docs/analyzer-rules/AZFW0002.md
@@ -24,8 +24,8 @@ To fix violations, change the method return type from `async void` to `async Tas
 Sample code with violation, before the fix
 
     [Function("Function1")]
-    public static async void Run([QueueTrigger("myqueue-items",
-                                  Connection = "connstr")] string myQueueItem,
+    public static async void Run(
+        [QueueTrigger("myqueue-items", Connection = "connstr")] string myQueueItem,
         FunctionContext context)
     {
         await Task.Delay(1);
@@ -36,8 +36,8 @@ Sample code with violation, before the fix
 Sample code, after the fix
 
     [Function("Function1")]
-    public static async Task Run([QueueTrigger("myqueue-items",
-                                  Connection = "connstr")] string myQueueItem,
+    public static async Task Run(
+        [QueueTrigger("myqueue-items", Connection = "connstr")] string myQueueItem,
         FunctionContext context)
     {
         await Task.Delay(1);

--- a/docs/analyzer-rules/AZFW0002.md
+++ b/docs/analyzer-rules/AZFW0002.md
@@ -13,7 +13,7 @@ This rule is triggered when an async method uses `void` as return type.
 
 ## Rule description
 
-When an exception is thrown out of an `async Task` or `async Task<T>` method, that exception is captured and placed on the `Task` object. With `async void` methods, there is no `Task` object, so any exceptions thrown out of an async void method will be posted to thread pool. An unhandled exception on the thread pool will cause the whole process to terminate.
+An `async void` method does not provide a `Task` to represent the operation in progress, preventing the Azure Functions Worker and Host from tracking function completion and errors, leading to potential reliability issues.
 
 Please refer [Avoid Async Void section in Best Practices in Asynchronous Programming](https://docs.microsoft.com/en-us/archive/msdn-magazine/2013/march/async-await-best-practices-in-asynchronous-programming#avoid-async-void) for more info.
 
@@ -48,4 +48,4 @@ Sample code, after the fix
 
 ## When to suppress warnings
 
-This rule should not be suppressed, as the an exception thrown from the async void method would cause the application process to crash.
+This rule should not be suppressed, as the absence of a `Task` will cause reliability issues on async functions.

--- a/sdk/Sdk.Analyzers/AsyncVoidAnalyzer.cs
+++ b/sdk/Sdk.Analyzers/AsyncVoidAnalyzer.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class AsyncVoidAnalyzer : DiagnosticAnalyzer
+    {    
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.AsyncVoidReturnType);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+        }
+
+        private static void AnalyzeMethod(SymbolAnalysisContext symbolAnalysisContext)
+        {
+            var symbol = (IMethodSymbol)symbolAnalysisContext.Symbol;
+
+            if (symbol.IsAsync && symbol.ReturnsVoid)
+            {
+                var diagnostic = Diagnostic.Create(DiagnosticDescriptors.AsyncVoidReturnType, symbol.Locations[0]);
+                symbolAnalysisContext.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/sdk/Sdk.Analyzers/AsyncVoidAnalyzer.cs
+++ b/sdk/Sdk.Analyzers/AsyncVoidAnalyzer.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
 
             if (symbol.IsAsync && symbol.ReturnsVoid)
             {
-                var diagnostic = Diagnostic.Create(DiagnosticDescriptors.AsyncVoidReturnType, symbol.Locations[0]);
+                // This symbol is a method symbol and will have only one item in Locations property.
+                var location = symbol.Locations[0]; 
+                var diagnostic = Diagnostic.Create(DiagnosticDescriptors.AsyncVoidReturnType, location);
                 symbolAnalysisContext.ReportDiagnostic(diagnostic);
             }
         }

--- a/sdk/Sdk.Analyzers/AsyncVoidCodeFixProvider.cs
+++ b/sdk/Sdk.Analyzers/AsyncVoidCodeFixProvider.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
+using System.Threading;
+using System.Linq;
+
+namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AsyncVoidCodeFixProvider)), Shared]
+    public sealed class AsyncVoidCodeFixProvider : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticDescriptors.AsyncVoidReturnType.Id);
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            Diagnostic diagnostic = context.Diagnostics.First();
+            context.RegisterCodeFix(new VoidToTaskCodeAction(context.Document, diagnostic), diagnostic);
+            
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// CodeAction implementation which fixes changes async void to async Task as the return type of the method.
+        /// </summary>
+        private sealed class VoidToTaskCodeAction : CodeAction
+        {
+            private readonly Document _document;
+            private readonly Diagnostic _diagnostic;
+
+            internal VoidToTaskCodeAction(Document document, Diagnostic diagnostic)
+            {
+                this._document = document;
+                this._diagnostic = diagnostic;
+            }
+
+            public override string Title => "Change return type of method to Task";
+
+            /// null value is fine since we do not have more than one fix action from this code fix provider.
+            public override string EquivalenceKey => null;
+
+            /// <summary>
+            /// Returns an updated Document where the async method return type is changed from void to Task.
+            /// </summary>
+            protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+            {
+                SyntaxNode root = await _document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                
+                MethodDeclarationSyntax methodDeclaration = root.FindNode(this._diagnostic.Location.SourceSpan)
+                                                                .FirstAncestorOrSelf<MethodDeclarationSyntax>();
+
+                TypeSyntax taskType = SyntaxFactory.ParseTypeName(Constants.Types.TaskType)
+                                                   .WithAdditionalAnnotations(Simplifier.Annotation)
+                                                   .WithTrailingTrivia(methodDeclaration.ReturnType.GetTrailingTrivia());
+                
+                MethodDeclarationSyntax newMethodDeclaration = methodDeclaration.WithReturnType(taskType);
+                
+                SyntaxNode newRoot = root.ReplaceNode(methodDeclaration, newMethodDeclaration);
+                
+                return _document.WithSyntaxRoot(newRoot);
+            }
+        }
+    }
+}

--- a/sdk/Sdk.Analyzers/Constants.cs
+++ b/sdk/Sdk.Analyzers/Constants.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
 {
     internal static class Constants
@@ -13,6 +9,9 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
         {
             public const string WorkerFunctionAttribute = "Microsoft.Azure.Functions.Worker.FunctionAttribute";
             public const string WebJobsBindingAttribute = "Microsoft.Azure.WebJobs.Description.BindingAttribute";
+            
+            // System types
+            internal const string TaskType = "System.Threading.Tasks.Task";
         }
 
         internal static class DiagnosticsCategories

--- a/sdk/Sdk.Analyzers/DiagnosticDescriptors.cs
+++ b/sdk/Sdk.Analyzers/DiagnosticDescriptors.cs
@@ -19,7 +19,10 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
         public static DiagnosticDescriptor WebJobsAttributesAreNotSuppoted { get; }
             = Create(id: "AZFW0001", title: "Invalid binding attributes", messageFormat: "The attribute '{0}' is a WebJobs attribute and not supported in the .NET Worker (Isolated Process).",
                 category: Constants.DiagnosticsCategories.Usage, severity: DiagnosticSeverity.Error);
-
+                
+        public static DiagnosticDescriptor AsyncVoidReturnType { get; }
+            = Create(id: "AZFW0002", title: "Avoid async void methods", messageFormat: "Do not use void as the return type for async methods. Use Task instead.",
+                category: Constants.DiagnosticsCategories.Usage, severity: DiagnosticSeverity.Error);
 
     }
 }

--- a/sdk/Sdk.Analyzers/Sdk.Analyzers.csproj
+++ b/sdk/Sdk.Analyzers/Sdk.Analyzers.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <MinorProductVersion>1</MinorProductVersion>
     <OutputType>Library</OutputType>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/sdk/Sdk.Analyzers/Sdk.Analyzers.csproj
+++ b/sdk/Sdk.Analyzers/Sdk.Analyzers.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <PatchProductVersion>4</PatchProductVersion>
+    <MinorProductVersion>1</MinorProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/test/FunctionMetadataGeneratorTests/SdkTests.csproj
+++ b/test/FunctionMetadataGeneratorTests/SdkTests.csproj
@@ -25,6 +25,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.0-preview" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
@@ -1,0 +1,179 @@
+﻿using Xunit;
+using AnalizerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.AsyncVoidAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using AnalyzerVerifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.AsyncVoidAnalyzer>;
+using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.AsyncVoidAnalyzer, Microsoft.Azure.Functions.Worker.Sdk.Analyzers.AsyncVoidCodeFixProvider, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using CodeFixVerifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.AsyncVoidAnalyzer, Microsoft.Azure.Functions.Worker.Sdk.Analyzers.AsyncVoidCodeFixProvider, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using System.Collections.Immutable;
+using System.Threading;
+
+namespace Sdk.Analyzers.Tests
+{
+    public sealed class AsyncVoidAnalyzerTests
+    {
+        private const string DiagnosticId = "AZFW0002";
+
+        [Fact]
+        public async Task AnalyzerReportsErrorForAsyncVoid()
+        {
+            string inputCode = @"
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp4
+{
+    public static class Function1
+    {
+        [Function(nameof(Function1))]
+        public static async void Run([QueueTrigger(""myqueue-items"")] string myQueueItem, FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(Function1));
+            logger.LogInformation(myQueueItem);
+            await Task.Delay(100);
+        }
+    }
+}";
+            var test = new AnalizerTest
+            {
+                ReferenceAssemblies = LoadRequiredDependencyAssemblies(),
+                TestCode = inputCode
+            };
+
+            var expectedDiagnosticResult = AnalyzerVerifier
+                                                .Diagnostic(DiagnosticId)
+                                                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                                                .WithSpan(11, 34, 11, 37);  // 11th line, 34th character(Run method)
+
+            test.ExpectedDiagnostics.Add(expectedDiagnosticResult);
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task AnalyzerDoesNotReportForAsyncTask()
+        {
+            string inputCode = @"
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp4
+{
+    public static class Function1
+    {
+        [Function(nameof(Function1))]
+        public static async Task Run([QueueTrigger(""myqueue-items"")] string myQueueItem, FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(Function1));
+            logger.LogInformation(myQueueItem);
+            await Task.Delay(100);
+        }
+    }
+}";
+            var test = new AnalizerTest
+            {
+                ReferenceAssemblies = LoadRequiredDependencyAssemblies(),
+                TestCode = inputCode
+            };
+
+            await test.RunAsync();
+        }
+                
+        [Fact]
+        public async Task AnalyzerDoesNotReportForNonAsyncCode()
+        {
+            string inputCode = @"
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp4
+{
+    public static class Function1
+    {
+        [Function(nameof(Function1))]
+        public static void Run([QueueTrigger(""myqueue-items"")] string myQueueItem, FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(Function1));
+            logger.LogInformation(myQueueItem);
+        }
+    }
+}";
+            var test = new AnalizerTest
+            {
+                ReferenceAssemblies = LoadRequiredDependencyAssemblies(),
+                TestCode = inputCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task CodeFixerWorks()
+        {
+            string inputCode = @"
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp4
+{
+    public static class Function1
+    {
+        [Function(nameof(Function1))]
+        public static async void Run([QueueTrigger(""myqueue-items"")] string myQueueItem, FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(Function1));
+            logger.LogInformation(myQueueItem);
+            await Task.Delay(100);
+        }
+    }
+}";
+
+            string expectedFixedCode = @"
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp4
+{
+    public static class Function1
+    {
+        [Function(nameof(Function1))]
+        public static async Task Run([QueueTrigger(""myqueue-items"")] string myQueueItem, FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(Function1));
+            logger.LogInformation(myQueueItem);
+            await Task.Delay(100);
+        }
+    }
+}";
+
+            var expectedDiagnosticResult = CodeFixVerifier
+                                            .Diagnostic(DiagnosticId)
+                                            .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                                            .WithSpan(11, 34, 11, 37); // 11th line, 34th character(Run method)
+
+            var test = new CodeFixTest
+            {
+                ReferenceAssemblies = LoadRequiredDependencyAssemblies(),
+                TestCode = inputCode,
+                FixedCode = expectedFixedCode
+            };
+
+            test.ExpectedDiagnostics.AddRange(new[] { expectedDiagnosticResult });
+            await test.RunAsync(CancellationToken.None);
+        }
+                
+        private static ReferenceAssemblies LoadRequiredDependencyAssemblies()
+        {
+            var referenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.Azure.WebJobs.Extensions", "4.0.1"),
+                new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.1.0"),
+                new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage", "4.0.4")));
+
+            return referenceAssemblies;
+        }
+    }
+}

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-
+    
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.0.1-beta1.21126.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #610 

Adding an analyzer & code fixer to prevent `async void` return types.

![async-void-analyzer-demo](https://user-images.githubusercontent.com/144469/132548860-7cabcbf9-1e39-427c-8882-606f3c300982.gif)

- Added Analyzer & code fix provider & tests for these.
- Added the analyzer documentation files.
- Updated minor version number of Worker.Sdk.Analyzers and Worker.Sdk to 1.

Few issues where users were seeing unexpected behavior due to `async void` usage: 

- #607 
- #624 