### PR TITLE
Throw build error when in-proc SDK is referenced in isolated function apps

### DIFF
--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <MinorProductVersion>3</MinorProductVersion>
+    <MinorProductVersion>4</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.props
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.props
@@ -13,7 +13,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup>
     <FunctionsExecutionModel>isolated</FunctionsExecutionModel>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
-    <_IsFunctionsSdkBuild>true</_IsFunctionsSdkBuild>
   </PropertyGroup>
 
   <!--Enable Azure Functions project capability to enable tools-->

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -31,7 +31,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <_FunctionsExtensionsFullPublish Condition="$(NoBuild) == '' And $(_FunctionsExtensionsFullPublish) == ''">True</_FunctionsExtensionsFullPublish>
     <_FunctionsExtensionsFullPublish Condition="$(_FunctionsExtensionsFullPublish) == ''">!$(NoBuild)</_FunctionsExtensionsFullPublish>
   </PropertyGroup>
-
+  
   <UsingTask TaskName="GenerateFunctionMetadata"
            AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
 
@@ -40,7 +40,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   <UsingTask TaskName="ZipDeployTask"
             AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
-
+ 
   <Target Name="_FunctionsPreBuild" BeforeTargets="Build">
       <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="high" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to v3"/>
       <Error Condition="$(AzureFunctionsVersion.StartsWith('v1',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v4"/>
@@ -48,6 +48,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <Error Condition="!$(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) And !$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version"/>
       <Error Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp' Or ('$(TargetFrameworkVersion)' != 'v6.0' And '$(TargetFrameworkVersion)' != 'v5.0')" Text="TargetFramework is invalid. Change the TargetFramework to net5.0 or net6.0" />
       <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set."/>
+      <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps."/>
   </Target>
 
   <Target Name="_FunctionsPostBuild" AfterTargets="Build">

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -31,7 +31,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <_FunctionsExtensionsFullPublish Condition="$(NoBuild) == '' And $(_FunctionsExtensionsFullPublish) == ''">True</_FunctionsExtensionsFullPublish>
     <_FunctionsExtensionsFullPublish Condition="$(_FunctionsExtensionsFullPublish) == ''">!$(NoBuild)</_FunctionsExtensionsFullPublish>
   </PropertyGroup>
-  
+
   <UsingTask TaskName="GenerateFunctionMetadata"
            AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
 
@@ -40,7 +40,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   <UsingTask TaskName="ZipDeployTask"
             AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
- 
+
   <Target Name="_FunctionsPreBuild" BeforeTargets="Build">
       <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="high" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to v3"/>
       <Error Condition="$(AzureFunctionsVersion.StartsWith('v1',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v4"/>


### PR DESCRIPTION
Fixes #824 

Throw build error when [in-proc SDK](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/) is referenced in isolated function apps. We check the [_IsFunctionsSdkBuild ](https://github.com/Azure/azure-functions-vs-build-sdk/blob/32ebc25b282fe08ebb283178150450755f2d1044/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.props#L15)property to determine this package is referenced or not.

Tested with a locally published version of the `Microsoft.Azure.Functions.Worker.Sdk` package.