### PR TITLE
Use current thread for handling invocation result

### DIFF
--- a/src/DotNetWorker.Core/Invocation/DefaultFunctionInvoker.cs
+++ b/src/DotNetWorker.Core/Invocation/DefaultFunctionInvoker.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Functions.Worker.Invocation
         public Task<object> InvokeAsync(object instance, object[] arguments)
         {
             return _methodInvoker.InvokeAsync((TInstance)instance, arguments)
-                .ContinueWith<object>(t => t.Result);
+                .ContinueWith<object>(t => t.Result, TaskContinuationOptions.ExecuteSynchronously);
         }
     }
 }


### PR DESCRIPTION
This PR accomplishes two things:

1. Fixes a compatibility problem with Durable Functions
2. Minor performance improvement for all function invocations in the .NET worker

The fix is simple, use the invoker thread to return the function return value instead of doing so on a worker pool thread. It's probably easier to just look at the code change.

### Issue describing the changes in this PR

One of the rules for orchestrator functions is that they must never do an `await` that would cause the callback to run on a background thread. In other words, all logic MUST run on a single thread. This includes any code that lives in the middleware pipeline between the Durable middleware and the actual function execution.

When debugging the Durable code, I observed behavior that was consistent with an "illegal await" in the function execution pipeline. I debugged the issue with @kshyju, I realized that the problem was in the DefaultFunctionInvoker. Specifically, it's using a `.ContinueWith(t => t.Result)` to convert a `Task<T>` into a `Task<object>`. It's a little strange to do it this way but there's an unfortunate side effect which is that the `t => t.Result` callback gets queued up on a worker pool thread by default. This is bad because it violates the Durable rules and also because of the unnecessary performance overhead of thread switching for something as simple as casting from one type to another.

My fix forces the callback to run on the main invoker thread, rather than scheduling it on a worker pool thread. I verified that this unblocks the Durable Functions integration work.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
