### PR TITLE
Use better approach for pre/post-build MSBuild targets

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -41,7 +41,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <UsingTask TaskName="ZipDeployTask"
             AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
 
-  <Target Name="_FunctionsPreBuild" BeforeTargets="Build">
+  <Target Name="_FunctionsPreBuild" BeforeTargets="BeforeBuild">
       <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="high" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to v3"/>
       <Error Condition="$(AzureFunctionsVersion.StartsWith('v1',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v4"/>
       <Error Condition="$(AzureFunctionsVersion.StartsWith('v2',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v3"/>
@@ -50,21 +50,21 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set."/>
   </Target>
 
-  <Target Name="_FunctionsPostBuild" AfterTargets="Build">
+  <Target Name="_FunctionsPostBuild" AfterTargets="AfterBuild">
 
     <PropertyGroup>
       <OutputFile>$(TargetDir)\worker.config.json</OutputFile>
       <ExtensionsCsProjFilePath>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ExtensionsCsProjFilePath>
     </PropertyGroup>
-    
-    <GenerateFunctionMetadata 
-      AssemblyPath="$(TargetDir)$(AssemblyName).dll" 
+
+    <GenerateFunctionMetadata
+      AssemblyPath="$(TargetDir)$(AssemblyName).dll"
       ReferencePaths="@(ReferencePath)"
       ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
       AzureFunctionsVersion="$(AzureFunctionsVersion)"
       OutputPath="$(TargetDir)"/>
 
-    <Copy 
+    <Copy
       SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
       DestinationFolder="$(ExtensionsCsProjFilePath)\buildout"
       OverwriteReadOnlyFiles="true" />
@@ -87,7 +87,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   </Target>
 
-  <!-- 
+  <!--
   Build the webjobs extensions in ".azurefunctions"
   -->
   <!--
@@ -113,19 +113,19 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" Targets="Restore" Properties="IsRestoring=true"/>
   </Target>
 
-  <!-- 
+  <!--
   Add HintPath to references in "extensions.json"
   -->
   <UsingTask TaskName="EnhanceExtensionsMetadata"
            AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
-  
+
   <Target Name="_EnhanceFunctionsExtensionsMetadataPostBuild"
           AfterTargets="_WorkerExtensionsBuildCopy">
 
     <EnhanceExtensionsMetadata
       ExtensionsJsonPath="$(TargetDir)\$(_FunctionsExtensionsDirectory)\$(_FunctionsExtensionsJsonName)"
       OutputPath="$(TargetDir)\$(_FunctionsExtensionsJsonName)"/>
-    
+
   </Target>
 
   <!--
@@ -150,11 +150,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <RemoveDir Directories="$(TargetDir)"
                ContinueOnError="true" />
   </Target>
-  
+
   <!--
   Publish targets from Functions SDK
   -->
-  
+
   <Target Name="_InitializeDotNetPublishProperties"
           BeforeTargets="PrepareForPublish"
           Condition="'$(DeployOnBuild)' != 'true'">
@@ -219,7 +219,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     ============================================================
     -->
-  
+
   <PropertyGroup>
     <CorePublishDependsOn>
       _InitializeDeployOnBuildProperties;
@@ -234,14 +234,14 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <OutputFile>$(PublishDir)\worker.config.json</OutputFile>
       <ExtensionsCsProjFilePath>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ExtensionsCsProjFilePath>
     </PropertyGroup>
-    
+
     <GenerateFunctionMetadata
       AssemblyPath="$(PublishDir)\$(AssemblyName).dll"
       ReferencePaths="@(ReferencePath)"
       ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
       AzureFunctionsVersion="$(AzureFunctionsVersion)"
       OutputPath="$(PublishDir)"/>
-    
+
     <Copy
       SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
       DestinationFolder="$(ExtensionsCsProjFilePath)\publishout"
@@ -265,7 +265,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   </Target>
 
-  <!-- 
+  <!--
   Publish the webjobs extensions in ".azurefunctions"
   -->
   <!--
@@ -310,7 +310,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </FunctionsWorkerExtensionsPublishDependsOn>
   </PropertyGroup>
 
-  <!-- 
+  <!--
   Add HintPath to references in "extensions.json"
   -->
   <Target Name="_EnhanceFunctionsExtensionsMetadataPostPublish">


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Per [this comment](https://github.com/dotnet/msbuild/issues/1680#issuecomment-468710590) (and the entire conversation), it is recommended against using `AfterTargets="Build"` since the `Build` target counter-intuitively comes _after_ the `AfterBuild` target and may lead to issues like https://github.com/dotnet/msbuild/issues/3345.

This PR replaces the existing targets ordering with the recommended one.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
