### PR TITLE
[Hotfix] Update Function Functions SDK to 3.1.1 and 4.1.1 which has the response parsing hotfix

### DIFF
--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         {
             string extensionReferences = GetExtensionReferences();
             string targetFramework = _azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) ? Constants.NetCoreApp31 : Constants.Net60;
-            string netSdkVersion = _azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) ? "3.0.13" : "4.0.1";
+            string netSdkVersion = _azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) ? "3.1.1" : "4.1.1";
 
             return $@"
 <Project Sdk=""Microsoft.NET.Sdk"">

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <MinorProductVersion>3</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>


### PR DESCRIPTION
Update `Microsoft.NET.Sdk.Functions` package versions to 3.1.1 and 4.1.1 in ExtensionCsProjGenerator. These versions of the SDK package have the below hotfix

https://github.com/Azure/azure-functions-vs-build-sdk/pull/557

This PR is updating the SDK versions on top of the latest stable worker SDK version ([1.3.0](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Sdk/1.3.0)). The target branch for this PR is a fork from [this commit](https://github.com/Azure/azure-functions-dotnet-worker/commit/66c6380a311b800bb301323693b4ce1cf69dd682), (Oct 26, 2021) which was the last update to the SDK project before 1.3.0 release.