### PR TITLE
adding the support for kafka headers with latest build

### DIFF
--- a/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.2.1")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.3.2")]

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -6,14 +6,13 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.2.1</VersionPrefix>
+    <VersionPrefix>3.3.2</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <Import Project="..\..\..\build\Extensions.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\..\Worker.Extensions.Abstractions\src\Worker.Extensions.Abstractions.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Publishing version 3.3.2 of Microsoft.Azure.Functions.Worker.Extensions.Kafka which uses 3.3.2 version of Microsoft.Azure.WebJobs.Extensions.Kafka
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
