### PR TITLE
InputConverterAttribute to support interfaces

### DIFF
--- a/src/DotNetWorker.Core/Converters/Converter/InputConverterAttribute.cs
+++ b/src/DotNetWorker.Core/Converters/Converter/InputConverterAttribute.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Functions.Worker.Converters
     [AttributeUsage(
         AttributeTargets.Parameter |
         AttributeTargets.Class |
+        AttributeTargets.Interface |
         AttributeTargets.Enum |
         AttributeTargets.Struct)]
     public sealed class InputConverterAttribute : Attribute


### PR DESCRIPTION
I would like the ability to convert a function input to an instance of an interface using `[InputConverter(...)]`. The only thing that seems to prevent this is the `AttributeUsage` declaration on the `InputConverterAttribute` class. I've added `AttributeTargets.Interface` to fix this.  I manually tested this with my Durable Functions bindings and it works great.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
