### PR TITLE
adding the support for kafka headers with latest 3.4.0 release of Kafka extension

### DIFF
--- a/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.3.3")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.3.3.1")]

--- a/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.3.3.1")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.4.0")]

--- a/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.3.2")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.3.3")]

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -6,7 +6,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.3.2</VersionPrefix>
+    <VersionPrefix>3.3.3</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -6,7 +6,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.3.3.1</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -6,7 +6,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.3.3</VersionPrefix>
+    <VersionPrefix>3.3.3.1</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
Publishing version 3.4.0 of Microsoft.Azure.Functions.Worker.Extensions.Kafka which uses 3.4.0 version of Microsoft.Azure.WebJobs.Extensions.Kafka

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
