### PR TITLE
[SDK] Improvements to WebJobsAttributesNotSupported analyzer

### DIFF
--- a/sdk/Sdk.Analyzers/AttributeDataExtensions.cs
+++ b/sdk/Sdk.Analyzers/AttributeDataExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers;
+
+internal static class AttributeDataExtensions
+{
+    /// <summary>
+    /// Checks if an attribute is a web jobs attribute.
+    /// </summary>
+    /// <param name="attributeData">The attribute to check.</param>
+    /// <returns>A boolean value indicating whether the attribute is a web jobs attribute.</returns>
+    public static bool IsWebJobAttribute(this AttributeData attributeData)
+    {
+        // Gets the attributes applied on the Attribute class we are checking.
+        var attributeAttributes = attributeData.AttributeClass?.GetAttributes();
+
+        if (attributeAttributes is null)
+        {
+            return false;
+        }
+            
+        foreach (var attribute in attributeAttributes)
+        {
+            if (string.Equals(attribute.AttributeClass?.ToDisplayString(), Constants.Types.WebJobsBindingAttribute,
+                    StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/sdk/Sdk.Analyzers/MethodSymbolExtensions.cs
+++ b/sdk/Sdk.Analyzers/MethodSymbolExtensions.cs
@@ -10,11 +10,26 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
 {
     internal static class MethodSymbolExtensions
     {
+        /// <summary>
+        /// Gets a collection of web jobs attributes present on the method symbol.
+        /// This includes attributes from parameters and return type.
+        /// </summary>
+        /// <param name="symbol">The method symbol to check.</param>
+        /// <returns>Enumerable collection of web jobs attributes present on the method symbol.</returns>
         public static IEnumerable<AttributeData> GetWebJobsAttributes(this IMethodSymbol symbol)
         {
-            return symbol.Parameters.Select(p => p.GetWebJobsAttribute()).Where(a => a is not null);
+            var webJobsAttributesFromParams = symbol.Parameters.Select(p => p.GetWebJobsAttribute()).Where(a => a is not null);
+            var webJobsAttributesFromReturnType = symbol.GetReturnTypeAttributes().Where(a=>a.IsWebJobAttribute());
+
+            return webJobsAttributesFromParams.Concat(webJobsAttributesFromReturnType);
         }
 
+        /// <summary>
+        /// Checks if a method symbol is an azure function in the isolated model.
+        /// </summary>
+        /// <param name="symbol">The method symbol to check.</param>
+        /// <param name="analysisContext">The context for the symbol analysis.</param>
+        /// <returns>A boolean value indicating whether the method symbol is an azure function.</returns>
         public static bool IsFunction(this IMethodSymbol symbol, SymbolAnalysisContext analysisContext)
         {
             var attributes = symbol.GetAttributes();

--- a/sdk/Sdk.Analyzers/MethodSymbolExtensions.cs
+++ b/sdk/Sdk.Analyzers/MethodSymbolExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
         public static IEnumerable<AttributeData> GetWebJobsAttributes(this IMethodSymbol symbol)
         {
             var webJobsAttributesFromParams = symbol.Parameters.Select(p => p.GetWebJobsAttribute()).Where(a => a is not null);
-            var webJobsAttributesFromReturnType = symbol.GetReturnTypeAttributes().Where(a=>a.IsWebJobAttribute());
+            var webJobsAttributesFromReturnType = symbol.GetReturnTypeAttributes().Where(a => a.IsWebJobAttribute());
 
             return webJobsAttributesFromParams.Concat(webJobsAttributesFromReturnType);
         }

--- a/sdk/Sdk.Analyzers/ParameterSymbolExtensions.cs
+++ b/sdk/Sdk.Analyzers/ParameterSymbolExtensions.cs
@@ -1,28 +1,26 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
 {
     internal static class ParameterSymbolExtensions
     {
+        /// <summary>
+        /// Gets the first web jobs Attribute if the parameter symbol has any, else returns null.
+        /// </summary>
+        /// <param name="parameter">The parameter symbol to check.</param>
+        /// <returns>An instance of <see cref="AttributeData"/> for the WebJobs Attribute found if any, else null.</returns>
         public static AttributeData GetWebJobsAttribute(this IParameterSymbol parameter)
         {
             var parameterAttributes = parameter.GetAttributes();
 
             foreach (var parameterAttribute in parameterAttributes)
             {
-                var attributeAttributes = parameterAttribute.AttributeClass.GetAttributes();
-
-                foreach (var attribute in attributeAttributes)
+                if (parameterAttribute.IsWebJobAttribute())
                 {
-                    if (string.Equals(attribute.AttributeClass.ToDisplayString(), Constants.Types.WebJobsBindingAttribute, StringComparison.Ordinal))
-                    {
-                        return parameterAttribute;
-                    }
+                    return parameterAttribute;
                 }
             }
 

--- a/sdk/Sdk.Analyzers/Sdk.Analyzers.csproj
+++ b/sdk/Sdk.Analyzers/Sdk.Analyzers.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>1</MinorProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <OutputType>Library</OutputType>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/sdk/Sdk.Analyzers/WebJobsAttributesNotSupported.cs
+++ b/sdk/Sdk.Analyzers/WebJobsAttributesNotSupported.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Linq;
-using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -2,3 +2,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
+- Improvements to WebJobsAttributesNotSupported analyzer. (#1092)

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/WebJobsAttributesNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/WebJobsAttributesNotSupportedTests.cs
@@ -10,7 +10,7 @@ namespace Sdk.Analyzers.Tests
     public class WebJobsAttributesNotSupportedTests
     {
         [Fact]
-        public async Task Test1()
+        public async Task WebJobsAttributeInParameters()
         {
             string testCode = @"
 using System.Net;
@@ -28,20 +28,133 @@ namespace FunctionApp
         }
     }
 }";
-            var test = new AnalizerTest();
-            // TODO: This needs to pull from a local source
-            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                new PackageIdentity("Microsoft.Azure.WebJobs.Extensions", "4.0.1"),
-                new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.0.0-preview5"),
-                new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.0.1-preview5"),
-                new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.0.0-preview5"),
-                new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Http", "3.0.12-preview1")));
+            var test = new AnalizerTest
+            {
+                // TODO: This needs to pull from a local source
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                    new PackageIdentity("Microsoft.Azure.WebJobs.Extensions", "4.0.1"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.1.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Http", "3.0.12"))),
 
-            test.TestCode = testCode;
+                TestCode = testCode
+            };
 
             test.ExpectedDiagnostics.Add(Verify.Diagnostic().WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
                 .WithSpan(12, 105, 12, 122).WithArguments("TimerTriggerAttribute"));
             
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task WebJobsAttributeInReturnType()
+        {
+            string testCode = @"
+using Microsoft.Azure.Functions.Worker;
+
+namespace FunctionApp
+{
+    public static class Function1
+    {
+        [Function(""Function1"")]
+        [return: Microsoft.Azure.WebJobs.Queue(""dest-q"")]
+        public static string Run([TimerTrigger(""0 */1 * * * *"")] MyInfo myTimer)
+        {
+            return ""Azure"";
+        }
+    }
+
+    public record MyInfo(bool IsPastDue);
+}";
+            var test = new AnalizerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
+                    new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "5.0.1"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"))),
+
+                TestCode = testCode
+            };
+
+            test.ExpectedDiagnostics.Add(Verify.Diagnostic().WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(9, 18, 9, 57).WithArguments("QueueAttribute"));
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task WebJobsAttributeInReturnTypeAndParameters()
+        {
+            string testCode = @"
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.WebJobs;
+using System.IO;
+
+namespace FunctionApp
+{
+    public static class Function1
+    {
+        [Function(""Function1"")]
+        [return: Microsoft.Azure.WebJobs.Queue(""dest-q"")]
+        public static string Run([TimerTrigger(""0 */1 * * * *"")] object myTimer, 
+                                 [Blob(""samples-workitems/{queueTrigger}"", FileAccess.Read)] Stream myBlob)
+        {
+            return ""Azure"";
+        }
+    }
+}";
+            var test = new AnalizerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
+                    new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "5.0.1"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"))),
+
+                TestCode = testCode
+            };
+
+            // Diagnostics from functions parameter
+            test.ExpectedDiagnostics.Add(Verify.Diagnostic().WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(13, 35, 13, 92).WithArguments("BlobAttribute"));
+            // Diagnostics from functions return type
+            test.ExpectedDiagnostics.Add(Verify.Diagnostic().WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(11, 18, 11, 57).WithArguments("QueueAttribute"));
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task NoWebJobsAttribute()
+        {
+            string testCode = @"
+using Microsoft.Azure.Functions.Worker;
+
+namespace GH258IsolatedReturnWebJobsAttr
+{
+    public class PureIsolatedTimerFunction
+    {
+        [Function(nameof(PureIsolatedTimerFunction))]
+        public void Run([TimerTrigger(""0 */5 * * * *"")] object myTimer)
+        {
+        }
+    }
+}";
+            var test = new AnalizerTest
+            {
+                // TODO: This needs to pull from a local source
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"))),
+
+                TestCode = testCode
+            };
+
+            // test.ExpectedDiagnostics is an empty collection.
+
             await test.RunAsync();
         }
     }

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/WebJobsAttributesNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests/WebJobsAttributesNotSupportedTests.cs
@@ -116,10 +116,10 @@ namespace FunctionApp
                 TestCode = testCode
             };
 
-            // Diagnostics from functions parameter
+            // Diagnostic entry for functions parameter
             test.ExpectedDiagnostics.Add(Verify.Diagnostic().WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
                 .WithSpan(13, 35, 13, 92).WithArguments("BlobAttribute"));
-            // Diagnostics from functions return type
+            // Diagnostic entry for functions return type
             test.ExpectedDiagnostics.Add(Verify.Diagnostic().WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
                 .WithSpan(11, 18, 11, 57).WithArguments("QueueAttribute"));
 


### PR DESCRIPTION
Resolves #256 

Updates to WebJobsAttributesNotSupported analyzer to handle the return use case as mentioned [here](https://github.com/Azure/azure-functions-dotnet-worker/issues/258#issuecomment-1256773079).

Before
![analyzer-webjobs-before](https://user-images.githubusercontent.com/144469/193653159-4fcf2710-9544-4a79-8377-251158456faa.gif)


After

![analyzer-webjobs-after](https://user-images.githubusercontent.com/144469/193653167-59eef760-42cd-40c2-b8f1-98fb1ba3c452.gif)


I also checked the case where IAsyncCollector/ICollector is used with worker version of attribute. 
````
[Function("Function1")]
public string Run([TimerTrigger("0 */5 * * * *")] object myTimer,
    [Microsoft.Azure.Functions.Worker.QueueOutputAttribute("a")] ICollector<string> s)
{
    return "hello";
}
````

This produces [CS0592](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0592?f1url=%3FappId%3Droslyn%26k%3Dk(CS0592)) because our worker output bindings are valid only on method or property.

https://github.com/Azure/azure-functions-dotnet-worker/blob/28ae2dda97f99772769d187cd0ad10c0285d0fdb/extensions/Worker.Extensions.Abstractions/src/OutputBindingAttribute.cs#L8-L9

### Pull request checklist


* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

