### PR TITLE
SBOM-Use 1ES hosted agent pool for builds

### DIFF
--- a/build/pipelines/templates/extensions-ci.yml
+++ b/build/pipelines/templates/extensions-ci.yml
@@ -7,7 +7,7 @@ jobs:
 - job: "Build_And_Test_Windows"
   pool:
     name: '1ES-Hosted-AzFunc'
-    vmImage: 'MMS2019TLS'
+    vmImage: 'MMS2022TLS'
 
   variables:
     - template: extensions-variables.yml

--- a/build/pipelines/templates/extensions-ci.yml
+++ b/build/pipelines/templates/extensions-ci.yml
@@ -6,7 +6,8 @@ parameters:
 jobs:
 - job: "Build_And_Test_Windows"
   pool:
-    vmImage: 'windows-latest'
+    name: '1ES-Hosted-AzFunc'
+    vmImage: 'MMS2019TLS'
 
   variables:
     - template: extensions-variables.yml

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -19,7 +19,7 @@ jobs:
 - job: "Build_And_Test_Windows"
   pool:
     name: '1ES-Hosted-AzFunc'
-    vmImage: 'MMS2022TLS'
+    vmImage: 'MMS2019TLS'
 
   variables:
     ${{ if not(contains(variables['Build.SourceBranch'], '/release/' )) }}:

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -18,7 +18,8 @@ pr:
 jobs:
 - job: "Build_And_Test_Windows"
   pool:
-    vmImage: 'windows-latest'
+    name: '1ES-Hosted-AzFunc'
+    vmImage: 'MMS2019TLS'
 
   variables:
     ${{ if not(contains(variables['Build.SourceBranch'], '/release/' )) }}:

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -19,7 +19,7 @@ jobs:
 - job: "Build_And_Test_Windows"
   pool:
     name: '1ES-Hosted-AzFunc'
-    vmImage: 'MMS2019TLS'
+    vmImage: 'MMS2022TLS'
 
   variables:
     ${{ if not(contains(variables['Build.SourceBranch'], '/release/' )) }}:

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -216,7 +216,7 @@ jobs:
 
 - job: "E2ETests_Ubuntu"  
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'MMSUbuntu18.04TLS'
     
   steps:
     - template: ../build/install-dotnet.yml

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -216,7 +216,7 @@ jobs:
 
 - job: "E2ETests_Ubuntu"  
   pool:
-    vmImage: 'MMSUbuntu18.04TLS'
+    vmImage: 'MMSUbuntu20.04TLS'
     
   steps:
     - template: ../build/install-dotnet.yml

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -216,6 +216,7 @@ jobs:
 
 - job: "E2ETests_Ubuntu"  
   pool:
+    name: '1ES-Hosted-AzFunc'
     vmImage: 'MMSUbuntu20.04TLS'
     
   steps:

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -51,13 +51,13 @@ function IsStorageEmulatorRunning()
 if (!$SkipCosmosDBEmulator)
 {
     Write-Host ""
-    Write-Host "---Starting CosmosDB emulator---"
+    Write-Host "---Starting CosmosDB emulator with debug---"
     $cosmosStatus = Get-CosmosDbEmulatorStatus
 
     if ($cosmosStatus -ne "Running")
     {
-        Write-Host "CosmosDB emulator is not running. Starting emulator in blocking fashion(without -NoWait)."
-        Start-CosmosDbEmulator
+        Write-Host "CosmosDB emulator is not running. Starting emulator in blocking fashion(without -NoWait), with debug flag."
+        Start-CosmosDbEmulator -debug
         $startedCosmos = $true
     }
     else

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -51,13 +51,12 @@ function IsStorageEmulatorRunning()
 if (!$SkipCosmosDBEmulator)
 {
     Write-Host ""
-    Write-Host "---Starting CosmosDB emulator with debug---"
+    Write-Host "---Starting CosmosDB emulator---"
     $cosmosStatus = Get-CosmosDbEmulatorStatus
 
     if ($cosmosStatus -ne "Running")
     {
         Write-Host "CosmosDB emulator is not running. Starting emulator."
-        # Without the -NoUI flag, the emulator is not starting in the new IES hosting agent pools.
         Start-CosmosDbEmulator -NoWait -NoUI
         $startedCosmos = $true
     }

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -56,8 +56,8 @@ if (!$SkipCosmosDBEmulator)
 
     if ($cosmosStatus -ne "Running")
     {
-        Write-Host "CosmosDB emulator is not running. Starting emulator."
-        Start-CosmosDbEmulator -NoWait
+        Write-Host "CosmosDB emulator is not running. Starting emulator in blocking fashion(without -NoWait)."
+        Start-CosmosDbEmulator
         $startedCosmos = $true
     }
     else

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -57,7 +57,7 @@ if (!$SkipCosmosDBEmulator)
     if ($cosmosStatus -ne "Running")
     {
         Write-Host "CosmosDB emulator is not running. Starting emulator in blocking fashion(without -NoWait), with debug flag."
-        Start-CosmosDbEmulator -debug -Trace
+        Start-CosmosDbEmulator -NoUI
         $startedCosmos = $true
     }
     else

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -56,8 +56,9 @@ if (!$SkipCosmosDBEmulator)
 
     if ($cosmosStatus -ne "Running")
     {
-        Write-Host "CosmosDB emulator is not running. Starting emulator in blocking fashion(without -NoWait), with debug flag."
-        Start-CosmosDbEmulator -NoUI
+        Write-Host "CosmosDB emulator is not running. Starting emulator."
+        # Without the -NoUI flag, the emulator is not starting in the new IES hosting agent pools.
+        Start-CosmosDbEmulator -NoWait -NoUI
         $startedCosmos = $true
     }
     else

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -57,7 +57,7 @@ if (!$SkipCosmosDBEmulator)
     if ($cosmosStatus -ne "Running")
     {
         Write-Host "CosmosDB emulator is not running. Starting emulator in blocking fashion(without -NoWait), with debug flag."
-        Start-CosmosDbEmulator -debug
+        Start-CosmosDbEmulator -debug -Trace
         $startedCosmos = $true
     }
     else


### PR DESCRIPTION
Switching to the newly created 1ES hosted pools. This is needed to fulfil the cyber security executive order compliance requirements.

While switching to the new hosted pools we ran into an issue where the Cosmos emulator [won't start](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/tools/start-emulators.ps1#L60) and is stuck at the "Start-CosmosDbEmulator" command. Tried a few variations with different flags (-debug, -trace) to get debug log and nothing helpful was found about why it would not start. The only difference between the new agents and the old one is, the old ones were running as "VssAdministrator" where the new one is not. Adding the `-noui` flag solves the problem. I could not find more details about what is really causing it.  I believe we don't really care whether the emulator is running with UI or not.