### PR TITLE
NetFxWorker sample project cleanup

### DIFF
--- a/samples/NetFxWorker/NetFxWorker.csproj
+++ b/samples/NetFxWorker/NetFxWorker.csproj
@@ -8,9 +8,9 @@
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0-preview3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.5.0-preview2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/NetFxWorker/Program.cs
+++ b/samples/NetFxWorker/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Azure.Functions.Worker;
 

--- a/samples/NetFxWorker/local.settings.json
+++ b/samples/NetFxWorker/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true"
+  }
+}


### PR DESCRIPTION
- Updating NetFxWorker sample project to use stable version of packages. 

- Also, added a `local.settings.json` to the project. Without this file, [core tools shows a warning](https://github.com/Azure/azure-functions-core-tools/blob/v4.x/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs#L20) when running the app, which might be confusing for users who are trying our sample.

![image](https://user-images.githubusercontent.com/144469/191298517-bca537a6-15dd-4fab-b454-be151fdf3f19.png)
