### PR TITLE
Exposing FunctionInputConverterException and FunctionWorkerException

### DIFF
--- a/src/DotNetWorker.Core/Context/Features/DefaultModelBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultModelBindingFeature.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Converters;
-using Microsoft.Azure.Functions.Worker.Diagnostics.Exceptions;
 
 namespace Microsoft.Azure.Functions.Worker.Context.Features
 {

--- a/src/DotNetWorker.Core/Diagnostics/Exceptions/FunctionInputConverterException.cs
+++ b/src/DotNetWorker.Core/Diagnostics/Exceptions/FunctionInputConverterException.cs
@@ -1,15 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace Microsoft.Azure.Functions.Worker.Diagnostics.Exceptions
+using System;
+
+namespace Microsoft.Azure.Functions.Worker
 {
-    internal class FunctionInputConverterException : FunctionWorkerException
+    /// <summary>
+    /// The exception that is thrown when input conversion for the function invocation fails.
+    /// </summary>
+    public class FunctionInputConverterException : FunctionWorkerException
     {
-        internal FunctionInputConverterException(string message) : base(message) { }
+        /// <summary>
+        /// Initializes a new instance of the FunctionInputConverterException class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public FunctionInputConverterException(string? message) : base(message) { }
 
-        internal FunctionInputConverterException(string message, Exception innerException) : base(message, innerException) { }
+        /// <summary>
+        /// Initializes a new instance of the FunctionInputConverterException class with a specified error message
+        /// and a reference to the inner exception that is thecause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception
+        /// or a null reference if no inner exception is specified..</param>
+        public FunctionInputConverterException(string? message, Exception? innerException) : base(message, innerException) { }
     }
 }

--- a/src/DotNetWorker.Core/Diagnostics/Exceptions/FunctionWorkerException.cs
+++ b/src/DotNetWorker.Core/Diagnostics/Exceptions/FunctionWorkerException.cs
@@ -1,18 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace Microsoft.Azure.Functions.Worker.Diagnostics
+using System;
+
+namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
-    /// Internal exception that is surfaced to the user
+    /// The exception that is thrown when an error occurs during function invocation in the .NET isolated model.
     /// </summary>
-    internal class FunctionWorkerException : Exception
+    public class FunctionWorkerException : Exception
     {
-        internal FunctionWorkerException(string message) : base(message) { }
+        /// <summary>
+        /// Initializes a new instance of the FunctionWorkerException class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public FunctionWorkerException(string? message) : base(message) { }
 
-        internal FunctionWorkerException(string message, Exception innerException) : base(message, innerException) { }
+        /// <summary>
+        /// Initializes a new instance of the FunctionWorkerException class with a specified error message
+        /// and a reference to the inner exception that is thecause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception
+        /// or a null reference if no inner exception is specified..</param>
+        public FunctionWorkerException(string? message, Exception? innerException) : base(message, innerException) { }
     }
 }


### PR DESCRIPTION
Fixes #746 

Exposing `FunctionInputConverterException` and `FunctionWorkerException` as public so that users can use these in middlewares of custom input converters as needed.

I have not updated the package versions in this PR. We shall club this change with another package release we plan to do shortly.