### PR TITLE
Fixing the wrong csproj location in test project references (missing "src" segment in path)

### DIFF
--- a/test/DotNetWorkerTests/DotNetWorkerTests.csproj
+++ b/test/DotNetWorkerTests/DotNetWorkerTests.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\extensions\Worker.Extensions.Abstractions\Worker.Extensions.Abstractions.csproj" />
-    <ProjectReference Include="..\..\extensions\Worker.Extensions.Http\Worker.Extensions.Http.csproj" />
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.Abstractions\src\Worker.Extensions.Abstractions.csproj" />
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.Http\src\Worker.Extensions.Http.csproj" />
     <ProjectReference Include="..\..\src\DotNetWorker\DotNetWorker.csproj" />
   </ItemGroup>
 

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\extensions\Worker.Extensions.Abstractions\Worker.Extensions.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\extensions\Worker.Extensions.Abstractions\src\Worker.Extensions.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\sdk\Sdk.Analyzers\Sdk.Analyzers.csproj" />
     <ProjectReference Include="..\..\..\src\DotNetWorker\DotNetWorker.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Some tests projects had incorrect path to the dependent .csproj files for the project references, specifically the "src" segment was missing in the path. This caused warning like below when you build the solution.

![build-warning](https://user-images.githubusercontent.com/144469/150189519-7c892eea-bc82-4280-9353-f09bc0a3f256.png)

Same warning can be seen in CI pipeline logs.
