### PR TITLE
Adding a new worker option property to opt-in the behavior to get empty entries in trigger payload

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,3 +2,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
+- Adding support for opting-in to get empty entries in function trigger payload (#1091)

--- a/src/DotNetWorker.Core/DotNetWorker.Core.csproj
+++ b/src/DotNetWorker.Core/DotNetWorker.Core.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <MinorProductVersion>9</MinorProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
+    <VersionSuffix>-preview2</VersionSuffix>
   </PropertyGroup>
 
   <Import Project="..\..\build\Common.props" />

--- a/src/DotNetWorker.Core/Hosting/WorkerOptions.cs
+++ b/src/DotNetWorker.Core/Hosting/WorkerOptions.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Functions.Worker
         
         /// <summary>
         /// Gets or sets a value that determines if empty entries should be included in the function trigger message payload.
+        /// For example, if a set of entries were sent to a messaging service such as Service Bus or Event Hub and your function
+        /// app has a Service bus trigger or Event hub trigger, only the non-empty entries from the payload will be sent to the
+        /// function code as trigger data when this setting value is <see langword="false"/>. When it is <see langword="true"/>,
+        /// All entries will be sent to the function code as it is. Default value for this setting is <see langword="false"/>.
         /// </summary>
         public bool IncludeEmptyEntriesInMessagePayload { get; set; }
     }

--- a/src/DotNetWorker.Core/Hosting/WorkerOptions.cs
+++ b/src/DotNetWorker.Core/Hosting/WorkerOptions.cs
@@ -27,5 +27,10 @@ namespace Microsoft.Azure.Functions.Worker
         /// exceptions when they are surfaced to the Host. 
         /// </summary>
         public bool EnableUserCodeException { get; set; } = false;
+        
+        /// <summary>
+        /// Gets or sets a value that determines if empty entries should be included in the function trigger message payload.
+        /// </summary>
+        public bool IncludeEmptyEntriesInMessagePayload { get; set; }
     }
 }

--- a/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
+++ b/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Microsoft.Azure.Functions.Worker.Grpc</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <MinorProductVersion>7</MinorProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
+    <VersionSuffix>-preview2</VersionSuffix>
   </PropertyGroup>
 
   <Import Project="..\..\build\Common.props" />

--- a/src/DotNetWorker.Grpc/GrpcWorker.cs
+++ b/src/DotNetWorker.Grpc/GrpcWorker.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Functions.Worker
             _invocationHandler.TryCancel(request.InvocationId);
         }
 
-        internal static WorkerInitResponse WorkerInitRequestHandler(WorkerInitRequest request, WorkerOptions? workerOptions = null)
+        internal static WorkerInitResponse WorkerInitRequestHandler(WorkerInitRequest request, WorkerOptions workerOptions)
         {
             var response = new WorkerInitResponse
             {
@@ -219,9 +219,13 @@ namespace Microsoft.Azure.Functions.Worker
             response.Capabilities.Add("HandlesWorkerTerminateMessage", bool.TrueString);
             response.Capabilities.Add("HandlesInvocationCancelMessage", bool.TrueString);
 
-            if (workerOptions is not null && workerOptions.EnableUserCodeException)
+            if (workerOptions.EnableUserCodeException)
             {
                 response.Capabilities.Add("EnableUserCodeException", bool.TrueString);
+            }
+            if (workerOptions.IncludeEmptyEntriesInMessagePayload)
+            {
+                response.Capabilities.Add("IncludeEmptyEntriesInMessagePayload", bool.TrueString);
             }
 
             return response;
@@ -298,7 +302,7 @@ namespace Microsoft.Azure.Functions.Worker
             return rpcFuncMetadata;
         }
 
-    internal void WorkerTerminateRequestHandler(WorkerTerminate request)
+        internal void WorkerTerminateRequestHandler(WorkerTerminate request)
         {
             _hostApplicationLifetime.StopApplication();
         }

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Microsoft.Azure.Functions.Worker</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <MinorProductVersion>11</MinorProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
+    <VersionSuffix>-preview2</VersionSuffix>
   </PropertyGroup>
 
   <Import Project="..\..\build\Common.props" />

--- a/test/DotNetWorkerTests/GrpcWorkerTests.cs
+++ b/test/DotNetWorkerTests/GrpcWorkerTests.cs
@@ -144,11 +144,11 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             bool shouldCapabilityPresent,
             string expectedCapabilityValue = null)
         {
-            var workerOption = new WorkerOptions();
+            var workerOptions = new WorkerOptions();
             // Update boolean property values of workerOption based on test input parameters.
-            workerOption.GetType().GetProperty(booleanPropertyName)?.SetValue(workerOption, booleanPropertyValue);
+            workerOptions.GetType().GetProperty(booleanPropertyName)?.SetValue(workerOptions, booleanPropertyValue);
             
-            var response = GrpcWorker.WorkerInitRequestHandler(new(), workerOption);
+            var response = GrpcWorker.WorkerInitRequestHandler(new(), workerOptions);
 
             IDictionary<string, string> capabilitiesDict = response.Capabilities;
             Assert.Same(bool.TrueString, capabilitiesDict["RpcHttpBodyOnly"]);

--- a/test/DotNetWorkerTests/GrpcWorkerTests.cs
+++ b/test/DotNetWorkerTests/GrpcWorkerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -120,7 +121,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         [Fact]
         public void InitRequest_ReturnsExpectedMetadata()
         {
-            var response = GrpcWorker.WorkerInitRequestHandler(new());
+            var response = GrpcWorker.WorkerInitRequestHandler(new(),new WorkerOptions());
 
             string grpcWorkerVersion = typeof(GrpcWorker).Assembly.GetName().Version?.ToString();
             Assert.Equal(RuntimeInformation.FrameworkDescription, response.WorkerMetadata.RuntimeName);
@@ -130,6 +131,44 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Contains(response.WorkerMetadata.CustomProperties,
                 kvp => string.Equals(kvp.Key, "Worker.Grpc.Version", StringComparison.OrdinalIgnoreCase)
                 && string.Equals(kvp.Value, grpcWorkerVersion, StringComparison.OrdinalIgnoreCase));
+            
+        }
+        
+        [Theory]
+        [InlineData("IncludeEmptyEntriesInMessagePayload", true, "IncludeEmptyEntriesInMessagePayload", true, "True")]
+        [InlineData("IncludeEmptyEntriesInMessagePayload", false, "IncludeEmptyEntriesInMessagePayload", false)]
+        public void InitRequest_ReturnsExpectedCapabilitiesBasedOnWorkerOptions(
+            string booleanPropertyName, 
+            bool booleanPropertyValue, 
+            string capabilityName, 
+            bool shouldCapabilityPresent,
+            string expectedCapabilityValue = null)
+        {
+            var workerOption = new WorkerOptions();
+            // Update boolean property values of workerOption based on test input parameters.
+            workerOption.GetType().GetProperty(booleanPropertyName)?.SetValue(workerOption, booleanPropertyValue);
+            
+            var response = GrpcWorker.WorkerInitRequestHandler(new(), workerOption);
+
+            IDictionary<string, string> capabilitiesDict = response.Capabilities;
+            Assert.Same(bool.TrueString, capabilitiesDict["RpcHttpBodyOnly"]);
+            Assert.Same(bool.TrueString, capabilitiesDict["RawHttpBodyBytes"]);
+            Assert.Same(bool.TrueString, capabilitiesDict["RpcHttpTriggerMetadataRemoved"]);
+            Assert.Same(bool.TrueString, capabilitiesDict["UseNullableValueDictionaryForHttp"]);
+            Assert.Same(bool.TrueString, capabilitiesDict["TypedDataCollection"]);
+            Assert.Same(bool.TrueString, capabilitiesDict["WorkerStatus"]);
+            Assert.Same(bool.TrueString, capabilitiesDict["HandlesWorkerTerminateMessage"]);
+            Assert.Same(bool.TrueString, capabilitiesDict["HandlesInvocationCancelMessage"]);
+
+            if (shouldCapabilityPresent)
+            {
+                Assert.Contains(capabilityName, capabilitiesDict);
+                Assert.Equal(expectedCapabilityValue, capabilitiesDict[capabilityName]);
+            }
+            else
+            {
+                Assert.DoesNotContain(capabilityName, capabilitiesDict);
+            }
         }
 
         [Fact]

--- a/test/DotNetWorkerTests/GrpcWorkerTests.cs
+++ b/test/DotNetWorkerTests/GrpcWorkerTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         [Theory]
         [InlineData("IncludeEmptyEntriesInMessagePayload", true, "IncludeEmptyEntriesInMessagePayload", true, "True")]
         [InlineData("IncludeEmptyEntriesInMessagePayload", false, "IncludeEmptyEntriesInMessagePayload", false)]
-        public void InitRequest_ReturnsExpectedCapabilitiesBasedOnWorkerOptions(
+        public void InitRequest_ReturnsExpectedCapabilities_BasedOnWorkerOptions(
             string booleanPropertyName, 
             bool booleanPropertyValue, 
             string capabilityName, 


### PR DESCRIPTION
Fixes #1017 

This change is part of a fix for [8499](https://github.com/Azure/azure-functions-host/issues/8499) which has details about what problem this is solving.

Adding a boolean property to WorkerOptions, using which customer can opt-in to get the behavior where empty entries in the message payload are not skipped. We made the host level changes in [this PR ](https://github.com/Azure/azure-functions-host/pull/8642)to support this behavior.

Sample usage.

````
var host = new HostBuilder()
    .ConfigureFunctionsWorkerDefaults(builder =>
    {
    }, options =>
    {
        options.IncludeEmptyEntriesInPayload = true;
    })
    .Build();
````

### Pull request checklist

* [x] My changes **do not** require documentation changes - Docs will be automatically published from type.
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
