### PR TITLE
FunctionApp with dotnet isolated runtime needs CLI 2.34.0 or lower

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can place a breakpoint in any function, and inspect your code as it is runni
 
 ### Create the Azure resources
 
-1. To deploy the app, first ensure that you've installed the Azure CLI. 
+1. To deploy the app, first ensure that you've installed the Azure CLI. You need to use Azure CLI 2.3.4 version or below to create function app on dotnet isolated runtime.
 
 2. Login to the CLI.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can place a breakpoint in any function, and inspect your code as it is runni
 
 ### Create the Azure resources
 
-1. To deploy the app, first ensure that you've installed the Azure CLI. You need to use Azure CLI 2.3.4 version or below to create function app on dotnet isolated runtime.
+1. To deploy the app, first ensure that you've installed the Azure CLI. You need to use Azure CLI 2.3.4 version or below to create a .NET 5 function app on dotnet isolated runtime. Support for other .NET versions on Azure CLI are being tracked by [this issue](https://github.com/Azure/azure-functions-dotnet-worker/issues/857).
 
 2. Login to the CLI.
 


### PR DESCRIPTION
FunctionApp with dotnet isolated runtime needs AzCLI 2.34.0 or lower.

Fixes Azure/azure-cli#22281

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
