### PR TITLE
Fix GetOutputBindings method to return correct output when OutputBindingData is not set

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,3 +2,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
+- Bug fix - GetOutputBindings returns incorrect data when OutputBindingData is not set (#983)

--- a/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
+++ b/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
@@ -190,20 +190,68 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             _features.Set<IFunctionBindingsFeature>(functionBindings);
 
             // Act
-            OutputBindingData<HttpResponseData> actual1 = _defaultFunctionContext.GetOutputBindings<HttpResponseData>()
-                .First(a => a.BindingType == "http");
+            var httpOutputBinding = _defaultFunctionContext.GetOutputBindings<HttpResponseData>().First(a => a.BindingType == "http");
+            var queueOutputBinding = _defaultFunctionContext.GetOutputBindings<object>().First(a => a.BindingType == "queue");
 
             // Assert
-            Assert.NotNull(actual1.Value);
-            Assert.Same(actual1.Value, actual1.Value);
+            Assert.NotNull(httpOutputBinding.Value);
+            Assert.Same(new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.OK), httpOutputBinding.Value);
 
             // Also verify we can do other typical operations like adding a response header.
-            actual1.Value.Headers.Add("X-Foo-Id", "bar");
+            httpOutputBinding.Value.Headers.Add("X-Foo-Id", "bar");
+
+            // overwrite the value of one of the outputbinding item
+            queueOutputBinding.Value = "foo";
 
             // Get again and verify previous changes(Adding header) are reflected.
             var actual2 = _defaultFunctionContext.GetOutputBindings<object>().First(a => a.BindingType == "http");
             var httpResponse = TestUtility.AssertIsTypeAndConvert<HttpResponseData>(actual2.Value);
             Assert.Equal("bar", httpResponse.Headers.First(a => a.Key == "X-Foo-Id").Value.First());
+
+            var queueOutputBinding2 = _defaultFunctionContext.GetOutputBindings<object>().First(a => a.BindingType == "queue");
+            Assert.Equal("foo", queueOutputBinding2.Value);
+        }
+
+        [Fact]
+        public void GetOutputBindingData_Works_When_OutputBindingData_Not_set()
+        {
+            // OutputBindingData won't be set when function fails to execute successfully.
+
+            // Arrange
+            var functionDefinition = new TestFunctionDefinition(
+            outputBindings: new Dictionary<string, BindingMetadata>
+            {
+                { "Name", new TestBindingMetadata("Name","queue",BindingDirection.Out) },
+                { "HttpResponse", new TestBindingMetadata("HttpResponse","http",BindingDirection.Out) }
+            });
+            _features.Set<FunctionDefinition>(functionDefinition);
+
+            _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
+
+            var functionBindings = new TestFunctionBindingsFeature();
+            // Not setting any values to functionBindings.OutputBindingData dictionary.
+
+            _features.Set<IFunctionBindingsFeature>(functionBindings);
+
+            // Act
+            var httpOutputBinding = _defaultFunctionContext.GetOutputBindings<HttpResponseData>().First(a => a.BindingType == "http");
+            var queueOutputBinding = _defaultFunctionContext.GetOutputBindings<object>().First(a => a.BindingType == "queue");
+
+            // Assert
+            Assert.Null(httpOutputBinding.Value);
+            Assert.Null(httpOutputBinding.Value);
+
+            // Overwrite the output binding entries with non null values.
+            httpOutputBinding.Value = new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.BadRequest);
+            queueOutputBinding.Value = "foo";
+
+            // Get again and verify previous changes made to the binding entries are reflected.
+            var httpOutputBinding2 = _defaultFunctionContext.GetOutputBindings<object>().First(a => a.BindingType == "http");
+            var httpResponse = TestUtility.AssertIsTypeAndConvert<HttpResponseData>(httpOutputBinding2.Value);
+            Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
+
+            var queueOutputBinding2 = _defaultFunctionContext.GetOutputBindings<object>().First(a => a.BindingType == "queue");
+            Assert.Equal("foo", queueOutputBinding2.Value);
         }
     }
 }

--- a/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
+++ b/test/DotNetWorkerTests/FunctionContextExtensionTests.cs
@@ -185,7 +185,8 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
 
             var functionBindings = new TestFunctionBindingsFeature();
-            functionBindings.OutputBindingData.Add("HttpResponse", new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.OK));
+            var grpcHttpResponse = new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.OK);
+            functionBindings.OutputBindingData.Add("HttpResponse", grpcHttpResponse);
             functionBindings.OutputBindingData.Add("Name", "some name");
             _features.Set<IFunctionBindingsFeature>(functionBindings);
 
@@ -195,7 +196,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
             // Assert
             Assert.NotNull(httpOutputBinding.Value);
-            Assert.Same(new GrpcHttpResponseData(_defaultFunctionContext, HttpStatusCode.OK), httpOutputBinding.Value);
+            Assert.Same(grpcHttpResponse, httpOutputBinding.Value);
 
             // Also verify we can do other typical operations like adding a response header.
             httpOutputBinding.Value.Headers.Add("X-Foo-Id", "bar");

--- a/test/DotNetWorkerTests/FunctionContextHttpExtensionTests.cs
+++ b/test/DotNetWorkerTests/FunctionContextHttpExtensionTests.cs
@@ -144,7 +144,12 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         public void GetHttpResponseData_Works_For_Http_Invocation_POCO_OutputBinding_Properties()
         {
             // Arrange
-            _features.Set<FunctionDefinition>(new TestFunctionDefinition());
+            _features.Set<FunctionDefinition>(new TestFunctionDefinition(
+            outputBindings: new Dictionary<string, BindingMetadata>
+            {
+                { "MyName", new TestBindingMetadata("MyName","queue",BindingDirection.Out) },
+                { "MyHttpResponse", new TestBindingMetadata("MyHttpResponse","http",BindingDirection.Out) }
+            }));
 
             _defaultFunctionContext = new DefaultFunctionContext(_serviceScopeFactory, _features);
             var grpcHttpReq = new GrpcHttpRequestData(CreateRpcHttp(), _defaultFunctionContext);


### PR DESCRIPTION
Fixes #983 

For `GetOutputBindings` method, currently the output binding entries are not returned when OutputBindingData dictionary does not have an entry for the binding item. This means, if the function execution was not successful (Ex: an exception being thrown from within the function code), the `GetOutputBindings` will return an empty collection.

With this fix, for the above mentioned use case, the `GetOutputBindings` method will return a collection of output binding entries with it's value property set to `null` which the user may overwrite with a non null value as needed.

Added a new test to validate this case.


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

