### PR TITLE
Remove SkipBuildOnPack option in E2E Tests Setup Script

### DIFF
--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -97,7 +97,7 @@ if (Test-Path $output)
   Remove-Item $output -Recurse -Force -ErrorAction Ignore
 }
 
-.\tools\devpack.ps1 -E2E -AdditionalPackArgs @("-c","Release") -SkipBuildOnPack
+.\tools\devpack.ps1 -E2E -AdditionalPackArgs @("-c","Release")
 
 if ($SkipStorageEmulator -And $SkipCosmosDBEmulator)
 {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

When switching branches the set up script uses old assemblies instead of building a new one based on the new branch. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
