### PR TITLE
Adding support for .NET Standard 2.0

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -24,7 +24,7 @@
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/build/Common.props
+++ b/build/Common.props
@@ -24,7 +24,7 @@
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
+- Added support for .NET Standard 2.0. This enables Workers built using .NET Framework
 - Storage extensions moved to 5.0.0
 - SignalR extensions:
     * Support AAD authentication in connection string. (#803)

--- a/src/DotNetWorker.Core/Context/Features/IDictionaryExtensions.cs
+++ b/src/DotNetWorker.Core/Context/Features/IDictionaryExtensions.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-// This is excluded in the projec for other targets,
+// This is excluded in the project for other targets,
 // but conditionally compiling for clarity.
 // This implementation will be used in .NET Standard 2.0
 #if NETSTANDARD2_0
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Functions.Worker
 {
@@ -16,6 +15,11 @@ namespace Microsoft.Azure.Functions.Worker
     {
         internal static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             if (dictionary.ContainsKey(key))
             {
                 return false;

--- a/src/DotNetWorker.Core/Context/Features/IDictionaryExtensions.cs
+++ b/src/DotNetWorker.Core/Context/Features/IDictionaryExtensions.cs
@@ -4,7 +4,6 @@
 // This is excluded in the projec for other targets,
 // but conditionally compiling for clarity.
 // This implementation will be used in .NET Standard 2.0
-
 #if NETSTANDARD2_0
 using System;
 using System.Collections.Concurrent;

--- a/src/DotNetWorker.Core/Context/Features/IDictionaryExtensions.cs
+++ b/src/DotNetWorker.Core/Context/Features/IDictionaryExtensions.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+// This is excluded in the projec for other targets,
+// but conditionally compiling for clarity.
+// This implementation will be used in .NET Standard 2.0
+
+#if NETSTANDARD2_0
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    internal static class IDictionaryExtensions
+    {
+        internal static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        {
+            if (dictionary.ContainsKey(key))
+            {
+                return false;
+            }
+
+            dictionary.Add(key, value);
+            return true;
+        }
+    }
+
+    internal static class ConcurrentDictionaryExtensions
+    {
+        public static TValue GetOrAdd<TKey, TValue, TArg>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+        {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (valueFactory == null)
+            {
+                throw new ArgumentNullException(nameof(valueFactory));
+            }
+
+            return dictionary.GetOrAdd(key, k => valueFactory(k, factoryArgument));
+        }
+    }
+}
+#endif

--- a/src/DotNetWorker.Core/Converters/MemoryConverter.cs
+++ b/src/DotNetWorker.Core/Converters/MemoryConverter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Functions.Worker.Converters
@@ -19,7 +18,11 @@ namespace Microsoft.Azure.Functions.Worker.Converters
 
             if (context.TargetType.IsAssignableFrom(typeof(string)))
             {
+#if NET5_0_OR_GREATER
                 var target = Encoding.UTF8.GetString(sourceMemory.Span);
+#else
+                var target = Encoding.UTF8.GetString(sourceMemory.Span.ToArray());
+#endif
                 return new ValueTask<ConversionResult>(ConversionResult.Success(target));
             }
 

--- a/src/DotNetWorker.Core/DotNetWorker.Core.csproj
+++ b/src/DotNetWorker.Core/DotNetWorker.Core.csproj
@@ -1,22 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <PackageId>Microsoft.Azure.Functions.Worker.Core</PackageId>
-    <Description>This library provides the core functionality to build an Azure Functions .NET Worker, adding support for the isolated, out-of-process execution model.</Description>
-    <AssemblyName>Microsoft.Azure.Functions.Worker.Core</AssemblyName>
-    <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>5</MinorProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+        <PackageId>Microsoft.Azure.Functions.Worker.Core</PackageId>
+        <Description>This library provides the core functionality to build an Azure Functions .NET Worker, adding support for the isolated, out-of-process execution model.</Description>
+        <AssemblyName>Microsoft.Azure.Functions.Worker.Core</AssemblyName>
+        <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <MinorProductVersion>5</MinorProductVersion>
+        <VersionSuffix>-preview1</VersionSuffix>
+    </PropertyGroup>
 
-  <Import Project="..\..\build\Common.props" />
+    <Import Project="..\..\build\Common.props" />
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.10.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <Compile Remove="StartupHook.cs" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+      <Compile Remove="Context\Features\IDictionaryExtensions.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Azure.Core" Version="1.10.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+        <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    </ItemGroup>
 </Project>

--- a/src/DotNetWorker.Core/Http/HttpRequestDataExtensions.cs
+++ b/src/DotNetWorker.Core/Http/HttpRequestDataExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Functions.Worker.Http
                 return null;
             }
 
-            using (var reader = new StreamReader(request.Body, encoding: encoding, leaveOpen: true))
+            using (var reader = new StreamReader(request.Body, bufferSize: -1, detectEncodingFromByteOrderMarks: true, encoding: encoding, leaveOpen: true))
             {
                 return await reader.ReadToEndAsync();
             }
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Functions.Worker.Http
                 return null;
             }
 
-            using (var reader = new StreamReader(request.Body, encoding: encoding, leaveOpen: true))
+            using (var reader = new StreamReader(request.Body, bufferSize: -1, detectEncodingFromByteOrderMarks: true, encoding: encoding, leaveOpen: true))
             {
                 return reader.ReadToEnd();
             }

--- a/src/DotNetWorker.Core/Invocation/DefaultMethodInfoLocator.cs
+++ b/src/DotNetWorker.Core/Invocation/DefaultMethodInfoLocator.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Reflection;
+#if NET5_0_OR_GREATER
 using System.Runtime.Loader;
+#endif
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Azure.Functions.Worker.Invocation
@@ -19,8 +21,11 @@ namespace Microsoft.Azure.Functions.Worker.Invocation
 
             string typeName = entryPointMatch.Groups["typename"].Value;
             string methodName = entryPointMatch.Groups["methodname"].Value;
-
+#if NET5_0_OR_GREATER
             Assembly assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(pathToAssembly);
+#else
+            Assembly assembly = Assembly.LoadFrom(pathToAssembly);
+#endif
 
             Type? functionType = assembly.GetType(typeName);
 

--- a/src/DotNetWorker.Core/WorkerInformation.cs
+++ b/src/DotNetWorker.Core/WorkerInformation.cs
@@ -18,7 +18,15 @@ namespace Microsoft.Azure.Functions.Worker
 
         public static WorkerInformation Instance = new();
 
+#if NET5_0_OR_GREATER
         public int ProcessId => Environment.ProcessId;
+
+        public string RuntimeIdentifier => RuntimeInformation.RuntimeIdentifier;
+#else
+        public int ProcessId => Process.GetCurrentProcess().Id;
+
+        public string RuntimeIdentifier => "n/a"; // Resolve in netstandard
+#endif
 
         public string WorkerVersion => _thisAssembly.GetName().Version?.ToString()!;
 
@@ -31,7 +39,6 @@ namespace Microsoft.Azure.Functions.Worker
 
         public Architecture OSArchitecture => RuntimeInformation.OSArchitecture;
 
-        public string RuntimeIdentifier => RuntimeInformation.RuntimeIdentifier;
 
         public string CommandLine => Environment.CommandLine;
     }

--- a/src/DotNetWorker.Grpc/ChannelReaderExtensions.cs
+++ b/src/DotNetWorker.Grpc/ChannelReaderExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+// This is excluded in the projec for other targets,
+// but conditionally compiling for clarity.
+// This implementation will be used in .NET Standard 2.0
+
+#if NETSTANDARD2_0
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+
+namespace Microsoft.Azure.Functions.Worker.Grpc
+{
+    internal static class ChannelReaderExtensions
+    {
+        public static async IAsyncEnumerable<T> ReadAllAsync<T>(this ChannelReader<T> reader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (reader.TryRead(out T? item))
+                {
+                    yield return item;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
+++ b/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
@@ -1,43 +1,51 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <PackageId>Microsoft.Azure.Functions.Worker.Grpc</PackageId>
-    <Description>This library provides gRPC support for Azure Functions .NET Worker communication with the Azure Functions Host.</Description>
-    <AssemblyName>Microsoft.Azure.Functions.Worker.Grpc</AssemblyName>
-    <RootNamespace>Microsoft.Azure.Functions.Worker.Grpc</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>4</MinorProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+        <PackageId>Microsoft.Azure.Functions.Worker.Grpc</PackageId>
+        <Description>This library provides gRPC support for Azure Functions .NET Worker communication with the Azure Functions Host.</Description>
+        <AssemblyName>Microsoft.Azure.Functions.Worker.Grpc</AssemblyName>
+        <RootNamespace>Microsoft.Azure.Functions.Worker.Grpc</RootNamespace>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <MinorProductVersion>4</MinorProductVersion>
+        <VersionSuffix>-preview1</VersionSuffix>
+    </PropertyGroup>
 
-  <Import Project="..\..\build\Common.props" />
+    <Import Project="..\..\build\Common.props" />
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.10.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.15.8" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.37.0" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.37.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.37.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="Azure.Core" Version="1.10.0" />
+        <PackageReference Include="Google.Protobuf" Version="3.15.8" />
+        <PackageReference Include="Grpc.Net.Client" Version="2.37.0" />
+        <PackageReference Include="Grpc.Net.ClientFactory" Version="2.37.0" />
+        <PackageReference Include="Grpc.Tools" Version="2.37.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-     <Protobuf Include=".\protobuf\src\proto\**\*.proto" ProtoRoot=".\protobuf\src\proto" />
-  </ItemGroup>
+    <ItemGroup>
+        <Protobuf Include=".\protobuf\src\proto\**\*.proto" ProtoRoot=".\protobuf\src\proto" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DotNetWorker.Core\DotNetWorker.Core.csproj" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+      <Compile Remove="ChannelReaderExtensions.cs" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Protobuf Update=".\protobuf\src\proto\FunctionRpc.proto" Access="Internal" />
-    <Protobuf Update=".\protobuf\src\proto\identity\ClaimsIdentityRpc.proto" Access="Internal" />
-    <Protobuf Update=".\protobuf\src\proto\shared\NullableTypes.proto" Access="Internal" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\DotNetWorker.Core\DotNetWorker.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Protobuf Update=".\protobuf\src\proto\FunctionRpc.proto" Access="Internal" />
+        <Protobuf Update=".\protobuf\src\proto\identity\ClaimsIdentityRpc.proto" Access="Internal" />
+        <Protobuf Update=".\protobuf\src\proto\shared\NullableTypes.proto" Access="Internal" />
+    </ItemGroup>
 </Project>

--- a/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
+++ b/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
@@ -12,7 +12,10 @@ using Microsoft.Azure.Functions.Worker.Grpc.Messages;
 
 namespace Microsoft.Azure.Functions.Worker
 {
-    internal class GrpcHttpRequestData : HttpRequestData, IAsyncDisposable, IDisposable
+    internal class GrpcHttpRequestData : HttpRequestData, IDisposable
+#if NET5_0_OR_GREATER
+        ,IAsyncDisposable
+#endif
     {
         private readonly RpcHttp _httpData;
         private Uri? _url;
@@ -70,7 +73,11 @@ namespace Microsoft.Azure.Functions.Worker
                         }
 
                         var stream = new MemoryStream(memory.Length);
+#if NET5_0_OR_GREATER
                         stream.Write(memory.Span);
+#else
+                        stream.Write(memory.Span.ToArray(), 0, memory.Span.Length);
+#endif
                         stream.Position = 0;
 
                         _bodyStream = stream;
@@ -120,10 +127,12 @@ namespace Microsoft.Azure.Functions.Worker
             return new GrpcHttpResponseData(FunctionContext, System.Net.HttpStatusCode.OK);
         }
 
+#if NET5_0
         public ValueTask DisposeAsync()
         {
             return _bodyStream?.DisposeAsync() ?? ValueTask.CompletedTask;
         }
+#endif
 
         protected virtual void Dispose(bool disposing)
         {
@@ -146,13 +155,18 @@ namespace Microsoft.Azure.Functions.Worker
 
         private IReadOnlyCollection<IHttpCookie> ToHttpCookies(string cookieString)
         {
-            var separateCookies = cookieString.Split(";");
+            var separateCookies = cookieString.Split(';');
 
             List<IHttpCookie> httpCookiesList = new List<IHttpCookie>(separateCookies.Length);
 
             for (int c = 0; c < separateCookies.Length; c++)
             {
-                var splitArray = separateCookies[c].Split("=", StringSplitOptions.RemoveEmptyEntries);
+#if NET5_0_OR_GREATER
+                var separator = '=';
+#else
+                var separator = new[] { '=' };
+#endif
+                var splitArray = separateCookies[c].Split(separator, StringSplitOptions.RemoveEmptyEntries);
                 var name = splitArray[0].Trim();
                 var value = splitArray[1];
                 httpCookiesList.Add(new HttpCookie(name, value));

--- a/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
+++ b/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
@@ -159,13 +159,15 @@ namespace Microsoft.Azure.Functions.Worker
 
             List<IHttpCookie> httpCookiesList = new List<IHttpCookie>(separateCookies.Length);
 
+#if NET5_0_OR_GREATER
+            var separator = '=';
+#else
+            var separator = new[] { '=' };
+#endif
+
             for (int c = 0; c < separateCookies.Length; c++)
             {
-#if NET5_0_OR_GREATER
-                var separator = '=';
-#else
-                var separator = new[] { '=' };
-#endif
+
                 var splitArray = separateCookies[c].Split(separator, StringSplitOptions.RemoveEmptyEntries);
                 var name = splitArray[0].Trim();
                 var value = splitArray[1];

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker</PackageId>
     <Description>This library enables you to create an Azure Functions .NET Worker, adding support for the isolated, out-of-process execution model.</Description>
     <AssemblyName>Microsoft.Azure.Functions.Worker</AssemblyName>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This PR adds support for .NET Standard 2.0, aiming at supporting .NET Framework OOP applications. 

Adding @mattchenderson for awareness. This will require work on templates and tooling, but I'm not currently looking at that as blockers.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR (coming. will sync with @mattchenderson )
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

