### PR TITLE
Enable integration testing for the Dotnet language worker

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ jobs:
   - pwsh: ./tools/start-emulators.ps1 -NoWait
     displayName: "Start emulators (-NoWait)"
 
+  - template: build/install-dotnet.yml
   - task: DotNetCoreCLI@2
     displayName: 'Build projects'
     inputs:
@@ -36,7 +37,14 @@ jobs:
       arguments: '-c Release -p:BuildNumber=$(buildNumber) -p:IsLocalBuild=False'
       projects: 'DotNetWorker.sln'
 
-  - pwsh: ./setup-e2e-tests.ps1
+  - pwsh: |
+      $useIntegrationTestingCoreTools = $null
+      if (-not ([bool]::TryParse($env:USECORETOOLSBUILDFROMINTEGRATIONTESTS, [ref] $useIntegrationTestingCoreTools)))
+      {
+        throw "UseCoreToolsBuildFromIntegrationTests can only be set to True or False. Current value is set to $env:USECORETOOLSBUILDFROMINTEGRATIONTESTS"
+      }
+      ./setup-e2e-tests.ps1 -FunctionsRuntimeVersion $env:FUNCTIONSRUNTIMEVERSION `
+                            -UseCoreToolsBuildFromIntegrationTests:$useIntegrationTestingCoreTools
     displayName: "Setup E2E tests"
 
   - task: DotNetCoreCLI@2
@@ -272,6 +280,7 @@ jobs:
     vmImage: 'ubuntu-latest'
     
   steps:
+    - template: build/install-dotnet.yml
     - task: DotNetCoreCLI@2
       displayName: 'Build projects'
       inputs:
@@ -279,7 +288,15 @@ jobs:
         arguments: '-c Release'
         projects: 'DotNetWorker.sln'
 
-    - pwsh: ./setup-e2e-tests.ps1 -SkipCosmosDBEmulator
+    - pwsh: |
+        $useIntegrationTestingCoreTools = $null
+        if (-not ([bool]::TryParse($env:USECORETOOLSBUILDFROMINTEGRATIONTESTS, [ref] $useIntegrationTestingCoreTools)))
+        {
+          throw "UseCoreToolsBuildFromIntegrationTests can only be set to True or False. Current value is set to $env:USECORETOOLSBUILDFROMINTEGRATIONTESTS"
+        }
+        ./setup-e2e-tests.ps1 -FunctionsRuntimeVersion $env:FUNCTIONSRUNTIMEVERSION `
+                              -UseCoreToolsBuildFromIntegrationTests:$useIntegrationTestingCoreTools `
+                              -SkipCosmosDBEmulator
       displayName: "Setup E2E tests"
       env:
         CORE_TOOLS_URL: $(CORE_TOOLS_URL)

--- a/build/install-dotnet.yml
+++ b/build/install-dotnet.yml
@@ -1,0 +1,12 @@
+steps:
+- pwsh: |
+    Invoke-WebRequest 'https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
+    ./dotnet-install.ps1 -InstallDir "$env:ProgramFiles/dotnet" -Version "6.0.100" -Channel 'release'
+  displayName: 'Install the .Net version used by the Core Tools for Windows'
+  condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq(variables['FUNCTIONSRUNTIMEVERSION'], '4'))
+
+- bash: |
+    curl -sSL https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh | bash /dev/stdin -v '6.0.100' -c 'release' --install-dir /usr/share/dotnet
+  displayName: 'Install the .Net version used by the Core Tools for Linux'
+  condition: and(eq( variables['Agent.OS'], 'Linux' ), eq(variables['FUNCTIONSRUNTIMEVERSION'], '4'))
+  


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-dotnet-worker/issues/709

This PR contains the following changes:
* Updated `setup-e2e-tests.ps1` to install the Core Tools to validate the language worker against Functions V3 and V4
* Added `install-dotnet.yml` script to install the .NET version required by the Core Tools for Functions V4
* Added the following two variables to the pipeline to control what version of the Core Tools is installed (to validate the Dotnet worker):
   * `FunctionsRuntimeVersion` - Specifies the major version of the Core Tools to be installed. The default value is `3`. To validate the worker against the Core Tools V4, set this value to `4`
   * `UseCoreToolsBuildFromIntegrationTests` – This is a boolean value to specify whether to use the Core Tools for integration testing. This value will be set by the integration test framework. By default, the value is set to `False`.
* Updated `azure-pipelines.yml` to parse the `UseCoreToolsBuildFromIntegrationTests` pipeline variable and pass the boolean value to the `setup-e2e-tests.ps1` script

 
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
