### PR TITLE
Adding UseWhen extension methods for middleware registration

### DIFF
--- a/samples/FunctionApp/Program.cs
+++ b/samples/FunctionApp/Program.cs
@@ -1,45 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.Functions.Worker;
-using Microsoft.Azure.Functions.Worker.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace FunctionApp
 {
-    public sealed class MyHttpMiddleware2 : IFunctionsWorkerMiddleware
-    {
-        public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
-        {
-            ILogger logger = context.GetLogger<MyHttpMiddleware2>();
-
-            logger.LogInformation($"From MyHttpMiddleware2 {DateTime.Now}");
-
-            await next(context);
-
-            // Stamp a response header.
-            context.GetHttpResponseData().Headers.Add("X-REQ-ID", Guid.NewGuid().ToString());
-        }
-    }
-    public sealed class MyHttpMiddleware : IFunctionsWorkerMiddleware
-    {
-        public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
-        {
-            ILogger logger = context.GetLogger<MyHttpMiddleware>();
-
-            logger.LogInformation($"From MyHttpMiddleware {DateTime.Now}");
-
-            await next(context);
-
-            // Stamp a response header.
-            context.GetHttpResponseData().Headers.Add("X-REQ-ID", Guid.NewGuid().ToString());
-        }
-    }
-
     class Program
     {
         static async Task Main(string[] args)
@@ -50,27 +17,7 @@ namespace FunctionApp
             //<docsnippet_startup>
             var host = new HostBuilder()
                 //<docsnippet_configure_defaults>
-                .ConfigureFunctionsWorkerDefaults((builder) =>
-                {
-                    builder.UseMiddleware<MyHttpMiddleware>();
-
-                    //builder.Use((context) =>
-                    //{
-                    //    return next.Invoke();
-                    //});
-
-                    builder.UseWhen((context) =>
-                    {
-                        //var re = await context.GetHttpRequestDataAsync();
-
-                        return true;
-
-                    }, (context, next) =>
-                     {
-                         return next.Invoke();
-                     });
-
-                })
+                .ConfigureFunctionsWorkerDefaults()
                 //</docsnippet_configure_defaults>
                 //<docsnippet_dependency_injection>
                 .ConfigureServices(s =>

--- a/samples/FunctionApp/Program.cs
+++ b/samples/FunctionApp/Program.cs
@@ -11,9 +11,9 @@ namespace FunctionApp
     {
         static async Task Main(string[] args)
         {
-// #if DEBUG
-//          Debugger.Launch();
-// #endif
+            // #if DEBUG
+            //          Debugger.Launch();
+            // #endif
             //<docsnippet_startup>
             var host = new HostBuilder()
                 //<docsnippet_configure_defaults>

--- a/samples/FunctionApp/Program.cs
+++ b/samples/FunctionApp/Program.cs
@@ -1,23 +1,76 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace FunctionApp
 {
+    public sealed class MyHttpMiddleware2 : IFunctionsWorkerMiddleware
+    {
+        public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+        {
+            ILogger logger = context.GetLogger<MyHttpMiddleware2>();
+
+            logger.LogInformation($"From MyHttpMiddleware2 {DateTime.Now}");
+
+            await next(context);
+
+            // Stamp a response header.
+            context.GetHttpResponseData().Headers.Add("X-REQ-ID", Guid.NewGuid().ToString());
+        }
+    }
+    public sealed class MyHttpMiddleware : IFunctionsWorkerMiddleware
+    {
+        public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+        {
+            ILogger logger = context.GetLogger<MyHttpMiddleware>();
+
+            logger.LogInformation($"From MyHttpMiddleware {DateTime.Now}");
+
+            await next(context);
+
+            // Stamp a response header.
+            context.GetHttpResponseData().Headers.Add("X-REQ-ID", Guid.NewGuid().ToString());
+        }
+    }
+
     class Program
     {
         static async Task Main(string[] args)
         {
-// #if DEBUG
-//          Debugger.Launch();
-// #endif
+            // #if DEBUG
+            //          Debugger.Launch();
+            // #endif
             //<docsnippet_startup>
             var host = new HostBuilder()
                 //<docsnippet_configure_defaults>
-                .ConfigureFunctionsWorkerDefaults()
+                .ConfigureFunctionsWorkerDefaults((builder) =>
+                {
+                    builder.UseMiddleware<MyHttpMiddleware>();
+
+                    //builder.Use((context) =>
+                    //{
+                    //    return next.Invoke();
+                    //});
+
+                    builder.UseWhen((context) =>
+                    {
+                        //var re = await context.GetHttpRequestDataAsync();
+
+                        return true;
+
+                    }, (context, next) =>
+                     {
+                         return next.Invoke();
+                     });
+
+                })
                 //</docsnippet_configure_defaults>
                 //<docsnippet_dependency_injection>
                 .ConfigureServices(s =>

--- a/samples/FunctionApp/Program.cs
+++ b/samples/FunctionApp/Program.cs
@@ -11,9 +11,9 @@ namespace FunctionApp
     {
         static async Task Main(string[] args)
         {
-            // #if DEBUG
-            //          Debugger.Launch();
-            // #endif
+// #if DEBUG
+//          Debugger.Launch();
+// #endif
             //<docsnippet_startup>
             var host = new HostBuilder()
                 //<docsnippet_configure_defaults>

--- a/test/DotNetWorkerTests/DefaultInvocationPipelineBuilderTests.cs
+++ b/test/DotNetWorkerTests/DefaultInvocationPipelineBuilderTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         }
 
         [Fact]
-        public void InlineMiddleware_RunsInExpectedOrder_With_UseWhen_Predicate_Returns_Value()
+        public void InlineMiddleware_RunsInExpectedOrder_With_UseWhen_Predicate_ReturnValue()
         {
             var services = new ServiceCollection();
             IFunctionsWorkerApplicationBuilder builder = new FunctionsWorkerApplicationBuilder(services);

--- a/test/DotNetWorkerTests/DefaultInvocationPipelineBuilderTests.cs
+++ b/test/DotNetWorkerTests/DefaultInvocationPipelineBuilderTests.cs
@@ -125,5 +125,48 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Equal(new[] { "Middleware1", "Middleware2", "Middleware3" }, context.Items.Keys);
         }
 
+        [Fact]
+        public void InlineMiddleware_RunsInExpectedOrder_With_UseWhen_Predicate_Returns_Value()
+        {
+            var services = new ServiceCollection();
+            IFunctionsWorkerApplicationBuilder builder = new FunctionsWorkerApplicationBuilder(services);
+
+            builder.Use(next => context =>
+            {
+                context.Items.Add("Middleware1", null);
+                return next(context);
+            });
+
+            builder.UseWhen((context) =>
+            {
+                return false;
+
+            }, (context, next) =>
+            {
+                context.Items.Add("Middleware2", null);
+                return next();
+            });
+
+            builder.UseWhen((context) =>
+            {
+                return true;
+
+            }, (context, next) =>
+            {
+                context.Items.Add("Middleware3", null);
+                return next();
+            });
+
+            FunctionExecutionDelegate app = builder.Services
+                .BuildServiceProvider()
+                .GetService<FunctionExecutionDelegate>();
+
+            var context = _mockContext.Object;
+            context.Items = new Dictionary<object, object>();
+
+            app(context);
+
+            Assert.Equal(new[] { "Middleware1", "Middleware3" }, context.Items.Keys);
+        }
     }
 }


### PR DESCRIPTION
Adding `UseWhen` extension method which allows configuring middleware which can be conditionally executed for function invocations.

Exposing the below 2 extension methods on `IFunctionsWorkerApplicationBuilder`

````
UseWhen<T>(this IFunctionsWorkerApplicationBuilder builder, Func<FunctionContext, bool> predicate)
````
````
UseWhen(this IFunctionsWorkerApplicationBuilder builder, Func<FunctionContext, bool> predicate, 
                                                                 Func<FunctionContext, Func<Task>, Task> middleware)
````

Sample usage

````
// Register middleware of type MyMiddleware
builder.UseWhen<MyMiddleware>((functionContext) =>
{
    return false;  // or true;
});

// Or Inline middleware delegate
builder.UseWhen((functionContext) =>
{
    return true;  // or false
}, (functionContext, next) =>
{
    var logger = functionContext.GetLogger("F");
    logger.LogInformation("Inside inline middleware.");

    return next.Invoke();
});
`````