### PR TITLE
Updating Worker.Extensions.EventGrid version from 2.1.0 to 3.0.0-beta.3

### DIFF
--- a/extensions/Worker.Extensions.EventGrid/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.EventGrid/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 ﻿using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.EventGrid", "2.1.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.EventGrid", "3.0.0-beta.3")]

--- a/extensions/Worker.Extensions.EventGrid/Worker.Extensions.EventGrid.csproj
+++ b/extensions/Worker.Extensions.EventGrid/Worker.Extensions.EventGrid.csproj
@@ -6,8 +6,9 @@
     <Description>Azure Event Grid extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>2.1.0</VersionPrefix>
-    
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionSuffix>-beta.3</VersionSuffix>
+
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #499 

Updating [Microsoft.Azure.Functions.Worker.Extensions.EventGrid](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.EventGrid/) version from 2.1.0 to 3.0.0-beta.3 which is the [latest version of WebJobs.Extensions.EventGrid](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.EventGrid/3.0.0-beta.3) as of today.

Diff between 2.1.0 and 3.0.0-beta.3 : https://www.fuget.org/packages/Microsoft.Azure.WebJobs.Extensions.EventGrid/3.0.0-beta.3/lib/netstandard2.0/diff/2.1.0/

As per the diff view above, 3 classes were removed. Those are not used anywhere else in the worker repo solution.

Once the `3.0.0-beta.3` package is out, I will update the sample app & release notes in a follow up PR.