### PR TITLE
Updated subtree from protobuf

### DIFF
--- a/src/DotNetWorker.Grpc/protobuf/src/proto/FunctionRpc.proto
+++ b/src/DotNetWorker.Grpc/protobuf/src/proto/FunctionRpc.proto
@@ -4,7 +4,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "com.microsoft.azure.functions.rpc.messages";
 option java_outer_classname = "FunctionProto";
-option csharp_namespace = "Microsoft.Azure.WebJobs.Script.Grpc.Messages";
+option csharp_namespace = "Microsoft.Azure.Functions.Worker.Grpc.Messages";
 option go_package ="github.com/Azure/azure-functions-go-worker/internal/rpc";
 
 package AzureFunctionsRpcMessages;

--- a/src/DotNetWorker.Grpc/protobuf/src/proto/FunctionRpc.proto
+++ b/src/DotNetWorker.Grpc/protobuf/src/proto/FunctionRpc.proto
@@ -4,7 +4,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "com.microsoft.azure.functions.rpc.messages";
 option java_outer_classname = "FunctionProto";
-option csharp_namespace = "Microsoft.Azure.Functions.Worker.Grpc.Messages";
+option csharp_namespace = "Microsoft.Azure.WebJobs.Script.Grpc.Messages";
 option go_package ="github.com/Azure/azure-functions-go-worker/internal/rpc";
 
 package AzureFunctionsRpcMessages;
@@ -78,7 +78,10 @@ message StreamingMessage {
 
     // Worker indexing message types
     FunctionsMetadataRequest functions_metadata_request = 29;
-    FunctionMetadataResponses function_metadata_responses = 30;
+    FunctionMetadataResponse function_metadata_response = 30;
+
+    // Host sends required metadata to worker to load functions
+    FunctionLoadRequestCollection function_load_request_collection = 31;
   }
 }
 
@@ -220,7 +223,12 @@ message CloseSharedMemoryResourcesResponse {
   map<string, bool> close_map_results = 1;
 }
 
-// Host tells the worker to load a Function
+// Host tells the worker to load a list of Functions
+message FunctionLoadRequestCollection {
+  repeated FunctionLoadRequest function_load_requests = 1;
+}
+
+// Load request of a single Function
 message FunctionLoadRequest {
   // unique function identifier (avoid name collisions, facilitate reload case)
   string function_id = 1;
@@ -273,6 +281,12 @@ message RpcFunctionMetadata {
 
   // Raw binding info
   repeated string raw_bindings = 10;
+
+  // unique function identifier (avoid name collisions, facilitate reload case)
+  string function_id = 13;
+
+  // A flag indicating if managed dependency is enabled or not
+  bool managed_dependency_enabled = 14;
 }
 
 // Host tells worker it is ready to receive metadata
@@ -282,12 +296,15 @@ message FunctionsMetadataRequest {
 }
 
 // Worker sends function metadata back to host
-message FunctionMetadataResponses {
+message FunctionMetadataResponse {
   // list of function indexing responses
-  repeated FunctionLoadRequest function_load_requests_results = 1;
+  repeated RpcFunctionMetadata function_metadata_results = 1;
 
   // status of overall metadata request
   StatusResult result = 2;
+
+  // if set to true then host will perform indexing
+  bool useDefaultMetadataIndexing = 3;
 }
 
 // Host requests worker to invoke a Function


### PR DESCRIPTION
Update protobuf to get the changes from [this commit](https://github.com/Azure/azure-functions-language-worker-protobuf/commit/0d3f1041c0be282906004adc98b304ee3c567501). This will provide us with gRPC messages needed to implement the capability to process a single payload of `FunctionLoadRequest` messages. 

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Part of the solution for [this host issue](https://github.com/Azure/azure-functions-host/issues/7880).

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
