### PR TITLE
Added null check before accessing AuthenticationType nullable property

### DIFF
--- a/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
+++ b/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
@@ -37,12 +37,10 @@ namespace Microsoft.Azure.Functions.Worker
 
                 if (cookieString != null && cookieString.Any())
                 {
-
                     return ToHttpCookies(cookieString.First());
                 }
 
                 return Array.Empty<IHttpCookie>();
-
             });
         }
 
@@ -103,7 +101,7 @@ namespace Microsoft.Azure.Functions.Worker
                 {
                     _identities = _httpData.Identities?.Select(id =>
                     {
-                        var identity = new ClaimsIdentity(id.AuthenticationType.Value, id.NameClaimType.Value, id.RoleClaimType.Value);
+                        var identity = new ClaimsIdentity(id.AuthenticationType?.Value, id.NameClaimType.Value, id.RoleClaimType.Value);
                         identity.AddClaims(id.Claims.Select(c => new Claim(c.Type, c.Value)));
 
                         return identity;


### PR DESCRIPTION
Fixes the null reference exception reported in #637

The `AuthenticationType` property is nullable. So adding a null check before accessing the `Value`.

Without this fix, If user tries to access the `Identities` properties of `HttpRequestData`, it throws a null reference exception when AuthenticationType prop is null.