### PR TITLE
Add BOM manifest generation task to build pipeline

### DIFF
--- a/build/pipelines/templates/extensions-ci.yml
+++ b/build/pipelines/templates/extensions-ci.yml
@@ -102,5 +102,11 @@ jobs:
     inputs:
       contents: '**\CodeSignSummary-*.md'
 
+  - task: ManifestGeneratorTask@0
+    displayName: 'SBOM Generation Task'
+    inputs:
+      BuildDropPath: '$(System.DefaultWorkingDirectory)/packages'
+      Verbosity: 'Information'
+      
   - publish: $(System.DefaultWorkingDirectory)/packages
     artifact: drop

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -204,6 +204,12 @@ jobs:
     inputs:
       contents: '**\CodeSignSummary-*.md'
 
+  - task: ManifestGeneratorTask@0
+    displayName: 'SBOM Generation Task'
+    inputs:
+      BuildDropPath: '$(System.DefaultWorkingDirectory)/packages'
+      Verbosity: 'Information'
+
   - publish: $(System.DefaultWorkingDirectory)/packages
     artifact: drop
 


### PR DESCRIPTION
Added the BOM manifest generator task before the publish step. This will produce the `_manifest` folder (which has the manifest JSON) inside the drop folder. Synced with Elias and he mentioned this step is good enough for the Dec31st milestone.

https://www.1eswiki.com/wiki/ADO_sbom_Generator#YAML_Pipelines_2

![image](https://user-images.githubusercontent.com/144469/145621637-155bb535-405b-4565-b3d4-d0c34803b193.png)

We are [still waiting for guidance](https://www.1eswiki.com/wiki/ADO_sbom_Generator#FAQs_about_ADO_SBOM_Generator_Tool) for distributing the SBOM with the software. 
