### PR TITLE
APIs for reading and updating input binding data, output binding data and invocation result.

### DIFF
--- a/src/DotNetWorker.Core/Context/DefaultBindingCache.cs
+++ b/src/DotNetWorker.Core/Context/DefaultBindingCache.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    internal class DefaultBindingCache<T> : IBindingCache<T>
+    {
+        private readonly ConcurrentDictionary<string, T> _cache = new();
+
+        public bool TryGetValue(string key, out T? value)
+        {
+            EnsureKeyNotNull(key);
+
+            if (_cache.TryGetValue(key, out var conversionResult))
+            {
+                value = conversionResult;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public bool TryAdd(string key, T value)
+        {
+            EnsureKeyNotNull(key);
+
+            return _cache.TryAdd(key, value);
+        }
+
+        private static void EnsureKeyNotNull(string key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+        }
+    }
+}

--- a/src/DotNetWorker.Core/Context/DefaultBindingCache.cs
+++ b/src/DotNetWorker.Core/Context/DefaultBindingCache.cs
@@ -9,10 +9,22 @@ namespace Microsoft.Azure.Functions.Worker
     /// <summary>
     /// In memory cache for binding data (per invocation)
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of cache entry value.</typeparam>
     internal class DefaultBindingCache<T> : IBindingCache<T>
     {
         private readonly ConcurrentDictionary<string, T> _cache = new();
+
+        public T this[string key]
+        {
+            get
+            {
+                return _cache[key];
+            }
+            set
+            {
+                _cache[key] = value;
+            }
+        }
 
         public bool TryGetValue(string key, out T? value)
         {

--- a/src/DotNetWorker.Core/Context/DefaultBindingCache.cs
+++ b/src/DotNetWorker.Core/Context/DefaultBindingCache.cs
@@ -6,6 +6,10 @@ using System.Collections.Concurrent;
 
 namespace Microsoft.Azure.Functions.Worker
 {
+    /// <summary>
+    /// In memory cache for binding data (per invocation)
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     internal class DefaultBindingCache<T> : IBindingCache<T>
     {
         private readonly ConcurrentDictionary<string, T> _cache = new();
@@ -14,14 +18,7 @@ namespace Microsoft.Azure.Functions.Worker
         {
             EnsureKeyNotNull(key);
 
-            if (_cache.TryGetValue(key, out var conversionResult))
-            {
-                value = conversionResult;
-                return true;
-            }
-
-            value = default;
-            return false;
+            return _cache.TryGetValue(key, out value);
         }
 
         public bool TryAdd(string key, T value)

--- a/src/DotNetWorker.Core/Context/Features/DefaultInputConversionFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultInputConversionFeature.cs
@@ -15,19 +15,13 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
     internal sealed class DefaultInputConversionFeature : IInputConversionFeature
     {
         private readonly IInputConverterProvider _inputConverterProvider;
-        
-        // Cache to store conversion result.
-        // If conversion was requested for same parameter more than once during a function invocation
-        // the result will be served from the cache for second time onwards.
-        private readonly ConcurrentDictionary<string, ValueTask<ConversionResult>> _conversionResultCache = new();
-        
         private static readonly Type _inputConverterAttributeType = typeof(InputConverterAttribute);
 
         // Users may create a POCO and specify a special converter implementation
         // to be used using "InputConverter" attribute. We cache that mapping here.
         // Key is assembly qualified name of POCO and Value is assembly qualified name of converter implementation.
         private static readonly ConcurrentDictionary<string, string?> _typeToConverterCache = new();
-        
+
         public DefaultInputConversionFeature(IInputConverterProvider inputConverterProvider)
         {
             _inputConverterProvider = inputConverterProvider ?? throw new ArgumentNullException(nameof(inputConverterProvider));
@@ -39,13 +33,6 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
         /// <param name="converterContext">The converter context.</param>
         /// <returns>An instance of <see cref="ConversionResult"/> representing the result of the conversion.</returns>
         public async ValueTask<ConversionResult> ConvertAsync(ConverterContext converterContext)
-        {
-            var key = GetCacheKey(converterContext);
-
-            return await _conversionResultCache.GetOrAdd(key, (key) => ExecuteInputConversion(converterContext));
-        }
-
-        private async ValueTask<ConversionResult> ExecuteInputConversion(ConverterContext converterContext)
         {
             // Check a converter is explicitly specified via the converter context. If so, use that.
             IInputConverter? converterFromContext = GetConverterFromContext(converterContext);
@@ -145,23 +132,6 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                 return converterType.AssemblyQualifiedName!;
 
             }, targetType);
-        }
-
-        /// <summary>
-        /// Creates a cache key for the ConverterContext instance passed in.
-        /// </summary>
-        /// <param name="converterContext"></param>
-        /// <returns></returns>
-        private string GetCacheKey(ConverterContext converterContext)
-        {
-            var cacheKey = $"{converterContext.TargetType.Name}_{converterContext.Source}";
-
-            foreach (var prop in converterContext.Properties)
-            {
-                cacheKey += prop.Key;
-            }
-
-            return cacheKey;
         }
     }
 }

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -16,26 +16,6 @@ namespace Microsoft.Azure.Functions.Worker
     public static class FunctionContextBindingFeatureExtensions
     {
         /// <summary>
-        /// Gets the input binding data for the current function invocation.
-        /// </summary>
-        /// <param name="context">The function context instance.</param>
-        /// <returns>The input binding data as a read only dictionary.</returns>
-        public static IReadOnlyDictionary<string, object?> GetInputData(this FunctionContext context)
-        {
-            return context.GetBindings().InputData;
-        }
-
-        /// <summary>
-        /// Gets the trigger meta data for the current function invocation.
-        /// </summary>
-        /// <param name="context">The function context instance.</param>
-        /// <returns>The invocation trigger meta data as a read only dictionary.</returns>
-        public static IReadOnlyDictionary<string, object?> GetTriggerMetadata(this FunctionContext context)
-        {
-            return context.GetBindings().TriggerMetadata;
-        }
-
-        /// <summary>
         /// Binds an input item for the requested type.
         /// </summary>
         /// <typeparam name="T">The type of input item to bind to.</typeparam>

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Azure.Functions.Worker
 
             // find the parameter from function definition for the Type requested.
             // Use that parameter definition(which has Type) to get converted value.
-
             FunctionParameter? parameter = null;
             foreach (var param in context.FunctionDefinition.Parameters)
             {
@@ -104,21 +103,24 @@ namespace Microsoft.Azure.Functions.Worker
         /// Gets the output binding entries for the current function invocation.
         /// </summary>
         /// <param name="context">The function context instance.</param>
-        /// <returns>Collection of <see cref="OutputBindingData"/></returns>
-        public static IEnumerable<OutputBindingData> GetOutputBindings(this FunctionContext context)
+        /// <returns>Collection of OutputBindingData instances of the requested type T.</returns>
+        public static IEnumerable<OutputBindingData<T>> GetOutputBindings<T>(this FunctionContext context)
         {
             var bindingsFeature = context.GetBindings();
 
             foreach (var data in bindingsFeature.OutputBindingData)
             {
-                // Gets binding type (http,queue etc) from function definition.
-                string? bindingType = null;
-                if (context.FunctionDefinition.OutputBindings.TryGetValue(data.Key, out var bindingData))
+                if (data.Value is T valueAsT)
                 {
-                    bindingType = bindingData.Type;
-                }
+                    // Gets binding type (http,queue etc) from function definition.
+                    string? bindingType = null;
+                    if (context.FunctionDefinition.OutputBindings.TryGetValue(data.Key, out var bindingData))
+                    {
+                        bindingType = bindingData.Type;
+                    }
 
-                yield return new OutputBindingData(context, data.Key, data.Value, bindingType);
+                    yield return new OutputBindingData<T>(context, data.Key, valueAsT, bindingType);
+                }
             }
         }
 

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.Functions.Worker
             ConversionResult bindingResult;
             var cacheKey = bindingMetadata.Name;
             var bindingCache = context.InstanceServices.GetService<IBindingCache<ConversionResult>>();
+            
             if (bindingCache!.TryGetValue(cacheKey, out var cachedResult))
             {
                 bindingResult = cachedResult;
@@ -135,7 +136,7 @@ namespace Microsoft.Azure.Functions.Worker
 
             var converterContext = converterContextFactory!.Create(targetType, source, context);
 
-            return await inputConversionFeature!.ConvertAsync(converterContext); //default;
+            return await inputConversionFeature!.ConvertAsync(converterContext);
         }
     }
 }

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -16,47 +16,12 @@ namespace Microsoft.Azure.Functions.Worker
     public static class FunctionContextBindingFeatureExtensions
     {
         /// <summary>
-        /// Binds an input binding item for the requested type.
-        /// </summary>
-        /// <typeparam name="T">The type of input item to bind to.</typeparam>
-        /// <param name="context">The function context.</param>
-        /// <returns>A <see cref="Task"/> wrapping an instance of T if binding was successful, else null</returns>
-        /// <exception cref="InvalidOperationException">Throws when more than one input binding entry found for the requested type.</exception>
-        public static async Task<T?> BindInputAsync<T>(this FunctionContext context)
-        {
-            var requestedInputBindingType = typeof(T);
-
-            // find the parameter from function definition for the Type requested.
-            FunctionParameter? parameter = null;
-            foreach (var param in context.FunctionDefinition.Parameters)
-            {
-                if (param.Type.IsAssignableFrom(requestedInputBindingType))
-                {
-                    if (parameter != null)
-                    {
-                        // More than one parameter found with the type requested.
-                        // customer should use the other overload of this method with an explicit BindingMetadata instance.
-                        throw new InvalidOperationException("More than one input binding item found for the requested type. Use the BindInputAsync overload which takes an instance of BindingMetadata");
-                    }
-                    parameter = param;
-                }
-            }
-
-            if (parameter != null)
-            {
-                return await GetConvertedValueFromInputConversionFeature<T>(context, parameter);
-            }
-
-            return default;
-        }
-
-        /// <summary>
         /// Binds an input binding item for the requested <see cref="BindingMetadata"/> instance.
         /// </summary>
         /// <param name="context">The function context.</param>
         /// <param name="bindingMetadata">The BindingMetadata instance for which input data should bound to.</param>
-        /// <returns>A <see cref="Task"/> wrapping an instance of T if binding was successful, else null</returns>
-        public static async Task<T?> BindInputAsync<T>(this FunctionContext context, BindingMetadata bindingMetadata)
+        /// <returns>An instance of T if binding was successful, else null</returns>
+        public static async ValueTask<T?> BindInputAsync<T>(this FunctionContext context, BindingMetadata bindingMetadata)
         {
             if (bindingMetadata == null)
             {
@@ -74,9 +39,27 @@ namespace Microsoft.Azure.Functions.Worker
                 }
             }
 
-            if (parameter != null)
+            if (parameter == null)
             {
-                return await GetConvertedValueFromInputConversionFeature<T>(context, parameter);
+                return default;
+            }
+
+            ConversionResult bindingResult;
+            var cacheKey = bindingMetadata.Name;
+            var bindingCache = context.InstanceServices.GetService<IBindingCache<ConversionResult>>();
+            if (bindingCache!.TryGetValue(cacheKey, out var cachedResult))
+            {
+                bindingResult = cachedResult;
+                return (T?)bindingResult.Value;
+            }
+
+            var requestedType = typeof(T);
+            bindingResult = await GetConvertedValueFromInputConversionFeature(context, bindingMetadata, requestedType);
+            bindingCache.TryAdd(cacheKey, bindingResult);
+
+            if (bindingResult.Status == ConversionStatus.Succeeded && bindingResult.Value != null)
+            {
+                return (T?)bindingResult.Value;
             }
 
             return default;
@@ -123,7 +106,7 @@ namespace Microsoft.Azure.Functions.Worker
             {
                 if (data.Value is T valueAsT)
                 {
-                    // Gets binding type (blob,queue etc) from function definition.
+                    // Gets binding type (ex: blob,queue) from function definition.
                     string? bindingType = null;
                     if (context.FunctionDefinition.OutputBindings.TryGetValue(data.Key, out var bindingData))
                     {
@@ -138,27 +121,21 @@ namespace Microsoft.Azure.Functions.Worker
         /// <summary>
         /// Executes the input conversion feature to bind the value of the parameter.
         /// </summary>
-        private static async Task<T?> GetConvertedValueFromInputConversionFeature<T>(FunctionContext context, FunctionParameter parameter)
+        private static async ValueTask<ConversionResult> GetConvertedValueFromInputConversionFeature(FunctionContext context, BindingMetadata bindingMetadata, Type targetType)
         {
             var converterContextFactory = context.InstanceServices.GetService<IConverterContextFactory>();
             var inputConversionFeature = context.Features.Get<IInputConversionFeature>();
             var functionBindings = context.GetBindings();
 
             // Check InputData first, then TriggerMetadata
-            if (!functionBindings.InputData.TryGetValue(parameter.Name, out object? source))
+            if (!functionBindings.InputData.TryGetValue(bindingMetadata.Name, out object? source))
             {
-                functionBindings.TriggerMetadata.TryGetValue(parameter.Name, out source);
+                functionBindings.TriggerMetadata.TryGetValue(bindingMetadata.Name, out source);
             }
 
-            var converterContext = converterContextFactory!.Create(parameter.Type, source, context);
-            var bindingResult = await inputConversionFeature!.ConvertAsync(converterContext);
+            var converterContext = converterContextFactory!.Create(targetType, source, context);
 
-            if (bindingResult.Status == ConversionStatus.Succeeded && bindingResult.Value!=null)
-            {
-                return (T)bindingResult.Value;
-            }
-
-            return default;
+            return await inputConversionFeature!.ConvertAsync(converterContext); //default;
         }
     }
 }

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Context.Features;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// FunctionContext extension methods for binding data.
+    /// </summary>
+    public static class FunctionContextBindingFeatureExtensions
+    {
+        /// <summary>
+        /// Gets the input binding data for the current function invocation.
+        /// </summary>
+        /// <param name="context">The function context instance.</param>
+        /// <returns>The input binding data as a read only dictionary.</returns>
+        public static IReadOnlyDictionary<string, object?> GetInputData(this FunctionContext context)
+        {
+            return context.GetBindings().InputData;
+        }
+
+        /// <summary>
+        /// Gets the trigger meta data for the current function invocation.
+        /// </summary>
+        /// <param name="context">The function context instance.</param>
+        /// <returns>The invocation trigger meta data as a read only dictionary.</returns>
+        public static IReadOnlyDictionary<string, object?> GetTriggerMetadata(this FunctionContext context)
+        {
+            return context.GetBindings().TriggerMetadata;
+        }
+
+        /// <summary>
+        /// Binds an input item for the requested type.
+        /// </summary>
+        /// <typeparam name="T">The type of input item to bind to.</typeparam>
+        /// <param name="context">The function context.</param>
+        /// <returns>An instance of <see cref="T"/> if binding was successful, else null</returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public static async Task<T?> BindInputAsync<T>(this FunctionContext context)
+        {
+            var inputType = typeof(T);
+
+            // find the parameter from function definition for the Type requested.
+            // Use that parameter definition(which has Type) to get converted value.
+
+            FunctionParameter? parameter = null;
+            foreach (var param in context.FunctionDefinition.Parameters)
+            {
+                if (param.Type.IsAssignableFrom(inputType))
+                {
+                    if (parameter != null)
+                    {
+                        // More than one parameter found with the type requested.
+                        // customer should use the other overload of this method with an explicit FunctionParameter instance.
+                        throw new InvalidOperationException("More than one binding item found for the requested Type. Use the BindInput overload which takes an instance of FunctionParameter");
+                    }
+                    parameter = param;
+                }
+            }
+
+            return await BindInputAsync<T>(context, parameter);
+        }
+
+        /// <summary>
+        /// Binds an input item for the requested function parameter.
+        /// </summary>
+        /// <param name="context">The function context.</param>
+        /// <param name="parameter">The function parameter for which input data should bound to.</param>
+        /// <returns></returns>
+        public static async Task<T?> BindInputAsync<T>(this FunctionContext context, FunctionParameter parameter)
+        {
+            if (parameter != null)
+            {
+                var convertedValue = await GetConvertedValueFromInputConversionFeature(context, parameter);
+
+                return (T)convertedValue;
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Gets the invocation result of the current function invocation.
+        /// </summary>
+        /// <param name="context">The function context instance.</param>
+        /// <returns>The invocation result value.</returns>
+        public static InvocationResult<T>? GetInvocationResult<T>(this FunctionContext context)
+        {
+            if (context.GetBindings().InvocationResult is T t)
+            {
+                return new InvocationResult<T>(context, t);
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Gets the output binding entries for the current function invocation.
+        /// </summary>
+        /// <param name="context">The function context instance.</param>
+        /// <returns>Collection of <see cref="OutputBindingData"/></returns>
+        public static IEnumerable<OutputBindingData> GetOutputBindings(this FunctionContext context)
+        {
+            var bindingsFeature = context.GetBindings();
+
+            foreach (var data in bindingsFeature.OutputBindingData)
+            {
+                // Gets binding type (http,queue etc) from function definition.
+                string? bindingType = null;
+                if (context.FunctionDefinition.OutputBindings.TryGetValue(data.Key, out var bindingData))
+                {
+                    bindingType = bindingData.Type;
+                }
+
+                yield return new OutputBindingData(context, data.Key, data.Value, bindingType);
+            }
+        }
+
+        /// <summary>
+        /// Executes the input conversion feature to bind the value of the parameter.
+        /// </summary>
+        private static async Task<object?> GetConvertedValueFromInputConversionFeature(FunctionContext context, FunctionParameter parameter)
+        {
+            IFunctionBindingsFeature functionBindings = context.GetBindings();
+
+            var converterContextFactory = context.InstanceServices.GetService<IConverterContextFactory>();
+
+            var inputConversionFeature = context.Features.Get<IInputConversionFeature>();
+
+            // Check InputData first, then TriggerMetadata
+            if (!functionBindings.InputData.TryGetValue(parameter.Name, out object? source))
+            {
+                functionBindings.TriggerMetadata.TryGetValue(parameter.Name, out source);
+            }
+
+            var converterContext = converterContextFactory!.Create(parameter.Type, source, context);
+            var bindingResult = await inputConversionFeature!.ConvertAsync(converterContext);
+
+            return bindingResult.Value;
+        }
+    }
+}

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Functions.Worker
     public static class FunctionContextBindingFeatureExtensions
     {
         /// <summary>
-        /// Binds an input item for the requested type.
+        /// Binds an input binding item for the requested type.
         /// </summary>
         /// <typeparam name="T">The type of input item to bind to.</typeparam>
         /// <param name="context">The function context.</param>
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Functions.Worker
         }
 
         /// <summary>
-        /// Binds an input item for the requested <see cref="BindingMetadata"/> instance.
+        /// Binds an input binding item for the requested <see cref="BindingMetadata"/> instance.
         /// </summary>
         /// <param name="context">The function context.</param>
         /// <param name="bindingMetadata">The BindingMetadata instance for which input data should bound to.</param>

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -88,15 +88,15 @@ namespace Microsoft.Azure.Functions.Worker
         /// Gets the invocation result of the current function invocation.
         /// </summary>
         /// <param name="context">The function context instance.</param>
-        /// <returns>The invocation result value.</returns>
-        public static InvocationResult<T>? GetInvocationResult<T>(this FunctionContext context)
+        /// <returns>An instance of <see cref="InvocationResult"/>.</returns>
+        public static InvocationResult<T> GetInvocationResult<T>(this FunctionContext context)
         {
             if (context.GetBindings().InvocationResult is T t)
             {
                 return new InvocationResult<T>(context, t);
             }
 
-            return default;
+            return new InvocationResult<T>(context, default); ;
         }
 
         /// <summary>

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -35,14 +35,14 @@ namespace Microsoft.Azure.Functions.Worker
             if (bindingCache!.TryGetValue(cacheKey, out var cachedResult))
             {
                 bindingResult = cachedResult;
-                return new InputBindingData<T>(bindingCache, bindingMetadata, (T?)bindingResult.Value);
+                return new DefaultInputBindingData<T>(bindingCache, bindingMetadata, (T?)bindingResult.Value);
             }
 
             var requestedType = typeof(T);
             bindingResult = await GetConvertedValueFromInputConversionFeature(context, bindingMetadata, requestedType);
             bindingCache.TryAdd(cacheKey, bindingResult);
 
-            return new InputBindingData<T>(bindingCache, bindingMetadata, (T?)bindingResult.Value);
+            return new DefaultInputBindingData<T>(bindingCache, bindingMetadata, (T?)bindingResult.Value);
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Functions.Worker
             var invocationResult = context.GetBindings().InvocationResult;
             if (invocationResult is T resultAsT)
             {
-                return new InvocationResult<T>(context, resultAsT);
+                return new DefaultInvocationResult<T>(context, resultAsT);
             }
 
             throw new InvalidOperationException($"Requested type({typeof(T)}) does not match the type of Invocation result({invocationResult!.GetType()})");
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Functions.Worker
         {
             var invocationResult = context.GetBindings().InvocationResult;
 
-            return new InvocationResult(context, invocationResult);
+            return new DefaultInvocationResult(context, invocationResult);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Functions.Worker
                         bindingType = bindingData.Type;
                     }
 
-                    yield return new OutputBindingData<T>(context, data.Key, valueAsT, bindingType!);
+                    yield return new DefaultOutputBindingData<T>(context, data.Key, valueAsT, bindingType!);
                 }
             }
         }

--- a/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextBindingFeatureExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Azure.Functions.Worker
         /// </summary>
         /// <param name="context">The function context.</param>
         /// <param name="bindingMetadata">The BindingMetadata instance for which input data should bound to.</param>
-        /// <returns>An instance of T if binding was successful, else null</returns>
-        public static async ValueTask<T?> BindInputAsync<T>(this FunctionContext context, BindingMetadata bindingMetadata)
+        /// <returns>An instance of <see cref="InputBindingData{T}"/> which wraps the input binding operation result value.</returns>
+        public static async ValueTask<InputBindingData<T>> BindInputAsync<T>(this FunctionContext context, BindingMetadata bindingMetadata)
         {
             if (bindingMetadata == null)
             {
@@ -35,19 +35,14 @@ namespace Microsoft.Azure.Functions.Worker
             if (bindingCache!.TryGetValue(cacheKey, out var cachedResult))
             {
                 bindingResult = cachedResult;
-                return (T?)bindingResult.Value;
+                return new InputBindingData<T>(bindingCache, bindingMetadata, (T?)bindingResult.Value);
             }
 
             var requestedType = typeof(T);
             bindingResult = await GetConvertedValueFromInputConversionFeature(context, bindingMetadata, requestedType);
             bindingCache.TryAdd(cacheKey, bindingResult);
 
-            if (bindingResult.Status == ConversionStatus.Succeeded && bindingResult.Value != null)
-            {
-                return (T?)bindingResult.Value;
-            }
-
-            return default;
+            return new InputBindingData<T>(bindingCache, bindingMetadata, (T?)bindingResult.Value);
         }
 
         /// <summary>

--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -30,19 +30,15 @@ namespace Microsoft.Azure.Functions.Worker.Core.Context
         public static HttpResponseData? GetHttpResponseData(this FunctionContext context)
         {
             var httpInvocationResult = context.GetInvocationResult<HttpResponseData>();
-            if (httpInvocationResult !=null)
+            if (httpInvocationResult.Value != null)
             {
                 return httpInvocationResult.Value;
             }
-
+            
             // see output binding entries has a property of type HttpResponseData;
             var httpOutputBinding = context.GetOutputBindings<HttpResponseData>().FirstOrDefault();
-            if (httpOutputBinding != null)
-            {
-                return httpOutputBinding.Value;
-            }
-
-            return default;
+            
+            return httpOutputBinding?.Value;
         }
     }
 }

--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Functions.Worker.Core.Context
         /// </summary>
         /// <param name="context">The FunctionContext instance.</param>
         /// <returns>HttpRequestData instance if the invocation is http, else null</returns>
-        public static async Task<HttpRequestData?> GetHttpRequestData(this FunctionContext context)
+        public static async Task<HttpRequestData?> GetHttpRequestDataAsync(this FunctionContext context)
         {
             return await context.BindInputAsync<HttpRequestData>();
         }

--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace Microsoft.Azure.Functions.Worker.Core.Context
+{
+    /// <summary>
+    /// FunctionContext extensions for http trigger function invocations.
+    /// </summary>
+    public static class FunctionContextHttpRequestExtensions
+    {
+        /// <summary>
+        /// Gets the <see cref="HttpRequestData"/> instance if the invocation is for an http trigger.
+        /// </summary>
+        /// <param name="context">The FunctionContext instance.</param>
+        /// <returns>HttpRequestData instance if the invocation is http, else null</returns>
+        public static async Task<HttpRequestData?> GetHttpRequestData(this FunctionContext context)
+        {
+            return await context.BindInputAsync<HttpRequestData>();
+        }
+    }
+}

--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Http;
 
@@ -19,6 +20,29 @@ namespace Microsoft.Azure.Functions.Worker.Core.Context
         public static async Task<HttpRequestData?> GetHttpRequestData(this FunctionContext context)
         {
             return await context.BindInputAsync<HttpRequestData>();
+        }
+
+        /// <summary>
+        /// Gets the <see cref="HttpResponseData"/> instance if the invocation is for an http trigger.
+        /// </summary>
+        /// <param name="context">The FunctionContext instance.</param>
+        /// <returns>HttpResponseData instance if the invocation is http, else null</returns>
+        public static HttpResponseData? GetHttpResponseData(this FunctionContext context)
+        {
+            var httpInvocationResult = context.GetInvocationResult<HttpResponseData>();
+            if (httpInvocationResult !=null)
+            {
+                return httpInvocationResult.Value;
+            }
+
+            // see output binding entries has a property of type HttpResponseData;
+            var httpOutputBinding = context.GetOutputBindings<HttpResponseData>().FirstOrDefault();
+            if (httpOutputBinding != null)
+            {
+                return httpOutputBinding.Value;
+            }
+
+            return default;
         }
     }
 }

--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Functions.Worker
         public static async ValueTask<HttpRequestData?> GetHttpRequestDataAsync(this FunctionContext context)
         {
             var httpTriggerBinding = context.FunctionDefinition.InputBindings.Values
-               .FirstOrDefault(a => a.Type == "httpTrigger");
+                                            .FirstOrDefault(a => a.Type == "httpTrigger");
 
             if (httpTriggerBinding != null)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Functions.Worker
                 return responseData;
             }
             
-            // see output binding entries has a property of type HttpResponseData;
+            // see output binding entries have a property of type HttpResponseData;
             var httpOutputBinding = context.GetOutputBindings<HttpResponseData>().FirstOrDefault();
             
             return httpOutputBinding?.Value;

--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Http;
 
-namespace Microsoft.Azure.Functions.Worker.Core.Context
+namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
     /// FunctionContext extensions for http trigger function invocations.
@@ -17,9 +17,17 @@ namespace Microsoft.Azure.Functions.Worker.Core.Context
         /// </summary>
         /// <param name="context">The FunctionContext instance.</param>
         /// <returns>HttpRequestData instance if the invocation is http, else null</returns>
-        public static async Task<HttpRequestData?> GetHttpRequestDataAsync(this FunctionContext context)
+        public static async ValueTask<HttpRequestData?> GetHttpRequestDataAsync(this FunctionContext context)
         {
-            return await context.BindInputAsync<HttpRequestData>();
+            var httpTriggerBinding = context.FunctionDefinition.InputBindings.Values
+               .FirstOrDefault(a => a.Type == "httpTrigger");
+
+            if (httpTriggerBinding != null)
+            {
+                return await context.BindInputAsync<HttpRequestData>(httpTriggerBinding);
+            }
+
+            return default;
         }
 
         /// <summary>
@@ -29,10 +37,10 @@ namespace Microsoft.Azure.Functions.Worker.Core.Context
         /// <returns>HttpResponseData instance if the invocation is http, else null</returns>
         public static HttpResponseData? GetHttpResponseData(this FunctionContext context)
         {
-            var httpInvocationResult = context.GetInvocationResult<HttpResponseData>();
-            if (httpInvocationResult.Value != null)
+            var httpInvocationResult = context.GetInvocationResult();
+            if (httpInvocationResult.Value is HttpResponseData responseData)
             {
-                return httpInvocationResult.Value;
+                return responseData;
             }
             
             // see output binding entries has a property of type HttpResponseData;

--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Azure.Functions.Worker
 
             if (httpTriggerBinding != null)
             {
-                return await context.BindInputAsync<HttpRequestData>(httpTriggerBinding);
+                var bindingResult = await context.BindInputAsync<HttpRequestData>(httpTriggerBinding);
+                return bindingResult.Value;
             }
 
             return default;

--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -42,10 +42,10 @@ namespace Microsoft.Azure.Functions.Worker
             {
                 return responseData;
             }
-            
+
             // see output binding entries have a property of type HttpResponseData;
             var httpOutputBinding = context.GetOutputBindings<HttpResponseData>().FirstOrDefault();
-            
+
             return httpOutputBinding?.Value;
         }
     }

--- a/src/DotNetWorker.Core/Context/IBindingCache.cs
+++ b/src/DotNetWorker.Core/Context/IBindingCache.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    internal interface IBindingCache<T>
+    {
+        /// <summary>
+        /// Attempts to get the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <param name="value">The value of the cache entry for the requested key.</param>
+        /// <returns>true if the key was found in the cache, else false.</returns>
+        bool TryGetValue(string key, out T? value);
+
+        /// <summary>
+        /// Attempts to add the specified key and value to the cache.
+        /// </summary>
+        /// <param name="key">The key of the cache entry.</param>
+        /// <param name="value">The value of the cache entry.</param>
+        /// <returns>true if the key/value pair was added to the cache, else false.</returns>
+        bool TryAdd(string key, T value);
+    }
+}

--- a/src/DotNetWorker.Core/Context/IBindingCache.cs
+++ b/src/DotNetWorker.Core/Context/IBindingCache.cs
@@ -6,6 +6,13 @@ namespace Microsoft.Azure.Functions.Worker
     internal interface IBindingCache<T>
     {
         /// <summary>
+        /// Gets or sets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the value to get or set.</param>
+        /// <returns>The value at the specified index.</returns>
+        T this[string key] { get; set; }
+
+        /// <summary>
         /// Attempts to get the value associated with the specified key.
         /// </summary>
         /// <param name="key">The key of the value to get.</param>

--- a/src/DotNetWorker.Core/Definition/BindingMetadata.cs
+++ b/src/DotNetWorker.Core/Definition/BindingMetadata.cs
@@ -9,12 +9,17 @@ namespace Microsoft.Azure.Functions.Worker
     public abstract class BindingMetadata
     {
         /// <summary>
-        /// The type of the binding. For example, "httpTrigger".
+        /// Gets the name of the binding metadata entry.
+        /// </summary>
+        public abstract string Name { get; }
+
+        /// <summary>
+        /// Gets the type of the binding. For example, "httpTrigger".
         /// </summary>
         public abstract string Type { get; }
 
         /// <summary>
-        /// The binding direction.
+        /// Gets the binding direction.
         /// </summary>
         public abstract BindingDirection Direction { get; }
     }

--- a/src/DotNetWorker.Core/DotNetWorker.Core.csproj
+++ b/src/DotNetWorker.Core/DotNetWorker.Core.csproj
@@ -8,8 +8,7 @@
         <AssemblyName>Microsoft.Azure.Functions.Worker.Core</AssemblyName>
         <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <MinorProductVersion>5</MinorProductVersion>
-        <PatchProductVersion>1</PatchProductVersion>
+        <MinorProductVersion>6</MinorProductVersion>
         <VersionSuffix>-preview1</VersionSuffix>
     </PropertyGroup>
 

--- a/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IConverterContextFactory, DefaultConverterContextFactory>();
             services.AddSingleton<IInputConversionFeatureProvider, DefaultInputConversionFeatureProvider>();
             services.AddSingleton<IInputConverterProvider, DefaultInputConverterProvider>();
+            
+            // Input binding cache
+            services.AddScoped<IBindingCache<ConversionResult>, DefaultBindingCache<ConversionResult>>();
 
             // Output Bindings
             services.AddSingleton<IOutputBindingsInfoProvider, DefaultOutputBindingsInfoProvider>();

--- a/src/DotNetWorker.Core/Invocation/DefaultInvocationResult.cs
+++ b/src/DotNetWorker.Core/Invocation/DefaultInvocationResult.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// A type wrapping the result of a function invocation.
+    /// </summary>
+    internal sealed class DefaultInvocationResult : InvocationResult
+    {
+        private readonly FunctionContext _functionContext;
+        private object? _value;
+
+        internal DefaultInvocationResult(FunctionContext functionContext, object? value)
+        {
+            _functionContext = functionContext;
+            _value = value;
+        }
+        /// <inheritdoc/>
+        public override object? Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _functionContext.GetBindings().InvocationResult = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A type wrapping the result of a function invocation.
+    /// </summary>
+    /// <typeparam name="T">The type of invocation result value.</typeparam>
+    internal sealed class DefaultInvocationResult<T> : InvocationResult<T>
+    {
+        private readonly FunctionContext _functionContext;
+        private T? _value;
+
+        internal DefaultInvocationResult(FunctionContext functionContext, T? value)
+        {
+            _functionContext = functionContext;
+            _value = value;
+        }
+
+        /// <inheritdoc/>
+        public override T? Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _functionContext.GetBindings().InvocationResult = value;
+            }
+        }
+    }
+}

--- a/src/DotNetWorker.Core/Invocation/InvocationResult.cs
+++ b/src/DotNetWorker.Core/Invocation/InvocationResult.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// A type wrapping the result of a function invocation.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public sealed class InvocationResult<T>
+    {
+        internal InvocationResult(FunctionContext functionContext, T value)
+        {
+            _functionContext = functionContext;
+            _value = value;
+        }
+
+        private readonly FunctionContext _functionContext;
+        private T _value;
+
+        /// <summary>
+        /// Gets or sets the invocation result value.
+        /// </summary>
+        public T Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _functionContext.GetBindings().InvocationResult = value;
+            }
+        }
+    }
+}

--- a/src/DotNetWorker.Core/Invocation/InvocationResult.cs
+++ b/src/DotNetWorker.Core/Invocation/InvocationResult.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Functions.Worker
     /// A type wrapping the result of a function invocation.
     /// </summary>
     /// <typeparam name="T">The type of invocation result value.</typeparam>
-    public sealed class InvocationResult<T>
+    public class InvocationResult<T>
     {
         internal InvocationResult(FunctionContext functionContext, T? value)
         {
@@ -29,6 +29,16 @@ namespace Microsoft.Azure.Functions.Worker
                 _value = value;
                 _functionContext.GetBindings().InvocationResult = value;
             }
+        }
+    }
+
+    /// <summary>
+    /// A type wrapping the result of a function invocation.
+    /// </summary>
+    public sealed class InvocationResult : InvocationResult<object>
+    {
+        internal InvocationResult(FunctionContext functionContext, object? value) : base(functionContext, value)
+        {
         }
     }
 }

--- a/src/DotNetWorker.Core/Invocation/InvocationResult.cs
+++ b/src/DotNetWorker.Core/Invocation/InvocationResult.cs
@@ -6,22 +6,22 @@ namespace Microsoft.Azure.Functions.Worker
     /// <summary>
     /// A type wrapping the result of a function invocation.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of invocation result value.</typeparam>
     public sealed class InvocationResult<T>
     {
-        internal InvocationResult(FunctionContext functionContext, T value)
+        internal InvocationResult(FunctionContext functionContext, T? value)
         {
             _functionContext = functionContext;
             _value = value;
         }
 
         private readonly FunctionContext _functionContext;
-        private T _value;
+        private T? _value;
 
         /// <summary>
         /// Gets or sets the invocation result value.
         /// </summary>
-        public T Value
+        public T? Value
         {
             get => _value;
             set

--- a/src/DotNetWorker.Core/Invocation/InvocationResult.cs
+++ b/src/DotNetWorker.Core/Invocation/InvocationResult.cs
@@ -6,39 +6,19 @@ namespace Microsoft.Azure.Functions.Worker
     /// <summary>
     /// A type wrapping the result of a function invocation.
     /// </summary>
-    /// <typeparam name="T">The type of invocation result value.</typeparam>
-    public class InvocationResult<T>
+    public abstract class InvocationResult : InvocationResult<object>
     {
-        internal InvocationResult(FunctionContext functionContext, T? value)
-        {
-            _functionContext = functionContext;
-            _value = value;
-        }
-
-        private readonly FunctionContext _functionContext;
-        private T? _value;
-
-        /// <summary>
-        /// Gets or sets the invocation result value.
-        /// </summary>
-        public T? Value
-        {
-            get => _value;
-            set
-            {
-                _value = value;
-                _functionContext.GetBindings().InvocationResult = value;
-            }
-        }
     }
 
     /// <summary>
     /// A type wrapping the result of a function invocation.
     /// </summary>
-    public sealed class InvocationResult : InvocationResult<object>
+    /// <typeparam name="T">The type of invocation result value.</typeparam>
+    public abstract class InvocationResult<T>
     {
-        internal InvocationResult(FunctionContext functionContext, object? value) : base(functionContext, value)
-        {
-        }
+        /// <summary>
+        /// Gets or sets the invocation result value.
+        /// </summary>
+        public abstract T? Value { get; set; }
     }
 }

--- a/src/DotNetWorker.Core/OutputBindings/DefaultInputBindingData.cs
+++ b/src/DotNetWorker.Core/OutputBindings/DefaultInputBindingData.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Converters;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// A type representing the input binding data.
+    /// </summary>
+    /// <typeparam name="T">The type of binding data value.</typeparam>
+    internal class DefaultInputBindingData<T> : InputBindingData<T>
+    {
+        private readonly IBindingCache<ConversionResult> _bindingCache;
+        private T? _value;
+        
+        internal DefaultInputBindingData(IBindingCache<ConversionResult> bindingCache, BindingMetadata bindingMetadata, T? value)
+        {
+            _bindingCache = bindingCache;
+            BindingMetadata = bindingMetadata;
+            _value = value;
+            
+        }
+
+        /// <summary>
+        /// Gets the binding metadata part of this input binding data instance.
+        /// </summary>
+        public override BindingMetadata BindingMetadata { get; }
+
+        /// <summary>
+        /// Gets or sets the value of the binding result.
+        /// </summary>
+        public override T? Value
+        {
+            
+            get => _value;
+            set
+            {
+                _value = value;
+                _bindingCache[BindingMetadata.Name] = ConversionResult.Success(value);
+            }
+        }
+    }
+}

--- a/src/DotNetWorker.Core/OutputBindings/DefaultOutputBindingData.cs
+++ b/src/DotNetWorker.Core/OutputBindings/DefaultOutputBindingData.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    internal sealed class DefaultOutputBindingData<T> : OutputBindingData<T>
+    {
+        private readonly FunctionContext _functionContext;
+        private T? _value;
+
+        internal DefaultOutputBindingData(FunctionContext functionContext, string name, T? value, string bindingType)
+        {
+            _functionContext = functionContext;
+            _value = value;
+            Name = name;
+            BindingType = bindingType;
+        }
+
+        public override string BindingType { get; }
+
+        public override string Name { get; }
+
+        public override T? Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _functionContext.GetBindings().OutputBindingData[Name] = value;
+            }
+        }
+    }
+}

--- a/src/DotNetWorker.Core/OutputBindings/InputBindingData.cs
+++ b/src/DotNetWorker.Core/OutputBindings/InputBindingData.cs
@@ -1,42 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Functions.Worker.Converters;
-
 namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
     /// A type representing the input binding data.
     /// </summary>
     /// <typeparam name="T">The type of binding data value.</typeparam>
-    public sealed class InputBindingData<T>
+    public abstract class InputBindingData<T>
     {
-        private readonly IBindingCache<ConversionResult> _bindingCache;
-        private T? _value;
-
-        internal InputBindingData(IBindingCache<ConversionResult> bindingCache, BindingMetadata bindingMetadata, T? value)
-        {
-            _bindingCache = bindingCache;
-            BindingMetadata = bindingMetadata;
-            _value = value;
-        }
-
         /// <summary>
         /// Gets the binding metadata part of this input binding data instance.
         /// </summary>
-        public BindingMetadata BindingMetadata { get; }
-
+        public abstract BindingMetadata BindingMetadata { get; }
+        
         /// <summary>
         /// Gets or sets the value of the binding result.
         /// </summary>
-        public T? Value
-        {
-            get => _value;
-            set
-            {
-                _value = value;
-                _bindingCache[BindingMetadata.Name] = ConversionResult.Success(value);
-            }
-        }
+        public abstract T? Value { get; set; }
     }
 }

--- a/src/DotNetWorker.Core/OutputBindings/InputBindingData.cs
+++ b/src/DotNetWorker.Core/OutputBindings/InputBindingData.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Converters;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// A type representing the input binding data.
+    /// </summary>
+    /// <typeparam name="T">The type of binding data value.</typeparam>
+    public sealed class InputBindingData<T>
+    {
+        private readonly IBindingCache<ConversionResult> _bindingCache;
+        private T? _value;
+
+        internal InputBindingData(IBindingCache<ConversionResult> bindingCache, BindingMetadata bindingMetadata, T? value)
+        {
+            _bindingCache = bindingCache;
+            BindingMetadata = bindingMetadata;
+            _value = value;
+        }
+
+        /// <summary>
+        /// Gets the binding metadata part of this input binding data instance.
+        /// </summary>
+        public BindingMetadata BindingMetadata { get; }
+
+        /// <summary>
+        /// Gets or sets the value of the binding result.
+        /// </summary>
+        public T? Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _bindingCache[BindingMetadata.Name] = ConversionResult.Success(value);
+            }
+        }
+    }
+}

--- a/src/DotNetWorker.Core/OutputBindings/OutputBindingData.cs
+++ b/src/DotNetWorker.Core/OutputBindings/OutputBindingData.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// A type representing the output binding data.
+    /// </summary>
+    public sealed class OutputBindingData
+    {
+        internal OutputBindingData(FunctionContext functionContext, string name, object? value, string bindingType)
+        {
+            _functionContext = functionContext;
+            _value = value;
+            Name = name;
+            BindingType = bindingType;
+        }
+
+        private readonly FunctionContext _functionContext;
+        private object? _value;
+
+        /// <summary>
+        /// Gets the name of the binding entry.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets or sets the value of the binding entry.
+        /// </summary>
+        public object? Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _functionContext.GetBindings().OutputBindingData[Name] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the type of the binding entry.
+        /// Ex: "http","queue" etc.
+        /// </summary>
+        public string BindingType { get; }
+    }
+}

--- a/src/DotNetWorker.Core/OutputBindings/OutputBindingData.cs
+++ b/src/DotNetWorker.Core/OutputBindings/OutputBindingData.cs
@@ -4,11 +4,11 @@
 namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
-    /// A type representing the output binding data.
+    /// A type representing an output binding entry.
     /// </summary>
-    public sealed class OutputBindingData
+    public sealed class OutputBindingData<T>
     {
-        internal OutputBindingData(FunctionContext functionContext, string name, object? value, string bindingType)
+        internal OutputBindingData(FunctionContext functionContext, string name, T? value, string bindingType)
         {
             _functionContext = functionContext;
             _value = value;
@@ -17,17 +17,17 @@ namespace Microsoft.Azure.Functions.Worker
         }
 
         private readonly FunctionContext _functionContext;
-        private object? _value;
+        private T? _value;
 
         /// <summary>
-        /// Gets the name of the binding entry.
+        /// Gets the name of the output binding entry.
         /// </summary>
         public string Name { get; }
 
         /// <summary>
-        /// Gets or sets the value of the binding entry.
+        /// Gets or sets the value of the output binding entry.
         /// </summary>
-        public object? Value
+        public T? Value
         {
             get => _value;
             set

--- a/src/DotNetWorker.Core/OutputBindings/OutputBindingData.cs
+++ b/src/DotNetWorker.Core/OutputBindings/OutputBindingData.cs
@@ -6,41 +6,22 @@ namespace Microsoft.Azure.Functions.Worker
     /// <summary>
     /// A type representing an output binding entry.
     /// </summary>
-    public sealed class OutputBindingData<T>
+    public abstract class OutputBindingData<T>
     {
-        private readonly FunctionContext _functionContext;
-        private T? _value;
-
-        internal OutputBindingData(FunctionContext functionContext, string name, T? value, string bindingType)
-        {
-            _functionContext = functionContext;
-            _value = value;
-            Name = name;
-            BindingType = bindingType;
-        }
-
-        /// <summary>
-        /// Gets the name of the output binding entry.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Gets or sets the value of the output binding entry.
-        /// </summary>
-        public T? Value
-        {
-            get => _value;
-            set
-            {
-                _value = value;
-                _functionContext.GetBindings().OutputBindingData[Name] = value;
-            }
-        }
-
         /// <summary>
         /// Gets the type of the binding entry.
         /// Ex: "http","queue" etc.
         /// </summary>
-        public string BindingType { get; }
+        public abstract string BindingType { get; }
+
+        /// <summary>
+        /// Gets the name of the output binding entry.
+        /// </summary>
+        public abstract string Name { get; }
+
+        /// <summary>
+        /// Gets or sets the value of the output binding entry.
+        /// </summary>
+        public abstract T? Value { get; set; }
     }
 }

--- a/src/DotNetWorker.Core/OutputBindings/OutputBindingData.cs
+++ b/src/DotNetWorker.Core/OutputBindings/OutputBindingData.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Functions.Worker
     /// </summary>
     public sealed class OutputBindingData<T>
     {
+        private readonly FunctionContext _functionContext;
+        private T? _value;
+
         internal OutputBindingData(FunctionContext functionContext, string name, T? value, string bindingType)
         {
             _functionContext = functionContext;
@@ -15,9 +18,6 @@ namespace Microsoft.Azure.Functions.Worker
             Name = name;
             BindingType = bindingType;
         }
-
-        private readonly FunctionContext _functionContext;
-        private T? _value;
 
         /// <summary>
         /// Gets the name of the output binding entry.

--- a/src/DotNetWorker.Grpc/Definition/GrpcBindingMetadata.cs
+++ b/src/DotNetWorker.Grpc/Definition/GrpcBindingMetadata.cs
@@ -7,11 +7,14 @@ namespace Microsoft.Azure.Functions.Worker
 {
     internal class GrpcBindingMetadata : BindingMetadata
     {
-        public GrpcBindingMetadata(BindingInfo bindingInfo)
+        public GrpcBindingMetadata(string name, BindingInfo bindingInfo)
         {
+            Name = name;
             Type = bindingInfo.Type;
             Direction = bindingInfo.Direction == BindingInfo.Types.Direction.In ? BindingDirection.In : BindingDirection.Out;
         }
+
+        public override string Name { get; }
 
         public override string Type { get; }
 

--- a/src/DotNetWorker.Grpc/Definition/GrpcFunctionDefinition.cs
+++ b/src/DotNetWorker.Grpc/Definition/GrpcFunctionDefinition.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Functions.Worker.Definition
             var grpcBindingsGroup = loadRequest.Metadata.Bindings.GroupBy(kv => kv.Value.Direction);
             var grpcInputBindings = grpcBindingsGroup.Where(kv => kv.Key == BindingInfo.Types.Direction.In).FirstOrDefault();
             var grpcOutputBindings = grpcBindingsGroup.Where(kv => kv.Key != BindingInfo.Types.Direction.In).FirstOrDefault();
-            var infoToMetadataLambda = new Func<KeyValuePair<string, BindingInfo>, BindingMetadata>(kv => new GrpcBindingMetadata(kv.Value));
+            var infoToMetadataLambda = new Func<KeyValuePair<string, BindingInfo>, BindingMetadata>(kv => new GrpcBindingMetadata(kv.Key, kv.Value));
 
             InputBindings = grpcInputBindings?.ToImmutableDictionary(kv => kv.Key, infoToMetadataLambda)
                 ?? ImmutableDictionary<string, BindingMetadata>.Empty;

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -8,8 +8,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>7</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
+    <MinorProductVersion>8</MinorProductVersion>
     <VersionSuffix>-preview1</VersionSuffix>
   </PropertyGroup>
 

--- a/test/DotNetWorkerTests/Features/DefaultInputConversionFeatureTests.cs
+++ b/test/DotNetWorkerTests/Features/DefaultInputConversionFeatureTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests.Features
                 p => Assert.True(p.Id == "1" && p.Author == "a"),
                 p => Assert.True(p.Id == "2" && p.Author == "c"),
                 p => Assert.True(p.Id == "3" && p.Author == "e"));
-        }        
+        }
 
         [Fact]
         public async Task Convert_Using_Default_Converters_Guid()
@@ -89,26 +89,6 @@ namespace Microsoft.Azure.Functions.Worker.Tests.Features
             Assert.Equal(ConversionStatus.Succeeded, actual.Status);
             var customer = TestUtility.AssertIsTypeAndConvert<Customer>(actual.Value);
             Assert.Equal("16-converted customer", customer.Name);
-        }
-
-        [Fact]
-        public async Task ConvertAsync_Returns_Cached_Results_When_Called_MoreThanOnce()
-        {
-            var source =@"{ ""id"": ""1"", ""title"": ""bar"" }";
-
-            var converterContext1 = CreateConverterContext(typeof(Book), source);
-            var actual1 = await _defaultInputConversionFeature.ConvertAsync(converterContext1);
-
-            // Call ConvertAsync again using a new ConverterContext instance, but with same source data and target type
-            var converterContext2 = CreateConverterContext(typeof(Book), source);
-            var actual2 = await _defaultInputConversionFeature.ConvertAsync(converterContext2);
-
-            var book1 = TestUtility.AssertIsTypeAndConvert<Book>(actual1.Value);
-            var book2 = TestUtility.AssertIsTypeAndConvert<Book>(actual2.Value);
-
-            Assert.Same(book1,book2);
-            Assert.Equal(ConversionStatus.Succeeded, actual1.Status);
-            Assert.Equal(ConversionStatus.Succeeded, actual2.Status);
         }
 
         [InputConverter(typeof(MyCustomerAsyncInputConverter))]

--- a/test/DotNetWorkerTests/Features/DefaultInputConversionFeatureTests.cs
+++ b/test/DotNetWorkerTests/Features/DefaultInputConversionFeatureTests.cs
@@ -91,6 +91,26 @@ namespace Microsoft.Azure.Functions.Worker.Tests.Features
             Assert.Equal("16-converted customer", customer.Name);
         }
 
+        [Fact]
+        public async Task ConvertAsync_Returns_Cached_Results_When_Called_MoreThanOnce()
+        {
+            var source =@"{ ""id"": ""1"", ""title"": ""bar"" }";
+
+            var converterContext1 = CreateConverterContext(typeof(Book), source);
+            var actual1 = await _defaultInputConversionFeature.ConvertAsync(converterContext1);
+
+            // Call ConvertAsync again using a new ConverterContext instance, but with same source data and target type
+            var converterContext2 = CreateConverterContext(typeof(Book), source);
+            var actual2 = await _defaultInputConversionFeature.ConvertAsync(converterContext2);
+
+            var book1 = TestUtility.AssertIsTypeAndConvert<Book>(actual1.Value);
+            var book2 = TestUtility.AssertIsTypeAndConvert<Book>(actual2.Value);
+
+            Assert.Same(book1,book2);
+            Assert.Equal(ConversionStatus.Succeeded, actual1.Status);
+            Assert.Equal(ConversionStatus.Succeeded, actual2.Status);
+        }
+
         [InputConverter(typeof(MyCustomerAsyncInputConverter))]
         internal record Customer(string Id, string Name);
 

--- a/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
+++ b/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Context.Features;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Grpc.Messages;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.Functions.Worker.Tests.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests
+{
+    public class FunctionContextExtensionTests
+    {
+        DefaultFunctionContext _defaultFunctionContext;
+        IServiceScopeFactory _serviceScopeFactory;
+        IServiceProvider _serviceProvider;
+        InvocationFeatures features;
+
+        public FunctionContextExtensionTests()
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IConverterContextFactory, DefaultConverterContextFactory>();
+
+            _serviceProvider = serviceCollection.BuildServiceProvider();
+            _serviceScopeFactory = _serviceProvider.GetService<IServiceScopeFactory>();
+
+            features = new InvocationFeatures(Enumerable.Empty<IInvocationFeatureProvider>());
+
+            var invocation = new Mock<FunctionInvocation>(MockBehavior.Strict).Object;
+            features.Set<FunctionInvocation>(invocation);
+        }
+
+        [Fact]
+        public async Task BindInputAsyncWorks_Type()
+        {
+            // Arrange
+            var definition = new TestFunctionDefinition(parameters: new FunctionParameter[]
+            {
+                new FunctionParameter("req", typeof(HttpRequestData))
+            });
+            features.Set<FunctionDefinition>(definition);
+
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, features);
+            var grpcHttpReq = new GrpcHttpRequestData(CreateRpcHttp(), _defaultFunctionContext);
+            var functionBindings = new TestFunctionBindingsFeature
+            {
+                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "req", grpcHttpReq } })
+            };
+            features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Mock input conversion feature to return a successfully converted value.
+            var conversionFeature = new Mock<IInputConversionFeature>(MockBehavior.Strict);
+            conversionFeature.Setup(a => a.ConvertAsync(It.IsAny<ConverterContext>())).ReturnsAsync(ConversionResult.Success(grpcHttpReq));
+            features.Set<IInputConversionFeature>(conversionFeature.Object);
+
+            // Act
+            var actual = await _defaultFunctionContext.BindInputAsync<HttpRequestData>();
+            var actual2 = await _defaultFunctionContext.BindInputAsync<Book>();
+
+            // Assert
+            var httpReqData = TestUtility.AssertIsTypeAndConvert<HttpRequestData>(actual);
+            Assert.NotNull(httpReqData);
+            Assert.Null(actual2);
+        }
+
+        [Fact]
+        public async Task BindInputAsyncWorks_ExplicitParameter()
+        {
+            // Arrange
+            var definition = new TestFunctionDefinition(parameters: new FunctionParameter[]
+            {
+                new FunctionParameter("req", typeof(HttpRequestData)),
+                new FunctionParameter("productId", typeof(string)),
+                new FunctionParameter("categoryId", typeof(string))
+            });
+            features.Set<FunctionDefinition>(definition);
+
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, features);
+            var grpcHttpReq = new GrpcHttpRequestData(CreateRpcHttp(), _defaultFunctionContext);
+            var functionBindings = new TestFunctionBindingsFeature
+            {
+                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "req", grpcHttpReq } }),
+                TriggerMetadata = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "categoryId", "1" } })
+            };
+            features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Mock input conversion feature to return a successfully converted value.
+            var conversionFeature = new Mock<IInputConversionFeature>(MockBehavior.Strict);
+            conversionFeature.Setup(a => a.ConvertAsync(It.IsAny<ConverterContext>())).ReturnsAsync(ConversionResult.Success("1"));
+            features.Set<IInputConversionFeature>(conversionFeature.Object);
+
+            // Act
+            var categoryIdParam = _defaultFunctionContext.FunctionDefinition.Parameters.First(a => a.Name == "categoryId");
+            var actual = await _defaultFunctionContext.BindInputAsync<string>(categoryIdParam);
+
+            // Assert
+            var categoryIdValue = TestUtility.AssertIsTypeAndConvert<string>(actual);
+            Assert.Equal("1", categoryIdValue);
+        }
+
+        private RpcHttp CreateRpcHttp()
+        {
+            var rpcHttp = new RpcHttp
+            {
+                Url = "https://m.sn",
+                Method = "GET"
+            };
+            rpcHttp.Headers.Add("foo", "b");
+
+            return rpcHttp;
+        }
+    }
+}

--- a/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
+++ b/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.Converters;
@@ -23,60 +24,28 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         DefaultFunctionContext _defaultFunctionContext;
         IServiceScopeFactory _serviceScopeFactory;
         IServiceProvider _serviceProvider;
-        InvocationFeatures features;
+        InvocationFeatures _features;
 
         public FunctionContextExtensionTests()
         {
             IServiceCollection serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton<IConverterContextFactory, DefaultConverterContextFactory>();
+            serviceCollection.AddSingleton<IBindingCache<ConversionResult>, DefaultBindingCache<ConversionResult>>();
 
             _serviceProvider = serviceCollection.BuildServiceProvider();
             _serviceScopeFactory = _serviceProvider.GetService<IServiceScopeFactory>();
 
-            features = new InvocationFeatures(Enumerable.Empty<IInvocationFeatureProvider>());
+            _features = new InvocationFeatures(Enumerable.Empty<IInvocationFeatureProvider>());
 
             var invocation = new Mock<FunctionInvocation>(MockBehavior.Strict).Object;
-            features.Set<FunctionInvocation>(invocation);
+            _features.Set<FunctionInvocation>(invocation);
         }
 
         [Fact]
-        public async Task BindInputAsyncWorks_Type()
+        public async Task BindInputAsyncWorks()
         {
             // Arrange
-            var definition = new TestFunctionDefinition(parameters: new FunctionParameter[]
-            {
-                new FunctionParameter("req", typeof(HttpRequestData))
-            });
-            features.Set<FunctionDefinition>(definition);
-
-            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, features);
-            var grpcHttpReq = new GrpcHttpRequestData(CreateRpcHttp(), _defaultFunctionContext);
-            var functionBindings = new TestFunctionBindingsFeature
-            {
-                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "req", grpcHttpReq } })
-            };
-            features.Set<IFunctionBindingsFeature>(functionBindings);
-
-            // Mock input conversion feature to return a successfully converted value.
-            var conversionFeature = new Mock<IInputConversionFeature>(MockBehavior.Strict);
-            conversionFeature.Setup(a => a.ConvertAsync(It.IsAny<ConverterContext>())).ReturnsAsync(ConversionResult.Success(grpcHttpReq));
-            features.Set<IInputConversionFeature>(conversionFeature.Object);
-
-            // Act
-            var actual = await _defaultFunctionContext.BindInputAsync<HttpRequestData>();
-            var actual2 = await _defaultFunctionContext.BindInputAsync<Book>();
-
-            // Assert
-            var httpReqData = TestUtility.AssertIsTypeAndConvert<HttpRequestData>(actual);
-            Assert.NotNull(httpReqData);
-            Assert.Null(actual2);
-        }
-
-        [Fact]
-        public async Task BindInputAsyncWorks_ExplicitBindingMetadata()
-        {
-            // Arrange
-            var definition = new TestFunctionDefinition(parameters: new FunctionParameter[]
+            var qTriggerFunctionDefinition = new TestFunctionDefinition(parameters: new FunctionParameter[]
                                     {
                                         new FunctionParameter("myBook", typeof(string)),
                                         new FunctionParameter("blob1", typeof(Book)),
@@ -84,50 +53,122 @@ namespace Microsoft.Azure.Functions.Worker.Tests
                                     },
                                     inputBindings: new Dictionary<string, BindingMetadata>
                                     {
-                                        { "myBook", new TestBindingMetadata("queueTrigger","myBook",BindingDirection.In) },
+                                        { "myBook", new TestBindingMetadata("myBook","queueTrigger",BindingDirection.In) },
                                         { "blob1", new TestBindingMetadata("blob1","blob",BindingDirection.In) },
                                         { "blob2", new TestBindingMetadata("blob2","blob",BindingDirection.In) }
                                     });
-            features.Set<FunctionDefinition>(definition);
+            _features.Set<FunctionDefinition>(qTriggerFunctionDefinition);
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
 
-            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, features);
             var functionBindings = new TestFunctionBindingsFeature
             {
-                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> {
-                    { "myBook", "book1" },
-                    { "blob1", JsonConvert.SerializeObject(new Book { Title="b1"}) },
-                    { "blob2", JsonConvert.SerializeObject(new Book { Title="b2"}) }
+                InputData = new ReadOnlyDictionary<string, object>(
+                    new Dictionary<string, object> {
+                            { "myBook", "book1" },
+                            { "blob1", JsonConvert.SerializeObject(new Book { Title="b1"}) },
+                            { "blob2", JsonConvert.SerializeObject(new Book { Title="b2"}) }
                     })
             };
-            features.Set<IFunctionBindingsFeature>(functionBindings);
+            _features.Set<IFunctionBindingsFeature>(functionBindings);
 
-            // Mock input conversion feature to return a successfully converted value.
+            // Mock input conversion feature to return a successfully converted value for blob2 input data.
             var conversionFeature = new Mock<IInputConversionFeature>(MockBehavior.Strict);
             conversionFeature.Setup(a => a.ConvertAsync(It.Is<ConverterContext>(ctx => ctx.Source.ToString().Contains("b2"))))
                              .ReturnsAsync(ConversionResult.Success(new Book { Id = "book 2" }));
-
-            features.Set<IInputConversionFeature>(conversionFeature.Object);
+            _features.Set<IInputConversionFeature>(conversionFeature.Object);
 
             // Act
             // bind to the second blob input binding(blob2).
             var blob2InputBinding = _defaultFunctionContext.FunctionDefinition.InputBindings.Values.First(a => a.Name == "blob2");
-            var actual = await _defaultFunctionContext.BindInputAsync<Book>(blob2InputBinding);
+            var book = await _defaultFunctionContext.BindInputAsync<Book>(blob2InputBinding);
 
             // Assert
-            var book = TestUtility.AssertIsTypeAndConvert<Book>(actual);
             Assert.Equal("book 2", book.Id);
+            book.Id = "updated Id value";
+
+            // Make a second call,requesting the result as Object.
+            var bookAsObject = await _defaultFunctionContext.BindInputAsync<object>(blob2InputBinding);
+            var book2 = TestUtility.AssertIsTypeAndConvert<Book>(bookAsObject);
+            Assert.Equal("updated Id value", book2.Id);
         }
 
-        private RpcHttp CreateRpcHttp()
+        [Fact]
+        public void GetInvocationResult_Works()
         {
-            var rpcHttp = new RpcHttp
+            // Arrange
+            var qTriggerFunctionDefinition = new TestFunctionDefinition(parameters: new FunctionParameter[]
             {
-                Url = "https://m.sn",
-                Method = "GET"
-            };
-            rpcHttp.Headers.Add("foo", "b");
+                new FunctionParameter("myQueueItem", typeof(string))
+            },
+            inputBindings: new Dictionary<string, BindingMetadata>
+            {
+                { "myQueueItem", new TestBindingMetadata("myQueueItem","queueTrigger",BindingDirection.In) }
+            });
+            _features.Set<FunctionDefinition>(qTriggerFunctionDefinition);
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
 
-            return rpcHttp;
+            var functionBindings = new TestFunctionBindingsFeature
+            {
+                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "myQueueItem", "bar" } }),
+                InvocationResult = new Book { Id = "value set from within the function" }
+            };
+            _features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Act
+            InvocationResult<Book> actual1 = _defaultFunctionContext.GetInvocationResult<Book>();
+            var book1 = TestUtility.AssertIsTypeAndConvert<Book>(actual1.Value);
+
+            // Also, try the other overload which does not return the result as requested type T.
+            InvocationResult actual2 = _defaultFunctionContext.GetInvocationResult();
+            var book2 = TestUtility.AssertIsTypeAndConvert<Book>(actual2.Value);
+
+            // Assert
+            Assert.NotNull(book1);
+            Assert.Equal("value set from within the function", book1.Id);
+            Assert.Same(book1, book2);
+
+            // Update the value, call GetInvocationResult again and verify changes.
+            book1.Id = "updated value from first middleware";
+            var actual3 = _defaultFunctionContext.GetInvocationResult();
+            var book3 = TestUtility.AssertIsTypeAndConvert<Book>(actual3.Value);
+            Assert.Equal("updated value from first middleware", book3.Id);
+            Assert.Same(book1, book3);
+        }
+
+        [Fact]
+        public void GetOutputBindingData_Works()
+        {
+            // Arrange
+            var functionDefinition = new TestFunctionDefinition(
+            outputBindings: new Dictionary<string, BindingMetadata>
+            {
+                { "Name", new TestBindingMetadata("Name","queue",BindingDirection.Out) },
+                { "HttpResponse", new TestBindingMetadata("HttpResponse","http",BindingDirection.Out) }
+            });
+            _features.Set<FunctionDefinition>(functionDefinition);
+
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
+
+            var functionBindings = new TestFunctionBindingsFeature();
+            functionBindings.OutputBindingData.Add("HttpResponse", new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.OK));
+            functionBindings.OutputBindingData.Add("Name", "some name");
+            _features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Act
+            OutputBindingData<HttpResponseData> actual1 = _defaultFunctionContext.GetOutputBindings<HttpResponseData>()
+                .First(a => a.BindingType == "http");
+
+            // Assert
+            Assert.NotNull(actual1.Value);
+            Assert.Same(actual1.Value, actual1.Value);
+
+            // Also verify we can do other typical operations like adding a response header.
+            actual1.Value.Headers.Add("X-Foo-Id", "bar");
+
+            // Get again and verify previous changes(Adding header) are reflected.
+            var actual2 = _defaultFunctionContext.GetOutputBindings<object>().First(a => a.BindingType == "http");
+            var httpResponse = TestUtility.AssertIsTypeAndConvert<HttpResponseData>(actual2.Value);
+            Assert.Equal("bar", httpResponse.Headers.First(a => a.Key == "X-Foo-Id").Value.First());
         }
     }
 }

--- a/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
+++ b/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
@@ -80,16 +80,22 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             // Act
             // bind to the second blob input binding(blob2).
             var blob2InputBinding = _defaultFunctionContext.FunctionDefinition.InputBindings.Values.First(a => a.Name == "blob2");
-            var book = await _defaultFunctionContext.BindInputAsync<Book>(blob2InputBinding);
+            var book = (await _defaultFunctionContext.BindInputAsync<Book>(blob2InputBinding)).Value;
 
             // Assert
             Assert.Equal("book 2", book.Id);
             book.Id = "updated Id value";
 
             // Make a second call,requesting the result as Object.
-            var bookAsObject = await _defaultFunctionContext.BindInputAsync<object>(blob2InputBinding);
-            var book2 = TestUtility.AssertIsTypeAndConvert<Book>(bookAsObject);
+            var bindingResult = await _defaultFunctionContext.BindInputAsync<object>(blob2InputBinding);
+            var book2 = TestUtility.AssertIsTypeAndConvert<Book>(bindingResult.Value);
             Assert.Equal("updated Id value", book2.Id);
+
+            // Replace the entire result of binding with a different object.
+            bindingResult.Value = new Book() {  Id ="book 3"};
+            var book3 = (await _defaultFunctionContext.BindInputAsync<Book>(blob2InputBinding)).Value;
+            Assert.NotSame(book3, book2);
+            Assert.Equal("book 3", book3.Id);
         }
 
         [Fact]

--- a/test/DotNetWorkerTests/FunctionContextHttpExtensionTests.cs
+++ b/test/DotNetWorkerTests/FunctionContextHttpExtensionTests.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Context.Features;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Grpc.Messages;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.Functions.Worker.Tests.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests
+{
+    public class FunctionContextHttpExtensionTests
+    {
+        DefaultFunctionContext _defaultFunctionContext;
+        IServiceScopeFactory _serviceScopeFactory;
+        IServiceProvider _serviceProvider;
+        InvocationFeatures _features;
+        Mock<IInputConversionFeature> _mockConversionFeature;
+
+        public FunctionContextHttpExtensionTests()
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IConverterContextFactory, DefaultConverterContextFactory>();
+            serviceCollection.AddSingleton<IBindingCache<ConversionResult>, DefaultBindingCache<ConversionResult>>();
+
+            _serviceProvider = serviceCollection.BuildServiceProvider();
+            _serviceScopeFactory = _serviceProvider.GetService<IServiceScopeFactory>();
+
+            _features = new InvocationFeatures(Enumerable.Empty<IInvocationFeatureProvider>());
+            _features.Set(new Mock<FunctionInvocation>(MockBehavior.Strict).Object);
+
+            _mockConversionFeature = new Mock<IInputConversionFeature>(MockBehavior.Strict);
+        }
+
+        [Fact]
+        public async Task GetHttpRequestDataAsync_Returns_Null_For_NonHttp_Invocation()
+        {
+            // Arrange
+            var qTriggerFunctionDefinition = new TestFunctionDefinition(parameters: new FunctionParameter[]
+            {
+                new FunctionParameter("myQueueItem", typeof(string))
+            },
+            inputBindings: new Dictionary<string, BindingMetadata>
+            {
+                { "myQueueItem", new TestBindingMetadata("myQueueItem","queueTrigger",BindingDirection.In) }
+            });
+            _features.Set<FunctionDefinition>(qTriggerFunctionDefinition);
+
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
+            var functionBindings = new TestFunctionBindingsFeature
+            {
+                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "myQueueItem", "foo" } })
+            };
+            _features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Act
+            var actual = await _defaultFunctionContext.GetHttpRequestDataAsync();
+
+            // Assert
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public async Task GetHttpRequestDataAsync_Works_For_Http_Invocation()
+        {
+            // Arrange
+            var httpFunctionDefinition = new TestFunctionDefinition(parameters: new FunctionParameter[]
+            {
+                new FunctionParameter("req", typeof(HttpRequestData))
+            },
+            inputBindings: new Dictionary<string, BindingMetadata>
+            {
+                { "req", new TestBindingMetadata("req","httpTrigger",BindingDirection.In) }
+            });
+            _features.Set<FunctionDefinition>(httpFunctionDefinition);
+
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
+            var grpcHttpReq = new GrpcHttpRequestData(CreateRpcHttp(), _defaultFunctionContext);
+            var functionBindings = new TestFunctionBindingsFeature
+            {
+                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "req", grpcHttpReq } })
+            };
+            _features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Mock input conversion feature to return a successfully converted HttpRequestData value.           
+            _mockConversionFeature.Setup(a => a.ConvertAsync(It.IsAny<ConverterContext>()))
+                                  .ReturnsAsync(ConversionResult.Success(grpcHttpReq));
+            _features.Set<IInputConversionFeature>(_mockConversionFeature.Object);
+
+            // Act
+            var actual1 = await _defaultFunctionContext.GetHttpRequestDataAsync();
+            var actual2 = await _defaultFunctionContext.GetHttpRequestDataAsync();
+
+            // Assert
+            Assert.NotNull(actual1);
+            Assert.NotNull(actual1.Url);
+            Assert.Equal(new [] { "gzip", "deflate" }, actual1.Headers.First(a => a.Key == "Accept-Encoding").Value);
+            Assert.Equal("light", actual1.Cookies.First(x => x.Name == "theme").Value);
+
+            // Calling "GetHttpRequestDataAsync" again should return same object(cached value).
+            Assert.Same(actual1, actual2);
+        }
+
+        [Fact]
+        public void GetHttpResponseData_Works_For_Http_Invocation()
+        {
+            // Arrange
+            _features.Set<FunctionDefinition>(new TestFunctionDefinition());
+
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
+            var grpcHttpReq = new GrpcHttpRequestData(CreateRpcHttp(), _defaultFunctionContext);
+            var functionBindings = new TestFunctionBindingsFeature
+            {
+                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "req", grpcHttpReq } }),
+                InvocationResult = new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.OK)
+            };
+            _features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Act
+            HttpResponseData actual = _defaultFunctionContext.GetHttpResponseData();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
+
+            // Also verify we can do other typical operations like adding a response header.
+            actual.Headers.Add("X-Foo-Id", "bar");
+
+            // Call the GetHttpResponseData method again and verify.
+            HttpResponseData actual2 = _defaultFunctionContext.GetHttpResponseData();
+            Assert.True(actual2.Headers.First(a=>a.Key== "X-Foo-Id").Value.Any());
+        }
+
+        [Fact]
+        public void GetHttpResponseData_Works_For_Http_Invocation_POCO_OutputBinding_Properties()
+        {
+            // Arrange
+            _features.Set<FunctionDefinition>(new TestFunctionDefinition());
+
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
+            var grpcHttpReq = new GrpcHttpRequestData(CreateRpcHttp(), _defaultFunctionContext);
+            var functionBindings = new TestFunctionBindingsFeature
+            {
+                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "req", grpcHttpReq } })
+            };
+            
+            // Set the outputbinding data of the function invocation.
+            // In the normal(non unit test) run of the worker, this values will be set by our execution middleware pipeline.
+            functionBindings.OutputBindingData.Add("MyHttpResponse", new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.OK));
+            functionBindings.OutputBindingData.Add("MyName", "foo");
+            _features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Act
+            HttpResponseData actual = _defaultFunctionContext.GetHttpResponseData();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
+
+            // Also verify we can do other typical operations like adding a response header.
+            actual.Headers.Add("X-Foo-Id", "bar");
+
+            // Call the GetHttpResponseData method again and verify.
+            HttpResponseData actual2 = _defaultFunctionContext.GetHttpResponseData();
+            Assert.True(actual2.Headers.First(a => a.Key == "X-Foo-Id").Value.Any());
+        }
+
+        private RpcHttp CreateRpcHttp()
+        {
+            var rpcHttp = new RpcHttp
+            {
+                Url = "https://m.sn"
+            };
+            rpcHttp.NullableHeaders["Accept-Encoding"] = new NullableString() { Value = "gzip, deflate" };
+            rpcHttp.NullableHeaders["Cookie"] = new NullableString() { Value = "theme=light; x-token=foo" };
+
+            return rpcHttp;
+        }
+    }
+}

--- a/test/DotNetWorkerTests/FunctionContextHttpExtensionTests.cs
+++ b/test/DotNetWorkerTests/FunctionContextHttpExtensionTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             // Assert
             Assert.NotNull(actual1);
             Assert.NotNull(actual1.Url);
-            Assert.Equal(new [] { "gzip", "deflate" }, actual1.Headers.First(a => a.Key == "Accept-Encoding").Value);
+            Assert.Equal(new[] { "gzip", "deflate" }, actual1.Headers.First(a => a.Key == "Accept-Encoding").Value);
             Assert.Equal("light", actual1.Cookies.First(x => x.Name == "theme").Value);
 
             // Calling "GetHttpRequestDataAsync" again should return same object(cached value).
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
             // Call the GetHttpResponseData method again and verify.
             HttpResponseData actual2 = _defaultFunctionContext.GetHttpResponseData();
-            Assert.True(actual2.Headers.First(a=>a.Key== "X-Foo-Id").Value.Any());
+            Assert.True(actual2.Headers.First(a => a.Key == "X-Foo-Id").Value.Any());
         }
 
         [Fact]
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             {
                 InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "req", grpcHttpReq } })
             };
-            
+
             // Set the outputbinding data of the function invocation.
             // In the normal(non unit test) run of the worker, this values will be set by our execution middleware pipeline.
             functionBindings.OutputBindingData.Add("MyHttpResponse", new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.OK));

--- a/test/DotNetWorkerTests/OutputBindings/OutputBindingsMiddlewareTests.cs
+++ b/test/DotNetWorkerTests/OutputBindings/OutputBindingsMiddlewareTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests.OutputBindings
 
             foreach (string bindingName in outputBindings)
             {
-                testOutputBindings[bindingName] = new TestBindingMetadata($"SomeOutput{bindingName}", BindingDirection.Out);
+                testOutputBindings[bindingName] = new TestBindingMetadata("foo",$"SomeOutput{bindingName}", BindingDirection.Out);
             }
 
             var definition = new TestFunctionDefinition(outputBindings: testOutputBindings);

--- a/test/DotNetWorkerTests/OutputBindings/OutputBindingsMiddlewareTests.cs
+++ b/test/DotNetWorkerTests/OutputBindings/OutputBindingsMiddlewareTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests.OutputBindings
 
             foreach (string bindingName in outputBindings)
             {
-                testOutputBindings[bindingName] = new TestBindingMetadata("foo",$"SomeOutput{bindingName}", BindingDirection.Out);
+                testOutputBindings[bindingName] = new TestBindingMetadata("foo", $"SomeOutput{bindingName}", BindingDirection.Out);
             }
 
             var definition = new TestFunctionDefinition(outputBindings: testOutputBindings);

--- a/test/DotNetWorkerTests/TestBindingMetadata.cs
+++ b/test/DotNetWorkerTests/TestBindingMetadata.cs
@@ -5,11 +5,14 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 {
     public class TestBindingMetadata : BindingMetadata
     {
-        public TestBindingMetadata(string type, BindingDirection direction)
+        public TestBindingMetadata(string name, string type, BindingDirection direction)
         {
+            Name = name;
             Type = type;
             Direction = direction;
         }
+
+        public override string Name { get; }
 
         public override string Type { get; }
 

--- a/test/DotNetWorkerTests/TestFunctionDefinition.cs
+++ b/test/DotNetWorkerTests/TestFunctionDefinition.cs
@@ -54,16 +54,16 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var parameters = new List<FunctionParameter>();
 
             // Always provide a trigger
-            inputs.Add($"triggerName", new TestBindingMetadata("TestTrigger", BindingDirection.In));
+            inputs.Add($"triggerName", new TestBindingMetadata("bar","TestTrigger", BindingDirection.In));
 
             for (int i = 0; i < inputBindingCount; i++)
             {
-                inputs.Add($"inputName{i}", new TestBindingMetadata($"TestInput{i}", BindingDirection.In));
+                inputs.Add($"inputName{i}", new TestBindingMetadata($"foo{i}", $"TestInput{i}", BindingDirection.In));
             }
 
             for (int i = 0; i < outputBindingCount; i++)
             {
-                outputs.Add($"outputName{i}", new TestBindingMetadata($"TestOutput{i}", BindingDirection.Out));
+                outputs.Add($"outputName{i}", new TestBindingMetadata($"foo{i}", $"TestOutput{i}", BindingDirection.Out));
             }
 
             for (int i = 0; i < paramTypes.Length; i++)

--- a/test/DotNetWorkerTests/TestFunctionDefinition.cs
+++ b/test/DotNetWorkerTests/TestFunctionDefinition.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var parameters = new List<FunctionParameter>();
 
             // Always provide a trigger
-            inputs.Add($"triggerName", new TestBindingMetadata("bar","TestTrigger", BindingDirection.In));
+            inputs.Add($"triggerName", new TestBindingMetadata("bar", "TestTrigger", BindingDirection.In));
 
             for (int i = 0; i < inputBindingCount; i++)
             {


### PR DESCRIPTION
Exposing the below extension methods on function context:

````
public static ValueTask<InputBindingData<T>> BindInputAsync<T>(BindingMetadata bindingMetadata);
public static InvocationResult<T> GetInvocationResult<T>();;
public static InvocationResult GetInvocationResult();
public static IEnumerable<OutputBindingData<T>> GetOutputBindings<T>();

// Http trigger specific
public static ValueTask<HttpRequestData?> GetHttpRequestDataAsync();
public static HttpResponseData? GetHttpResponseData();
````

The `BindInputAsync` method internally relies on the input conversion feature and caches the result of it so that it can be used for a second time if needed, within the same invocation.

### Usage samples:

1) Global exception handling middleware for http functions.
````
public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
{
    try
    {
        await next(context);
    }
    catch (Exception ex)
    {
        _logger.LogError(ex, "Error processing invocation");

        var httpReqData = await context.GetHttpRequestDataAsync();

        if (httpReqData != null)
        {
            var newResponse = httpReqData.CreateResponse();
            await newResponse.WriteAsJsonAsync(new { Status = "Failed" });

            // Update invocation result.
            var httpInvoationResult = context.GetInvocationResult();
            httpInvoationResult.Value = newResponse;
        }
    }
}
````

2) To get input data inside a middleware for a specific input binding entry.

````
BindingMetadata blobBindingMetaData = context.FunctionDefinition
                                             .InputBindings.Values
                                             .Where(a => a.Type == "blob")
                                             .FirstOrDefault();

if (blobBindingMetaData != null)
{
    var bindingResult = await context.BindInputAsync<MyBlob>(blobBindingMetaData);
    // Update a property value. 
    // This will be reflected in the function parameter value.
    bindingResult.Value.Name = "Edited name";
   
   // or you could even replace the entire object
   bindingResult.Value = new MyBlob { Name = "Totally different object" };
}

````

3) Middleware using these APIs to stamp http response headers.

````
public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
{
    var logger = context.GetLogger<StampHttpHeadersMiddleware>();
    var requestId = "azf-" + Guid.NewGuid();

    using (logger.BeginScope("azfunc-requestid:{requestId}", requestId))
    {
        await next(context);
    }

    var httpRequestData = await context.GetHttpRequestDataAsync();
    if (httpRequestData != null)
    {
        var httpResponseData = context.GetHttpResponseData();
        if (httpResponseData != null)
        {
            httpResponseData.Headers.Add("x-azfunc-requestid", requestId);
        }
    }
}
````