### PR TITLE
[AppInsights] updating dependency creation

### DIFF
--- a/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
+++ b/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
@@ -8,17 +8,14 @@
     <MajorProductVersion>1</MajorProductVersion>
     <MinorProductVersion>0</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
+    <VersionSuffix>-preview2</VersionSuffix>
   </PropertyGroup>
 
   <Import Project="..\..\build\Common.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\DotNetWorker.Core\DotNetWorker.Core.csproj" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.7.0-preview1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
   </ItemGroup>
 
 </Project>

--- a/src/DotNetWorker.ApplicationInsights/FunctionActivitySource.cs
+++ b/src/DotNetWorker.ApplicationInsights/FunctionActivitySource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Microsoft.Azure.Functions.Worker.Core.Diagnostics
@@ -18,16 +19,17 @@ namespace Microsoft.Azure.Functions.Worker.Core.Diagnostics
 
         public static Activity? StartInvoke(FunctionContext context)
         {
-            var activity = _activitySource.StartActivity("Invoke", ActivityKind.Internal, context.TraceContext.TraceParent);
-
-            if (activity is not null)
-            {
-                activity.AddTag(InvocationIdKey, context.InvocationId);
-                activity.AddTag(NameKey, context.FunctionDefinition.Name);
-                activity.AddTag(ProcessIdKey, _processId);
-            }
+            var activity = _activitySource.StartActivity("Invoke", ActivityKind.Internal, context.TraceContext.TraceParent,
+                tags: GetTags(context));
 
             return activity;
+        }
+
+        private static IEnumerable<KeyValuePair<string, object?>> GetTags(FunctionContext context)
+        {
+            yield return new KeyValuePair<string, object?>(InvocationIdKey, context.InvocationId);
+            yield return new KeyValuePair<string, object?>(NameKey, context.FunctionDefinition.Name);
+            yield return new KeyValuePair<string, object?>(ProcessIdKey, _processId);
         }
     }
 }

--- a/test/DotNetWorkerTests/ApplicationInsights/ApplicationInsightsConfigurationTests.cs
+++ b/test/DotNetWorkerTests/ApplicationInsights/ApplicationInsightsConfigurationTests.cs
@@ -41,27 +41,30 @@ public class ApplicationInsightsConfigurationTests
             modules = services.Where(s => s.ServiceType == typeof(ITelemetryModule));
         });
 
-        var provider = builder.Build().Services;
+        using (var host = builder.Build())
+        {
+            var provider = host.Services;
 
-        Assert.Collection(initializers,
-            t => Assert.Equal(typeof(FunctionsTelemetryInitializer), t.ImplementationType),
-            t => Assert.Equal(typeof(AzureWebAppRoleEnvironmentTelemetryInitializer), t.ImplementationType),
-            t => Assert.Equal(typeof(Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer), t.ImplementationType),
-            t => Assert.Equal(typeof(HttpDependenciesParsingTelemetryInitializer), t.ImplementationType),
-            t => Assert.Equal(typeof(ComponentVersionTelemetryInitializer), t.ImplementationType));
+            Assert.Collection(initializers,
+                t => Assert.Equal(typeof(FunctionsTelemetryInitializer), t.ImplementationType),
+                t => Assert.Equal(typeof(AzureWebAppRoleEnvironmentTelemetryInitializer), t.ImplementationType),
+                t => Assert.Equal(typeof(Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer), t.ImplementationType),
+                t => Assert.Equal(typeof(HttpDependenciesParsingTelemetryInitializer), t.ImplementationType),
+                t => Assert.Equal(typeof(ComponentVersionTelemetryInitializer), t.ImplementationType));
 
-        Assert.Collection(modules,
-            t => Assert.Equal(typeof(FunctionsTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(DiagnosticsTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(AppServicesHeartbeatTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(AzureInstanceMetadataTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(PerformanceCollectorModule), t.ImplementationType),
-            t => Assert.Equal(typeof(QuickPulseTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(DependencyTrackingTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(EventCounterCollectionModule), t.ImplementationType));
+            Assert.Collection(modules,
+                t => Assert.Equal(typeof(FunctionsTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(DiagnosticsTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(AppServicesHeartbeatTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(AzureInstanceMetadataTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(PerformanceCollectorModule), t.ImplementationType),
+                t => Assert.Equal(typeof(QuickPulseTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(DependencyTrackingTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(EventCounterCollectionModule), t.ImplementationType));
 
-        var middleware = provider.GetRequiredService<FunctionActivitySourceMiddleware>();
-        Assert.NotNull(middleware);
+            var middleware = provider.GetRequiredService<FunctionActivitySourceMiddleware>();
+            Assert.NotNull(middleware);
+        }
     }
 
     [Fact]
@@ -80,14 +83,17 @@ public class ApplicationInsightsConfigurationTests
 
         Assert.False(called);
 
-        var provider = builder.Build().Services;
-        var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>();
-        Assert.NotNull(options.Value);
+        using (var host = builder.Build())
+        {
+            var provider = host.Services;
+            var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>();
+            Assert.NotNull(options.Value);
 
-        var middleware = provider.GetRequiredService<FunctionActivitySourceMiddleware>();
-        Assert.NotNull(middleware);
+            var middleware = provider.GetRequiredService<FunctionActivitySourceMiddleware>();
+            Assert.NotNull(middleware);
 
-        Assert.True(called);
+            Assert.True(called);
+        }
     }
 
     [Fact]
@@ -119,21 +125,24 @@ public class ApplicationInsightsConfigurationTests
             called = true;
         });
 
-        var serviceProvider = builder.Build().Services;
+        using (var host = builder.Build())
+        {
+            var serviceProvider = host.Services;
 
-        var appInsightsOptions = serviceProvider.GetRequiredService<IOptions<ApplicationInsightsLoggerOptions>>();
-        Assert.False(appInsightsOptions.Value.IncludeScopes);
+            var appInsightsOptions = serviceProvider.GetRequiredService<IOptions<ApplicationInsightsLoggerOptions>>();
+            Assert.False(appInsightsOptions.Value.IncludeScopes);
 
-        var userWriter = serviceProvider.GetRequiredService<IUserLogWriter>();
-        Assert.IsType<NullUserLogWriter>(userWriter);
+            var userWriter = serviceProvider.GetRequiredService<IUserLogWriter>();
+            Assert.IsType<NullUserLogWriter>(userWriter);
 
-        var systemWriter = serviceProvider.GetRequiredService<ISystemLogWriter>();
-        Assert.IsNotType<NullLogWriter>(systemWriter);
+            var systemWriter = serviceProvider.GetRequiredService<ISystemLogWriter>();
+            Assert.IsNotType<NullLogWriter>(systemWriter);
 
-        var middleware = serviceProvider.GetRequiredService<FunctionActivitySourceMiddleware>();
-        Assert.NotNull(middleware);
+            var middleware = serviceProvider.GetRequiredService<FunctionActivitySourceMiddleware>();
+            Assert.NotNull(middleware);
 
-        Assert.True(called);
+            Assert.True(called);
+        }
     }
 
     [Fact]
@@ -152,14 +161,17 @@ public class ApplicationInsightsConfigurationTests
 
         Assert.False(called);
 
-        var provider = builder.Build().Services;
-        var options = provider.GetRequiredService<IOptions<ApplicationInsightsLoggerOptions>>();
-        Assert.NotNull(options.Value);
+        using (var host = builder.Build())
+        {
+            var provider = host.Services;
+            var options = provider.GetRequiredService<IOptions<ApplicationInsightsLoggerOptions>>();
+            Assert.NotNull(options.Value);
 
-        var middleware = provider.GetRequiredService<FunctionActivitySourceMiddleware>();
-        Assert.NotNull(middleware);
+            var middleware = provider.GetRequiredService<FunctionActivitySourceMiddleware>();
+            Assert.NotNull(middleware);
 
-        Assert.True(called);
+            Assert.True(called);
+        }
     }
 
     [Fact]
@@ -182,27 +194,30 @@ public class ApplicationInsightsConfigurationTests
             modules = services.Where(s => s.ServiceType == typeof(ITelemetryModule));
         });
 
-        var provider = builder.Build().Services;
+        using (var host = builder.Build())
+        {
+            var provider = host.Services;
 
-        // Ensure that our Initializer and Module are added alongside the defaults
-        Assert.Collection(initializers,
+            // Ensure that our Initializer and Module are added alongside the defaults
+            Assert.Collection(initializers,
             t => Assert.Equal(typeof(FunctionsTelemetryInitializer), t.ImplementationType),
             t => Assert.Equal(typeof(AzureWebAppRoleEnvironmentTelemetryInitializer), t.ImplementationType),
             t => Assert.Equal(typeof(Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer), t.ImplementationType),
             t => Assert.Equal(typeof(HttpDependenciesParsingTelemetryInitializer), t.ImplementationType),
             t => Assert.Equal(typeof(ComponentVersionTelemetryInitializer), t.ImplementationType));
 
-        Assert.Collection(modules,
-            t => Assert.Equal(typeof(FunctionsTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(DiagnosticsTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(AppServicesHeartbeatTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(AzureInstanceMetadataTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(PerformanceCollectorModule), t.ImplementationType),
-            t => Assert.Equal(typeof(QuickPulseTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(DependencyTrackingTelemetryModule), t.ImplementationType),
-            t => Assert.Equal(typeof(EventCounterCollectionModule), t.ImplementationType));
+            Assert.Collection(modules,
+                t => Assert.Equal(typeof(FunctionsTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(DiagnosticsTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(AppServicesHeartbeatTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(AzureInstanceMetadataTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(PerformanceCollectorModule), t.ImplementationType),
+                t => Assert.Equal(typeof(QuickPulseTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(DependencyTrackingTelemetryModule), t.ImplementationType),
+                t => Assert.Equal(typeof(EventCounterCollectionModule), t.ImplementationType));
 
-        var middleware = provider.GetRequiredService<FunctionActivitySourceMiddleware>();
-        Assert.NotNull(middleware);
+            var middleware = provider.GetRequiredService<FunctionActivitySourceMiddleware>();
+            Assert.NotNull(middleware);
+        }
     }
 }

--- a/test/DotNetWorkerTests/ApplicationInsights/EndToEndTests.cs
+++ b/test/DotNetWorkerTests/ApplicationInsights/EndToEndTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.Azure.Functions.Worker.Tests.ApplicationInsights;
 
-public class EndToEndTests
+public class EndToEndTests : IDisposable
 {
     private readonly TestTelemetryChannel _channel;
     private readonly IHost _host;
@@ -31,7 +33,11 @@ public class EndToEndTests
             {
                 var functionsBuilder = services.AddFunctionsWorkerCore();
                 functionsBuilder
-                    .AddApplicationInsights(appInsightsOptions => appInsightsOptions.InstrumentationKey = "abc")
+                    .AddApplicationInsights(appInsightsOptions =>
+                    {
+                        appInsightsOptions.InstrumentationKey = "abc";
+                        appInsightsOptions.EnableAdaptiveSampling = false;
+                    })
                     .AddApplicationInsightsLogger();
 
                 functionsBuilder.UseDefaultWorkerMiddleware();
@@ -72,10 +78,16 @@ public class EndToEndTests
         }
 
         var activity = AppInsightsFunctionDefinition.LastActivity;
+        IEnumerable<ITelemetry> telemetries = null;
 
-        // App Insights can potentially log this, which causes tests to be flaky. Explicitly ignore.
-        var aiTelemetry = _channel.Telemetries.Where(p => p is TraceTelemetry t && t.Message.Contains("AI: TelemetryChannel found a telemetry item"));
-        var telemetries = _channel.Telemetries.Except(aiTelemetry);
+        // There can be a race while telemetry is flushed. Explicitly wait for what we're looking for.
+        await Functions.Tests.TestUtility.RetryAsync(() =>
+        {
+            // App Insights can potentially log this, which causes tests to be flaky. Explicitly ignore.
+            var aiTelemetry = _channel.Telemetries.Where(p => p is TraceTelemetry t && t.Message.Contains("AI: TelemetryChannel found a telemetry item"));
+            telemetries = _channel.Telemetries.Except(aiTelemetry);
+            return Task.FromResult(telemetries.Count() == 2);
+        }, timeout: 5000, pollingInterval: 500, userMessageCallback: () => $"Expected 2 telemetries. Found [{string.Join(", ", telemetries.Select(t => t.GetType().Name))}].");
 
         // Log written in test function should go to App Insights directly        
         Assert.Collection(telemetries,
@@ -84,7 +96,7 @@ public class EndToEndTests
                 var dependency = (DependencyTelemetry)t;
 
                 Assert.Equal("TestName", dependency.Context.Operation.Name);
-                Assert.Equal(activity.SpanId.ToString(), dependency.Context.Operation.ParentId);
+                Assert.Equal(activity.RootId, dependency.Context.Operation.Id);
 
                 ValidateProperties(dependency);
             },
@@ -98,10 +110,15 @@ public class EndToEndTests
                 Assert.DoesNotContain("AzureFunctions_InvocationId", trace.Properties.Keys);
 
                 Assert.Equal("TestName", trace.Context.Operation.Name);
-                Assert.Equal(activity.SpanId.ToString(), trace.Context.Operation.ParentId);
+                Assert.Equal(activity.RootId, trace.Context.Operation.Id);
 
                 ValidateProperties(trace);
             });
+    }
+
+    public void Dispose()
+    {
+        _host?.Dispose();
     }
 
     internal class AppInsightsFunctionDefinition : FunctionDefinition

--- a/test/DotNetWorkerTests/DotNetWorkerTests.csproj
+++ b/test/DotNetWorkerTests/DotNetWorkerTests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\extensions\Worker.Extensions.Http\src\Worker.Extensions.Http.csproj" />
     <ProjectReference Include="..\..\src\DotNetWorker.ApplicationInsights\DotNetWorker.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\src\DotNetWorker\DotNetWorker.csproj" />
+    <ProjectReference Include="..\TestUtility\TestUtility.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #998 

Using App Insights `StartTelemetry` to create dependencies for proper hierarchy. This method does a bunch of work to check Activity trace ids and properly set up the operation and parent ids on telemetry. 

Original example of an isolated function calling into Table storage:
![image](https://user-images.githubusercontent.com/1089915/190506165-ed10c690-6b08-48d2-b1f5-5dff6e3998ff.png)

After this change (note how each entry is a child of the other):
![image](https://user-images.githubusercontent.com/1089915/190506226-68be7dbc-88fd-4ca9-b1ae-1b2b3cb7211d.png)

