### PR TITLE
Publishing Microsoft.Azure.Functions.Worker.Extensions.ServiceBus to 5.0.0-beta.6

### DIFF
--- a/extensions/Worker.Extensions.ServiceBus/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.ServiceBus/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 ﻿using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.ServiceBus", "5.0.0-beta.4")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.ServiceBus", "5.0.0-beta.6")]

--- a/extensions/Worker.Extensions.ServiceBus/ServiceBusEntityType.cs
+++ b/extensions/Worker.Extensions.ServiceBus/ServiceBusEntityType.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
     /// Service Bus entity type.
     /// </summary>
-    public enum EntityType
+    public enum ServiceBusEntityType
     {
         /// <summary>
         /// Service Bus Queue

--- a/extensions/Worker.Extensions.ServiceBus/ServiceBusOutputAttribute.cs
+++ b/extensions/Worker.Extensions.ServiceBus/ServiceBusOutputAttribute.cs
@@ -11,18 +11,8 @@ namespace Microsoft.Azure.Functions.Worker
         /// Initializes a new instance of the <see cref="ServiceBusOutputAttribute"/> class.
         /// </summary>
         /// <param name="queueOrTopicName">The name of the queue or topic to bind to.</param>
-        public ServiceBusOutputAttribute(string queueOrTopicName)
-        {
-            QueueOrTopicName = queueOrTopicName;
-            EntityType = EntityType.Queue;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ServiceBusOutputAttribute"/> class.
-        /// </summary>
-        /// <param name="queueOrTopicName">The name of the queue or topic to bind to.</param>
-        /// <param name="queueOrTopicName">The type of the entity to bind to.</param>
-        public ServiceBusOutputAttribute(string queueOrTopicName, EntityType entityType)
+        /// <param name="entityType">The type of the entity to bind to.</param>
+        public ServiceBusOutputAttribute(string queueOrTopicName, ServiceBusEntityType entityType = ServiceBusEntityType.Queue)
         {
             QueueOrTopicName = queueOrTopicName;
             EntityType = entityType;
@@ -41,6 +31,6 @@ namespace Microsoft.Azure.Functions.Worker
         /// <summary>
         /// Value indicating the type of the entity to bind to.
         /// </summary>
-        public EntityType EntityType { get; set; }
+        public ServiceBusEntityType EntityType { get; set; }
     }
 }

--- a/extensions/Worker.Extensions.ServiceBus/Worker.Extensions.ServiceBus.csproj
+++ b/extensions/Worker.Extensions.ServiceBus/Worker.Extensions.ServiceBus.csproj
@@ -7,7 +7,7 @@
 
     <!--Version information-->
     <VersionPrefix>5.0.0</VersionPrefix>
-    <VersionSuffix>-beta.4</VersionSuffix>
+    <VersionSuffix>-beta.6</VersionSuffix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION

Publishing 5.0.0-beta.6 version of `Microsoft.Azure.Functions.Worker.Extensions.ServiceBus`.  Switching to this version should solve the issue users are running into with beta.4 version, such as #646 

The 4.2.1 version of `Microsoft.Azure.WebJobs.Extensions.ServiceBus` has [2 constructors](https://www.fuget.org/packages/Microsoft.Azure.WebJobs.Extensions.ServiceBus/4.2.1/lib/netstandard2.0/Microsoft.Azure.WebJobs.ServiceBus.dll/Microsoft.Azure.WebJobs/ServiceBusAttribute)

````
public ServiceBusAttribute(string queueOrTopicName)

public ServiceBusAttribute(string queueOrTopicName, EntityType entityType)
````

The 5.0.0-beta.4 version of `Microsoft.Azure.WebJobs.Extensions.ServiceBus` has only [1 constructor where the second parameter is using a default value](https://www.fuget.org/packages/Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.0.0-beta.4/lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll/Microsoft.Azure.WebJobs/ServiceBusAttribute). The second parameter was also renamed to `serviceBusEntityType`

````
public ServiceBusAttribute(string queueOrTopicName, ServiceBusEntityType serviceBusEntityType = 0)
````

This change was not reflected in the [recent 5.0.0-beta.4 release of the Microsoft.Azure.Functions.Worker.Extensions.ServiceBus package](https://github.com/Azure/azure-functions-dotnet-worker/pull/513/files). Because of this, the [logic which is trying to pick the best constructor](https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Bindings/AttributeConverter.cs#L26) is failing to pick any and ends up throwing the "_Can't figure out which ctor to call_" exception.

This PR is updating the worker version of the attribute to match it to [beta.6](https://www.fuget.org/packages/Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.0.0-beta.6/lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll/Microsoft.Azure.WebJobs/ServiceBusAttribute) signature.


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
