### PR TITLE
Handle = character in cookie value and added tests

### DIFF
--- a/src/DotNetWorker.Core/DotNetWorker.Core.csproj
+++ b/src/DotNetWorker.Core/DotNetWorker.Core.csproj
@@ -9,6 +9,7 @@
         <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <MinorProductVersion>5</MinorProductVersion>
+        <PatchProductVersion>1</PatchProductVersion>
         <VersionSuffix>-preview1</VersionSuffix>
     </PropertyGroup>
 

--- a/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
+++ b/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
@@ -9,6 +9,7 @@
         <RootNamespace>Microsoft.Azure.Functions.Worker.Grpc</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <MinorProductVersion>4</MinorProductVersion>
+        <PatchProductVersion>1</PatchProductVersion>
         <VersionSuffix>-preview1</VersionSuffix>
     </PropertyGroup>
 

--- a/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
+++ b/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Functions.Worker
 {
     internal class GrpcHttpRequestData : HttpRequestData, IDisposable
 #if NET5_0_OR_GREATER
-        ,IAsyncDisposable
+        , IAsyncDisposable
 #endif
     {
         private readonly RpcHttp _httpData;
@@ -169,9 +169,9 @@ namespace Microsoft.Azure.Functions.Worker
             {
                 // count:2 tells the split method to stop splitting after
                 // it finds the first instance of separator character.
-                var splitArray = separateCookies[c].Split(separator, count:2, StringSplitOptions.RemoveEmptyEntries);
+                var splitArray = separateCookies[c].Split(separator, count: 2, StringSplitOptions.RemoveEmptyEntries);
                 var name = splitArray[0].Trim();
-                var value = splitArray.Length>1 ? splitArray[1]: string.Empty;
+                var value = splitArray.Length > 1 ? splitArray[1] : string.Empty;
                 httpCookiesList.Add(new HttpCookie(name, value));
             }
 

--- a/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
+++ b/src/DotNetWorker.Grpc/Http/GrpcHttpRequestData.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Functions.Worker
 
                 var cookieString = Headers.FirstOrDefault(item => item.Key.Equals("Cookie", StringComparison.OrdinalIgnoreCase)).Value;
 
-                if (cookieString != null && cookieString.Any())
+                if (cookieString != null && cookieString.Any() && !string.IsNullOrWhiteSpace(cookieString.First()))
                 {
                     return ToHttpCookies(cookieString.First());
                 }
@@ -167,10 +167,11 @@ namespace Microsoft.Azure.Functions.Worker
 
             for (int c = 0; c < separateCookies.Length; c++)
             {
-
-                var splitArray = separateCookies[c].Split(separator, StringSplitOptions.RemoveEmptyEntries);
+                // count:2 tells the split method to stop splitting after
+                // it finds the first instance of separator character.
+                var splitArray = separateCookies[c].Split(separator, count:2, StringSplitOptions.RemoveEmptyEntries);
                 var name = splitArray[0].Trim();
-                var value = splitArray[1];
+                var value = splitArray.Length>1 ? splitArray[1]: string.Empty;
                 httpCookiesList.Add(new HttpCookie(name, value));
             }
 

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Microsoft.Azure.Functions.Worker</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <MinorProductVersion>7</MinorProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <VersionSuffix>-preview1</VersionSuffix>
   </PropertyGroup>
 

--- a/test/DotNetWorkerTests/GrpcHttpRequestDataTests.cs
+++ b/test/DotNetWorkerTests/GrpcHttpRequestDataTests.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.Functions.Worker.Grpc.Messages;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests
+{
+    public class GrpcHttpRequestDataTests
+    {
+        Mock<FunctionContext> mockFunctionContext;
+
+        public GrpcHttpRequestDataTests()
+        {
+            mockFunctionContext = new Mock<FunctionContext>();
+        }
+
+        [Fact]
+        public void Headers_Property_is_Populated()
+        {
+            var headerDict = new Dictionary<string, string>
+            {
+                { "accept-encoding","gzip, deflate, br" },
+                { "cookie","foo=bar; theme=dark" }
+            };
+
+            var httpRequest = CreateGrpcHttpRequestData(headerDict);
+
+            Assert.Equal(2, httpRequest.Headers.Count());
+            Assert.Equal("foo=bar; theme=dark", httpRequest.Headers.GetValues("cookie").First());
+            Assert.True(httpRequest.Headers.Contains("accept-encoding"));
+            Assert.False(httpRequest.Headers.Contains("cache-control"));
+        }
+
+        [Fact]
+        public void Cookie_Property_is_Populated()
+        {
+            var headerDict = new Dictionary<string, string>
+            {
+                { "accept-encoding","gzip, deflate, br" },
+                // cookie string with missing value, trailing '='
+                { "cookie","foo=bar; theme=dark; tz=; token=a5a2Qo=" }
+            };
+
+            var cookies = CreateGrpcHttpRequestData(headerDict).Cookies;
+
+            Assert.Equal(4, cookies.Count);
+            Assert.Equal("bar", cookies.Single(c => c.Name == "foo").Value);
+            Assert.Equal("dark", cookies.Single(c => c.Name == "theme").Value);
+            Assert.Equal("a5a2Qo=", cookies.Single(c => c.Name == "token").Value);
+            Assert.Equal(string.Empty, cookies.Single(c => c.Name == "tz").Value);
+        }
+
+        [Fact]
+        public void Empty_Cookie_Header_Value_is_Handled()
+        {
+            var headerDict = new Dictionary<string, string>
+            {
+                { "accept-encoding","gzip, deflate, br" },
+                { "cookie","" }
+            };
+
+            var request = CreateGrpcHttpRequestData(headerDict);
+
+            Assert.Equal(0, request.Cookies.Count);
+            // Header should still be populated with raw value(empty string)
+            Assert.Equal(2, request.Headers.Count());
+            Assert.Equal("", request.Headers.GetValues("cookie").First());
+        }
+
+        private GrpcHttpRequestData CreateGrpcHttpRequestData(Dictionary<string, string> headerDict = null)
+        {
+            var rpcHttp = new RpcHttp
+            {
+                Url = "https://m.sn"
+            };
+
+            if (headerDict != null)
+            {
+                foreach (var header in headerDict)
+                {
+                    rpcHttp.NullableHeaders[header.Key] = new NullableString() { Value = header.Value };
+                }
+            }
+            return new GrpcHttpRequestData(rpcHttp, mockFunctionContext.Object);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #837

When the cookie value has a "=" character, our logic was returning incorrect cookie value because we relied on `Split("=")` to get name and value of cookie. When the cookie item string is like "token=xyz1=", the Split method returns 3 items and we take the second item as the value. This means we only get "xyz1" and will miss the "=" character. To fix this , I am using the overload of Split which takes the "count" parameter. 

While testing this, I also found another issue. When cookie string is empty, we were returning one item in the Cookies property with name and value properties set to empty string. This is inconsistent with what ASP.NET core behaves (they return 0 items).

Added tests for this class.