### PR TITLE
Fixes GetHttpResponseData to return the correct entry from OutputBinding entries

### DIFF
--- a/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextHttpRequestExtensions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Functions.Worker
     /// </summary>
     public static class FunctionContextHttpRequestExtensions
     {
+        private const string HttpBindingType = "http";
+
         /// <summary>
         /// Gets the <see cref="HttpRequestData"/> instance if the invocation is for an http trigger.
         /// </summary>
@@ -45,7 +47,7 @@ namespace Microsoft.Azure.Functions.Worker
             }
 
             // see output binding entries have a property of type HttpResponseData;
-            var httpOutputBinding = context.GetOutputBindings<HttpResponseData>().FirstOrDefault();
+            var httpOutputBinding = context.GetOutputBindings<HttpResponseData>().First(a => a.BindingType == HttpBindingType);
 
             return httpOutputBinding?.Value;
         }


### PR DESCRIPTION
In #987 we changed how we read the OutputBinding data. But the `GetHttpResponseData` extension method was not updated to reflect this change. Fixing that here.