### PR TITLE
Fixing tests validating incorrect versions of storage

### DIFF
--- a/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
@@ -160,8 +160,8 @@ namespace Microsoft.Azure.Functions.SdkTests
 
             AssertDictionary(extensions, new Dictionary<string, string>
             {
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0-beta.4" },
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.0.0-beta.4" },
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0" },
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.0.0" },
             });
 
             void ValidateQueueTrigger(ExpandoObject b)
@@ -264,8 +264,8 @@ namespace Microsoft.Azure.Functions.SdkTests
 
             AssertDictionary(extensions, new Dictionary<string, string>
             {
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0-beta.4" },
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.0.0-beta.4" },
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0" },
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.0.0" },
             });
 
             void ValidateQueueTrigger(ExpandoObject b)
@@ -327,7 +327,7 @@ namespace Microsoft.Azure.Functions.SdkTests
 
             AssertDictionary(extensions, new Dictionary<string, string>
             {
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0-beta.4" }
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0" }
             });
 
             void ValidateHttpTrigger(ExpandoObject b)


### PR DESCRIPTION
Kicking the can down again for now, but I'm opening an issue for us to avoid this in the future.