### PR TITLE
SBOM-Switching to "demands" and "ImageOverride" approach to pick a VM image from pool

### DIFF
--- a/build/pipelines/templates/extensions-ci.yml
+++ b/build/pipelines/templates/extensions-ci.yml
@@ -7,7 +7,8 @@ jobs:
 - job: "Build_And_Test_Windows"
   pool:
     name: '1ES-Hosted-AzFunc'
-    vmImage: 'MMS2022TLS'
+    demands:
+      - ImageOverride -equals MMS2022TLS
 
   variables:
     - template: extensions-variables.yml

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -19,7 +19,8 @@ jobs:
 - job: "Build_And_Test_Windows"
   pool:
     name: '1ES-Hosted-AzFunc'
-    vmImage: 'MMS2022TLS'
+    demands:
+      - ImageOverride -equals MMS2022TLS
 
   variables:
     ${{ if not(contains(variables['Build.SourceBranch'], '/release/' )) }}:
@@ -217,8 +218,9 @@ jobs:
 - job: "E2ETests_Ubuntu"  
   pool:
     name: '1ES-Hosted-AzFunc'
-    vmImage: 'MMSUbuntu20.04TLS'
-    
+    demands:
+      - ImageOverride -equals MMSUbuntu20.04TLS
+
   steps:
     - template: ../build/install-dotnet.yml
     - task: DotNetCoreCLI@2


### PR DESCRIPTION
Switching to "demands" and "ImageOverride" approach to pick a VM image from pool. This the recommended way than using `vmImage`. 