### PR TITLE
Throw when function metadata file not found

### DIFF
--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <MinorProductVersion>4</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>


### PR DESCRIPTION
Throw when function metadata file not found instead of returning empty collection. This will cause host to log the correct error (instead of logging 0 functions found)