### PR TITLE
Supporting dependency injection of types which implements IAsyncDisposable

### DIFF
--- a/src/DotNetWorker.Core/Context/DefaultFunctionContext.cs
+++ b/src/DotNetWorker.Core/Context/DefaultFunctionContext.cs
@@ -3,11 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.Functions.Worker
 {
-    internal sealed class DefaultFunctionContext : FunctionContext, IDisposable
+    internal sealed class DefaultFunctionContext : FunctionContext, IAsyncDisposable
     {
         private readonly IServiceScopeFactory _serviceScopeFactory;
         private readonly FunctionInvocation _invocation;
@@ -24,7 +25,6 @@ namespace Microsoft.Azure.Functions.Worker
             _invocation = features.Get<FunctionInvocation>() ?? throw new InvalidOperationException($"The '{nameof(FunctionInvocation)}' feature is required.");
             FunctionDefinition = features.Get<FunctionDefinition>() ?? throw new InvalidOperationException($"The {nameof(Worker.FunctionDefinition)} feature is required.");
         }
-
 
         public override string InvocationId => _invocation.Id;
 
@@ -58,11 +58,18 @@ namespace Microsoft.Azure.Functions.Worker
 
         public override RetryContext RetryContext => Features.GetRequired<IExecutionRetryFeature>().Context;
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
             if (_instanceServicesScope != null)
             {
-                _instanceServicesScope.Dispose();
+                if (_instanceServicesScope is IAsyncDisposable asyncServiceScope)
+                {
+                    await asyncServiceScope.DisposeAsync();
+                }
+                else
+                {
+                    _instanceServicesScope.Dispose();
+                }
             }
 
             _instanceServicesScope = null;

--- a/src/DotNetWorker.Core/Context/DefaultFunctionContext.cs
+++ b/src/DotNetWorker.Core/Context/DefaultFunctionContext.cs
@@ -60,16 +60,9 @@ namespace Microsoft.Azure.Functions.Worker
 
         public async ValueTask DisposeAsync()
         {
-            if (_instanceServicesScope != null)
+            if (_instanceServicesScope is IAsyncDisposable asyncServiceScope)
             {
-                if (_instanceServicesScope is IAsyncDisposable asyncServiceScope)
-                {
-                    await asyncServiceScope.DisposeAsync();
-                }
-                else
-                {
-                    _instanceServicesScope.Dispose();
-                }
+                await asyncServiceScope.DisposeAsync();
             }
 
             _instanceServicesScope = null;

--- a/src/DotNetWorker.Core/Context/DefaultFunctionContext.cs
+++ b/src/DotNetWorker.Core/Context/DefaultFunctionContext.cs
@@ -65,6 +65,8 @@ namespace Microsoft.Azure.Functions.Worker
                 await asyncServiceScope.DisposeAsync();
             }
 
+            _instanceServicesScope?.Dispose();
+
             _instanceServicesScope = null;
             _instanceServices = null;
         }

--- a/src/DotNetWorker.Grpc/GrpcWorker.cs
+++ b/src/DotNetWorker.Grpc/GrpcWorker.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Functions.Worker
         private readonly IFunctionMetadataProvider _functionMetadataProvider;
 
         public GrpcWorker(IFunctionsApplication application, FunctionRpcClient rpcClient, GrpcHostChannel outputChannel, IInvocationFeaturesFactory invocationFeaturesFactory,
-            IOutputBindingsInfoProvider outputBindingsInfoProvider, IMethodInfoLocator methodInfoLocator, 
+            IOutputBindingsInfoProvider outputBindingsInfoProvider, IMethodInfoLocator methodInfoLocator,
             IOptions<GrpcWorkerStartupOptions> startupOptions, IOptions<WorkerOptions> workerOptions,
             IInputConversionFeatureProvider inputConversionFeatureProvider, IFunctionMetadataProvider functionMetadataProvider)
         {
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Functions.Worker
         }
 
         internal static async Task<InvocationResponse> InvocationRequestHandlerAsync(InvocationRequest request, IFunctionsApplication application,
-            IInvocationFeaturesFactory invocationFeaturesFactory, ObjectSerializer serializer, 
+            IInvocationFeaturesFactory invocationFeaturesFactory, ObjectSerializer serializer,
             IOutputBindingsInfoProvider outputBindingsInfoProvider,
             IInputConversionFeatureProvider functionInputConversionFeatureProvider)
         {
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Functions.Worker
                 invocationFeatures.Set<IFunctionBindingsFeature>(new GrpcFunctionBindingsFeature(context, request, outputBindingsInfoProvider));
 
                 if (functionInputConversionFeatureProvider.TryCreate(typeof(DefaultInputConversionFeature), out var conversion))
-                {                                    
+                {
                     invocationFeatures.Set<IInputConversionFeature>(conversion!);
                 }
 
@@ -223,7 +223,10 @@ namespace Microsoft.Azure.Functions.Worker
             }
             finally
             {
-                (context as IDisposable)?.Dispose();
+                if (context is IAsyncDisposable asyncContext)
+                {
+                    await asyncContext.DisposeAsync();
+                }  
             }
 
             return response;

--- a/src/DotNetWorker.Grpc/GrpcWorker.cs
+++ b/src/DotNetWorker.Grpc/GrpcWorker.cs
@@ -226,7 +226,9 @@ namespace Microsoft.Azure.Functions.Worker
                 if (context is IAsyncDisposable asyncContext)
                 {
                     await asyncContext.DisposeAsync();
-                }  
+                }
+
+                (context as IDisposable)?.Dispose();
             }
 
             return response;
@@ -261,7 +263,7 @@ namespace Microsoft.Azure.Functions.Worker
             {
                 var functionMetadataList = await _functionMetadataProvider.GetFunctionMetadataAsync(functionAppDirectory);
 
-                foreach(var func in functionMetadataList)
+                foreach (var func in functionMetadataList)
                 {
                     response.FunctionMetadataResults.Add(func);
                 }

--- a/test/DotNetWorkerTests/DefaultFunctionContextTests.cs
+++ b/test/DotNetWorkerTests/DefaultFunctionContextTests.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Linq;
-using Microsoft.Azure.Functions.Worker.Context;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             IServiceCollection serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton<SingletonService>();
             serviceCollection.AddTransient<TransientService>();
+            serviceCollection.AddTransient<AsyncTransientService>();
             serviceCollection.AddScoped<ScopedService>();
             _serviceProvider = serviceCollection.BuildServiceProvider();
             _serviceScopeFactory = _serviceProvider.GetService<IServiceScopeFactory>();
@@ -36,24 +37,28 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         }
 
         [Fact]
-        public void CreateAndDisposeInstanceServicesTest()
+        public async Task CreateAndDisposeInstanceServicesTestAsync()
         {
             var services = _defaultFunctionContext.InstanceServices;
             Assert.NotNull(services);
             var singletonService = services.GetService<SingletonService>();
+            var asyncTransientService = services.GetService<AsyncTransientService>();
             var transientService = services.GetService<TransientService>();
             var scopedService = services.GetService<ScopedService>();
             Assert.NotNull(scopedService);
             Assert.NotNull(transientService);
             Assert.NotNull(singletonService);
+            Assert.NotNull(asyncTransientService);
 
-            _defaultFunctionContext.Dispose();
+            await _defaultFunctionContext.DisposeAsync();
 
             Assert.Throws<ObjectDisposedException>(services.GetService<SingletonService>);
+            Assert.Throws<ObjectDisposedException>(services.GetService<AsyncTransientService>);
             Assert.Throws<ObjectDisposedException>(services.GetService<TransientService>);
             Assert.Throws<ObjectDisposedException>(services.GetService<ScopedService>);
             Assert.True(scopedService.IsDisposed);
             Assert.True(transientService.IsDisposed);
+            Assert.True(asyncTransientService.IsDisposed);
             Assert.False(singletonService.IsDisposed);
         }
 
@@ -61,7 +66,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         private class SingletonService : IDisposable
         {
             public SingletonService() { }
-            public bool IsDisposed { get; private set; }
+            public bool IsDisposed { get; protected set; }
             public void Dispose()
             {
                 IsDisposed = true;
@@ -71,5 +76,14 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         private class TransientService : SingletonService { }
 
         private class ScopedService : SingletonService { }
+
+        private class AsyncTransientService : TransientService, IAsyncDisposable
+        {
+            public ValueTask DisposeAsync()
+            {
+                IsDisposed = true;
+                return default;
+            }
+        }
     }
 }

--- a/test/DotNetWorkerTests/DefaultFunctionContextTests.cs
+++ b/test/DotNetWorkerTests/DefaultFunctionContextTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Throws<ObjectDisposedException>(services.GetService<ScopedService>);
             Assert.True(scopedService.IsDisposed);
             Assert.True(transientService.IsDisposed);
-            Assert.True(asyncTransientService.IsDisposed);
+            Assert.True(asyncTransientService.IsAsyncDisposed);
             Assert.False(singletonService.IsDisposed);
         }
 
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         private class SingletonService : IDisposable
         {
             public SingletonService() { }
-            public bool IsDisposed { get; protected set; }
+            public bool IsDisposed { get; private set; }
             public void Dispose()
             {
                 IsDisposed = true;
@@ -79,9 +79,11 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
         private class AsyncTransientService : TransientService, IAsyncDisposable
         {
+            public bool IsAsyncDisposed { get; private set; }
+
             public ValueTask DisposeAsync()
             {
-                IsDisposed = true;
+                IsAsyncDisposed = true;
                 return default;
             }
         }

--- a/test/DotNetWorkerTests/TestFunctionContext.cs
+++ b/test/DotNetWorkerTests/TestFunctionContext.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.OutputBindings;
 using Microsoft.Azure.Functions.Worker.Tests.Features;
 
 namespace Microsoft.Azure.Functions.Worker.Tests
 {
-    internal class TestFunctionContext : FunctionContext, IDisposable
+    internal class TestFunctionContext : FunctionContext, IAsyncDisposable
     {
         private readonly FunctionInvocation _invocation;
      
@@ -66,9 +67,10 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
         public override RetryContext RetryContext => Features.Get<IExecutionRetryFeature>()?.Context;
 
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
             IsDisposed = true;
+            return default;
         }
     }
 }

--- a/test/DotNetWorkerTests/TestFunctionContext.cs
+++ b/test/DotNetWorkerTests/TestFunctionContext.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             BindingContext = new DefaultBindingContext(this);
         }
 
-        public bool IsDisposed { get; internal set; }
+        public bool IsDisposed { get; private set; }
 
         public override IServiceProvider InstanceServices { get; set; }
 

--- a/test/DotNetWorkerTests/TestFunctionContext.cs
+++ b/test/DotNetWorkerTests/TestFunctionContext.cs
@@ -11,10 +11,29 @@ using Microsoft.Azure.Functions.Worker.Tests.Features;
 
 namespace Microsoft.Azure.Functions.Worker.Tests
 {
-    internal class TestFunctionContext : FunctionContext, IAsyncDisposable
+    internal class TestAsyncFunctionContext : TestFunctionContext, IAsyncDisposable
+    {
+        public TestAsyncFunctionContext()
+            : base(new TestFunctionDefinition(), new TestFunctionInvocation())
+        {
+        }
+        public TestAsyncFunctionContext(IInvocationFeatures features) : base(features)
+        {
+        }
+
+        public bool IsAsyncDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            IsAsyncDisposed = true;
+            return default;
+        }
+    }
+
+    internal class TestFunctionContext : FunctionContext, IDisposable
     {
         private readonly FunctionInvocation _invocation;
-     
+
         public TestFunctionContext()
             : this(new TestFunctionDefinition(), new TestFunctionInvocation())
         {
@@ -47,7 +66,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             BindingContext = new DefaultBindingContext(this);
         }
 
-        public bool IsDisposed { get; private set; }
+        public bool IsDisposed { get; internal set; }
 
         public override IServiceProvider InstanceServices { get; set; }
 
@@ -67,10 +86,9 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
         public override RetryContext RetryContext => Features.Get<IExecutionRetryFeature>()?.Context;
 
-        public ValueTask DisposeAsync()
+        public void Dispose()
         {
             IsDisposed = true;
-            return default;
         }
     }
 }


### PR DESCRIPTION
Fixes #833 

Original issue:
When the function code uses a dependency which implements `IAsyncDisposable`, our code throws when [we call Dispose](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/src/DotNetWorker.Grpc/GrpcWorker.cs#L226) method of the `DefaultFunctionContext`, producing an exception like below (_In this example ServiceBusClient is the dependency which implements IAsyncDisposable_).

> 'Azure.Messaging.ServiceBus.ServiceBusClient' type only implements IAsyncDisposable. Use DisposeAsync to dispose the container.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.Dispose()
   at Microsoft.Azure.Functions.Worker.DefaultFunctionContext.Dispose() in C:\Dev\OSS\azure-functions-dotnet-worker\src\DotNetWorker.Core\Context\DefaultFunctionContext.cs:line 65

This is because the Dispose method of DefaultFunctionContext[ is calling](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/src/DotNetWorker.Core/Context/DefaultFunctionContext.cs#L65) `Dispose` of the IServiceScope where we should be calling the DisposeAsync when any of the dependencies this scope holds is IAsyncDisposable type.

Fix:
The `CreateScope` method returns an instance of `ServiceProviderEngineScope` which implements both `IAsyncDisposable` and `IDisposable`. So we will call the `DisposeAsync` after casting the IServiceScope instance to `IAsyncDisposable`

Note: The [new ](https://devblogs.microsoft.com/dotnet/announcing-net-6/#microsoft-extensions-dependencyinjection-createasyncscope-apis) CreateAsyncScope method is [available from Net 6 onwards](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderserviceextensions.createasyncscope?view=dotnet-plat-ext-6.0). This means, we need to use version 6.X of the `Microsoft.Extensions.Hosting.Abstractions` package. We decided to not use this method at this time and is continue to use `CreateScope` method.
