### PR TITLE
Setting the TFM in the internal csproj based on the Function app TFM

### DIFF
--- a/sdk/Sdk/Constants.cs
+++ b/sdk/Sdk/Constants.cs
@@ -37,7 +37,12 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         // NetFramework
         internal const string NetCoreApp31 = "netcoreapp3.1";
         internal const string Net60 = "net6.0";
+        internal const string Net70 = "net7.0";
         internal const string Net50 = "net5.0";
+        internal const string NetCoreApp = ".NETCoreApp";
+        internal const string NetCoreVersion7 = "v7.0";
+        internal const string NetCoreVersion6 = "v6.0";
+        internal const string NetCoreVersion31 = "v3.1";
         internal const string AzureFunctionsVersion3 = "v3";
     }
 }

--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -14,12 +14,16 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
 
         private readonly IDictionary<string, string> _extensions;
         private readonly string _outputPath;
+        private readonly string _targetFrameworkIdentifier;
+        private readonly string _targetFrameworkVersion;
         private readonly string _azureFunctionsVersion;
 
-        public ExtensionsCsprojGenerator(IDictionary<string, string> extensions, string outputPath, string azureFunctionsVersion)
+        public ExtensionsCsprojGenerator(IDictionary<string, string> extensions, string outputPath, string azureFunctionsVersion, string targetFrameworkIdentifier, string targetFrameworkVersion)
         {
             _extensions = extensions ?? throw new ArgumentNullException(nameof(extensions));
             _outputPath = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
+            _targetFrameworkIdentifier = targetFrameworkIdentifier ?? throw new ArgumentNullException(nameof(targetFrameworkIdentifier));
+            _targetFrameworkVersion = targetFrameworkVersion ?? throw new ArgumentNullException(nameof(targetFrameworkVersion));
             _azureFunctionsVersion = azureFunctionsVersion ?? throw new ArgumentNullException(nameof(azureFunctionsVersion));
         }
 
@@ -52,7 +56,21 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         internal string GetCsProjContent()
         {
             string extensionReferences = GetExtensionReferences();
-            string targetFramework = _azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) ? Constants.NetCoreApp31 : Constants.Net60;
+            string targetFramework = Constants.Net60;
+
+            if (_targetFrameworkIdentifier.Equals(Constants.NetCoreApp, StringComparison.OrdinalIgnoreCase))
+            {
+                if (_azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) || _targetFrameworkVersion.Equals(Constants.NetCoreVersion31, StringComparison.OrdinalIgnoreCase))
+                {
+                    targetFramework = Constants.NetCoreApp31;
+                }
+
+                if (_targetFrameworkVersion.Equals(Constants.NetCoreVersion7, StringComparison.OrdinalIgnoreCase))
+                {
+                    targetFramework = Constants.Net70;
+                }
+            }
+
             string netSdkVersion = _azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) ? "3.1.0" : "4.1.0";
 
             return $@"

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -14,6 +14,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         <_ToolingSuffix></_ToolingSuffix>
         <_AzureFunctionsNotSet Condition="'$(AzureFunctionsVersion)' == ''">true</_AzureFunctionsNotSet>
         <AzureFunctionsVersion Condition="'$(AzureFunctionsVersion)' == ''">v3</AzureFunctionsVersion>
+        <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
+        <TargetFrameworkVersion>$(TargetFrameworkVersion)</TargetFrameworkVersion>
         <_ToolingSuffix Condition="($(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) Or $(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v5.0'">net5-isolated</_ToolingSuffix>
         <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">net6-isolated</_ToolingSuffix>
         <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v7.0'">net7-isolated</_ToolingSuffix>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -32,7 +32,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         <_FunctionsExtensionsFullPublish Condition="$(NoBuild) == '' And $(_FunctionsExtensionsFullPublish) == ''">True</_FunctionsExtensionsFullPublish>
         <_FunctionsExtensionsFullPublish Condition="$(_FunctionsExtensionsFullPublish) == ''">!$(NoBuild)</_FunctionsExtensionsFullPublish>
         <MSBuildFunctionsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Functions\</MSBuildFunctionsTargetsPath>
-
+      
         <FunctionsEnableWorkerIndexing Condition="$(FunctionsEnableWorkerIndexing) == ''">false</FunctionsEnableWorkerIndexing>
     </PropertyGroup>
 
@@ -100,6 +100,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           ReferencePaths="@(ReferencePath)"
           ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
           AzureFunctionsVersion="$(AzureFunctionsVersion)"
+          TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+          TargetFrameworkVersion="$(TargetFrameworkVersion)"
           OutputPath="$(TargetDir)"/>
 
         <Copy
@@ -126,7 +128,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
                                   .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
         Overwrite="true" />
 
-    </Target>
+  </Target>
 
 
     <!--
@@ -284,6 +286,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           ReferencePaths="@(ReferencePath)"
           ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
           AzureFunctionsVersion="$(AzureFunctionsVersion)"
+          TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+          TargetFrameworkVersion="$(TargetFrameworkVersion)"
           OutputPath="$(PublishDir)"/>
 
         <Copy
@@ -312,6 +316,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           ReferencePaths="@(ReferencePath)"
           ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
           AzureFunctionsVersion="$(AzureFunctionsVersion)"
+          TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+          TargetFrameworkVersion="$(TargetFrameworkVersion)"
           OutputPath="$(PublishDir)"/>
 
         <Copy

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -14,8 +14,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         <_ToolingSuffix></_ToolingSuffix>
         <_AzureFunctionsNotSet Condition="'$(AzureFunctionsVersion)' == ''">true</_AzureFunctionsNotSet>
         <AzureFunctionsVersion Condition="'$(AzureFunctionsVersion)' == ''">v3</AzureFunctionsVersion>
-        <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
-        <TargetFrameworkVersion>$(TargetFrameworkVersion)</TargetFrameworkVersion>
         <_ToolingSuffix Condition="($(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) Or $(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v5.0'">net5-isolated</_ToolingSuffix>
         <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">net6-isolated</_ToolingSuffix>
         <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v7.0'">net7-isolated</_ToolingSuffix>
@@ -34,7 +32,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         <_FunctionsExtensionsFullPublish Condition="$(NoBuild) == '' And $(_FunctionsExtensionsFullPublish) == ''">True</_FunctionsExtensionsFullPublish>
         <_FunctionsExtensionsFullPublish Condition="$(_FunctionsExtensionsFullPublish) == ''">!$(NoBuild)</_FunctionsExtensionsFullPublish>
         <MSBuildFunctionsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Functions\</MSBuildFunctionsTargetsPath>
-      
+
         <FunctionsEnableWorkerIndexing Condition="$(FunctionsEnableWorkerIndexing) == ''">false</FunctionsEnableWorkerIndexing>
     </PropertyGroup>
 
@@ -72,6 +70,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           ReferencePaths="@(ReferencePath)"
           ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
           AzureFunctionsVersion="$(AzureFunctionsVersion)"
+          TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+          TargetFrameworkVersion="$(TargetFrameworkVersion)"
           OutputPath="$(TargetDir)"/>
 
         <Copy
@@ -126,7 +126,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
                                   .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
         Overwrite="true" />
 
-  </Target>
+    </Target>
 
 
     <!--

--- a/sdk/Sdk/Tasks/GenerateFunctionMetadata.cs
+++ b/sdk/Sdk/Tasks/GenerateFunctionMetadata.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Tasks
         [Required]
         public string? AzureFunctionsVersion { get; set; }
 
+        [Required]
+        public string? TargetFrameworkIdentifier { get; set; }
+
+        [Required]
+        public string? TargetFrameworkVersion { get; set; }
+
         public override bool Execute()
         {
             try
@@ -39,7 +45,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Tasks
                 var functions = functionGenerator.GenerateFunctionMetadata(AssemblyPath!, ReferencePaths.Select(p => p.ItemSpec));
 
                 var extensions = functionGenerator.Extensions;
-                var extensionsCsProjGenerator = new ExtensionsCsprojGenerator(extensions, ExtensionsCsProjFilePath!, AzureFunctionsVersion!);
+                var extensionsCsProjGenerator = new ExtensionsCsprojGenerator(extensions, ExtensionsCsProjFilePath!, AzureFunctionsVersion!, TargetFrameworkIdentifier!, TargetFrameworkVersion!);
 
                 extensionsCsProjGenerator.Generate();
 

--- a/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                 { "Microsoft.Azure.WebJobs.Extensions", "2.0.0" },
             };
 
-            var generator = new ExtensionsCsprojGenerator(extensions, "", "v3");
+            var generator = new ExtensionsCsprojGenerator(extensions, "", "v3", Constants.NetCoreApp, Constants.NetCoreVersion31);
 
             string actualCsproj = generator.GetCsProjContent().Replace("\r\n", "\n");
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                 { "Microsoft.Azure.WebJobs.Extensions", "2.0.0" },
             };
 
-            var generator = new ExtensionsCsprojGenerator(extensions, "", "v4");
+            var generator = new ExtensionsCsprojGenerator(extensions, "", "v4", Constants.NetCoreApp, Constants.NetCoreVersion6);
 
             string actualCsproj = generator.GetCsProjContent().Replace("\r\n", "\n");
 


### PR DESCRIPTION
Updating the csproj generation so that it determines the TFM for internal csproj based on the TFM of the function app.

### Issue describing the changes in this PR

resolves #981

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
