### PR TITLE
Use a consistent function ID via code gen

### DIFF
--- a/sdk/Sdk.Generators/Abstractions/GeneratorFunctionMetadata.cs
+++ b/sdk/Sdk.Generators/Abstractions/GeneratorFunctionMetadata.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
         public string? ScriptFile { get; set; }
 
-        public string? FunctionId { get; set; }
-
         public bool IsProxy { get; set; }
 
         public string? EntryPoint { get; set; }

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Emitter.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Emitter.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     indentedTextWriter.WriteLine($"var {functionVariableName} = new DefaultFunctionMetadata");
                     indentedTextWriter.WriteLine("{");
                     indentedTextWriter.Indent++;
-                    indentedTextWriter.WriteLine("FunctionId = Guid.NewGuid().ToString(),");
+                    indentedTextWriter.WriteLine($"FunctionId = \"{function.FunctionId}\",");
                     indentedTextWriter.WriteLine("Language = \"dotnet-isolated\",");
                     indentedTextWriter.WriteLine($"Name = \"{function.Name}\",");
                     indentedTextWriter.WriteLine($"EntryPoint = \"{function.EntryPoint}\",");

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Emitter.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Emitter.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     indentedTextWriter.WriteLine($"var {functionVariableName} = new DefaultFunctionMetadata");
                     indentedTextWriter.WriteLine("{");
                     indentedTextWriter.Indent++;
-                    indentedTextWriter.WriteLine($"FunctionId = \"{function.FunctionId}\",");
                     indentedTextWriter.WriteLine("Language = \"dotnet-isolated\",");
                     indentedTextWriter.WriteLine($"Name = \"{function.Name}\",");
                     indentedTextWriter.WriteLine($"EntryPoint = \"{function.EntryPoint}\",");

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Emitter.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Emitter.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 indentedTextWriter.Indent++;
                 indentedTextWriter.WriteLine(@"///<summary>");
                 indentedTextWriter.WriteLine(@"/// Adds the GeneratedFunctionMetadataProvider to the service collection.");
-                indentedTextWriter.WriteLine(@"/// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.");
+                indentedTextWriter.WriteLine(@"/// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.");
                 indentedTextWriter.WriteLine(@"///</summary>");
                 indentedTextWriter.WriteLine("public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)");
                 indentedTextWriter.WriteLine("{");

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -441,10 +441,10 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 return httpBinding;
             }
 
-            private bool TryCreateBindingDict(AttributeData bindingAttrData, string bindingName, Location bindingLocation, out IDictionary<string, string>? bindings)
+            private bool TryCreateBindingDict(AttributeData bindingAttrData, string bindingName, Location? bindingLocation, out IDictionary<string, string>? bindings)
             {
                 // Get binding info as a dictionary with keys as the property name and value as the property value
-                if (!TryGetAttributeProperties(bindingAttrData, bindingLocation, out IDictionary<string, object>? attributeProperties))
+                if (!TryGetAttributeProperties(bindingAttrData, bindingLocation, out IDictionary<string, object?>? attributeProperties))
                 {
                     bindings = null;
                     return false;
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 {
                     var propertyName = prop.Key;
 
-                    if (prop.Value.GetType().IsArray)
+                    if (prop.Value?.GetType().IsArray ?? false)
                     {
                         string arr = FormatArray((IEnumerable)prop.Value);
                         bindings[propertyName] = arr;
@@ -487,9 +487,9 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 return true;
             }
 
-            private bool TryGetAttributeProperties(AttributeData attributeData, Location attribLocation, out IDictionary<string, object>? attrProperties)
+            private bool TryGetAttributeProperties(AttributeData attributeData, Location? attribLocation, out IDictionary<string, object?>? attrProperties)
             {
-                attrProperties = new Dictionary<string, object>();
+                attrProperties = new Dictionary<string, object?>();
 
                 if (attributeData.ConstructorArguments.Any())
                 {
@@ -520,7 +520,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 return true;
             }
 
-            private bool TryLoadConstructorArguments(AttributeData attributeData, IDictionary<string, object> dict, Location attribLocation)
+            private bool TryLoadConstructorArguments(AttributeData attributeData, IDictionary<string, object?> dict, Location? attribLocation)
             {
                 IMethodSymbol? attribMethodSymbol = attributeData.AttributeConstructor;
 

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     {
                         Name = functionName,
                         EntryPoint = assemblyName + "." + functionClassName + "." + method.Identifier.ValueText,
-                        FunctionId = Guid.NewGuid().ToString(),
                         Language = "dotnet-isolated",
                         ScriptFile = scriptFile
                     };

--- a/src/DotNetWorker.Core/FunctionMetadata/DefaultFunctionMetadata.cs
+++ b/src/DotNetWorker.Core/FunctionMetadata/DefaultFunctionMetadata.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Azure.Functions.Worker.Core.FunctionMetadata
 
         private static string? HashFunctionId(DefaultFunctionMetadata function)
         {
-            // we use uint to avoid the '-' sign when we .ToString() the result.
+            // We use uint to avoid the '-' sign when we .ToString() the result.
+            // This function is adapted from https://github.com/Azure/azure-functions-host/blob/71ecbb2c303214f96d7e17310681fd717180bdbb/src/WebJobs.Script/Utility.cs#L847-L863
             static uint GetStableHash(string value)
             {
                 unchecked

--- a/src/DotNetWorker.Core/FunctionMetadata/DefaultFunctionMetadata.cs
+++ b/src/DotNetWorker.Core/FunctionMetadata/DefaultFunctionMetadata.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Azure.Functions.Worker.Core.FunctionMetadata
 {
@@ -7,8 +11,20 @@ namespace Microsoft.Azure.Functions.Worker.Core.FunctionMetadata
     /// </summary>
     public class DefaultFunctionMetadata : IFunctionMetadata
     {
+        private string? _functionId;
+        private string? _name;
+        private string? _entryPoint;
+        private string? _scriptFile;
+
         /// <inheritdoc/>
-        public string? FunctionId { get; set; }
+        public string? FunctionId
+        {
+            get
+            {
+                _functionId ??= HashFunctionId(this);
+                return _functionId;
+            }
+        }
 
         /// <inheritdoc/>
         public bool IsProxy { get; set; }
@@ -20,15 +36,69 @@ namespace Microsoft.Azure.Functions.Worker.Core.FunctionMetadata
         public bool ManagedDependencyEnabled { get; set; }
 
         /// <inheritdoc/>
-        public string? Name { get; set; }
+        public string? Name { get => _name; set => ClearIdAndSet(value, ref _name); }
 
         /// <inheritdoc/>
-        public string? EntryPoint { get; set; }
+        public string? EntryPoint { get => _entryPoint; set => ClearIdAndSet(value, ref _entryPoint); }
 
         /// <inheritdoc/>
         public IList<string>? RawBindings { get; set; }
 
         /// <inheritdoc/>
-        public string? ScriptFile { get; set; }
+        public string? ScriptFile { get => _scriptFile; set => ClearIdAndSet(value, ref _scriptFile); }
+
+        private static string? HashFunctionId(DefaultFunctionMetadata function)
+        {
+            // we use uint to avoid the '-' sign when we .ToString() the result.
+            static uint GetStableHash(string value)
+            {
+                unchecked
+                {
+                    uint hash = 23;
+                    foreach (char c in value)
+                    {
+                        hash = (hash * 31) + c;
+                    }
+
+                    return hash;
+                }
+            }
+
+            unchecked
+            {
+                bool atLeastOnePresent = false;
+                uint hash = 17;
+
+                if (function.Name is not null)
+                {
+                    atLeastOnePresent = true;
+                    hash = hash * 31 + GetStableHash(function.Name);
+                }
+
+                if (function.ScriptFile is not null)
+                {
+                    atLeastOnePresent = true;
+                    hash = hash * 31 + GetStableHash(function.ScriptFile);
+                }
+
+                if (function.EntryPoint is not null)
+                {
+                    atLeastOnePresent = true;
+                    hash = hash * 31 + GetStableHash(function.EntryPoint);
+                }
+
+                return atLeastOnePresent ? hash.ToString() : null;
+            }
+        }
+
+        private void ClearIdAndSet(string? value, ref string? field)
+        {
+            if (!StringComparer.Ordinal.Equals(value, field))
+            {
+                _functionId = null;
+            }
+
+            field = value;
+        }
     }
 }

--- a/src/DotNetWorker.Core/FunctionMetadata/IFunctionMetadata.cs
+++ b/src/DotNetWorker.Core/FunctionMetadata/IFunctionMetadata.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 
 namespace Microsoft.Azure.Functions.Worker.Core.FunctionMetadata
 {

--- a/test/DotNetWorkerTests/ApplicationInsights/EndToEndTests.cs
+++ b/test/DotNetWorkerTests/ApplicationInsights/EndToEndTests.cs
@@ -35,7 +35,9 @@ public class EndToEndTests : IDisposable
                 functionsBuilder
                     .AddApplicationInsights(appInsightsOptions =>
                     {
+#pragma warning disable CS0618 // Obsolete member. Test case, this is fine to use.
                         appInsightsOptions.InstrumentationKey = "abc";
+#pragma warning restore CS0618 // Obsolete member. Test case, this is fine to use.
 
                         // keep things more deterministic for tests
                         appInsightsOptions.EnableAdaptiveSampling = false;

--- a/test/DotNetWorkerTests/FunctionMetadata/DefaultFunctionMetadataTests.cs
+++ b/test/DotNetWorkerTests/FunctionMetadata/DefaultFunctionMetadataTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using Xunit;
+
+namespace DotNetWorkerTests.FunctionMetadata
+{
+    public class DefaultFunctionMetadataTests
+    {
+        [Fact]
+        public void FunctionId_StableHash_SameValues()
+        {
+            DefaultFunctionMetadata func1 = new()
+            {
+                Name = Guid.NewGuid().ToString(),
+                EntryPoint = Guid.NewGuid().ToString(),
+                ScriptFile = Guid.NewGuid().ToString(),
+            };
+
+            DefaultFunctionMetadata func2 = new()
+            {
+                Name = func1.Name,
+                EntryPoint = func1.EntryPoint,
+                ScriptFile = func1.ScriptFile,
+            };
+
+            string func1Id = func1.FunctionId;
+            Assert.NotNull(func1.FunctionId);
+            Assert.Equal(func1Id, func1.FunctionId); // does not change
+            Assert.Equal(func1.FunctionId, func2.FunctionId);
+        }
+
+        [Fact]
+        public void FunctionId_StableHash_DifferentValues()
+        {
+            DefaultFunctionMetadata func1 = new()
+            {
+                Name = Guid.NewGuid().ToString(),
+                EntryPoint = Guid.NewGuid().ToString(),
+                ScriptFile = Guid.NewGuid().ToString(),
+            };
+
+            DefaultFunctionMetadata func2 = new()
+            {
+                Name = func1.Name + "2",
+                EntryPoint = func1.EntryPoint,
+                ScriptFile = func1.ScriptFile,
+            };
+
+            Assert.NotEqual(func1.FunctionId, func2.FunctionId);
+        }
+    }
+}

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
@@ -116,7 +116,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = ""dotnet-isolated"",
                 Name = """ + functionName + @""",
                 EntryPoint = ""TestProject.EventHubsInput." + functionName + @""",
@@ -247,7 +246,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = ""dotnet-isolated"",
                 Name = """ + functionName + @""",
                 EntryPoint = ""TestProject.EventHubsInput." + functionName + @""",
@@ -340,7 +338,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'EnumerableBinaryInputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.EnumerableBinaryInputFunction',
@@ -486,7 +483,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'EnumerableStringClassInputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.EnumerableStringClassInputFunction',
@@ -508,7 +504,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function1RawBindings.Add(Function1binding0JSON);
             var Function1 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'EnumerableNestedStringClassInputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.EnumerableNestedStringClassInputFunction',
@@ -530,7 +525,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function2RawBindings.Add(Function2binding0JSON);
             var Function2 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'EnumerableNestedStringGenericClassInputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.EnumerableNestedStringGenericClassInputFunction',
@@ -552,7 +546,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function3RawBindings.Add(Function3binding0JSON);
             var Function3 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'EnumerableNestedStringGenericClass2InputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.EnumerableNestedStringGenericClass2InputFunction',
@@ -671,7 +664,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'EnumerableBinaryClassInputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.EnumerableBinaryClassInputFunction',
@@ -693,7 +685,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function1RawBindings.Add(Function1binding0JSON);
             var Function1 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'EnumerableNestedBinaryClassInputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.EnumerableNestedBinaryClassInputFunction',
@@ -798,7 +789,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'EnumerablePocoInputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.EnumerablePocoInputFunction',
@@ -819,7 +809,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function1RawBindings.Add(Function1binding0JSON);
             var Function1 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'ListPocoInputFunction',
                 EntryPoint = 'TestProject.EventHubsInput.ListPocoInputFunction',

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -355,7 +355,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -567,7 +567,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -708,7 +708,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -834,7 +834,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
@@ -96,7 +96,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'HttpTriggerSimple',
                 EntryPoint = 'TestProject.HttpTriggerSimple.Run',
@@ -187,7 +186,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'HttpTrigger',
                 EntryPoint = 'TestProject.HttpTriggerSimple.HttpTrigger',
@@ -289,7 +287,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'JustHtt',
                 EntryPoint = 'TestProject.HttpTriggerSimple.Justhtt',

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -485,7 +485,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -584,7 +584,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
@@ -128,7 +128,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding2JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'HttpTriggerWithMultipleOutputBindings',
                 EntryPoint = 'TestProject.HttpTriggerWithMultipleOutputBindings.Run',
@@ -270,7 +269,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding3JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'HttpTriggerWithBlobInput',
                 EntryPoint = 'TestProject.HttpTriggerWithBlobInput.Run',
@@ -380,7 +378,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'Products',
                 EntryPoint = 'TestProject.HttpTriggerWithBlobInput.Run',
@@ -470,7 +467,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'TimerFunction',
                 EntryPoint = 'TestProject.Timer.RunTimer',
@@ -569,7 +565,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'FunctionName',
                 EntryPoint = 'TestProject.BasicHttp.Http',

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -104,7 +104,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'QueueTriggerFunction',
                 EntryPoint = 'TestProject.QueueTriggerAndOutput.QueueTriggerAndOutputFunction',
@@ -215,7 +214,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'QueueToBlobFunction',
                 EntryPoint = 'TestProject.QueueTriggerAndOutput.QueueToBlob',
@@ -243,7 +241,6 @@ namespace Microsoft.Azure.Functions.Worker
             Function1RawBindings.Add(Function1binding1JSON);
             var Function1 = new DefaultFunctionMetadata
             {
-                FunctionId = Guid.NewGuid().ToString(),
                 Language = 'dotnet-isolated',
                 Name = 'BlobToQueueFunction',
                 EntryPoint = 'TestProject.QueueTriggerAndOutput.BlobToQueue',

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.Functions.Worker
     {
         ///<summary>
         /// Adds the GeneratedFunctionMetadataProvider to the service collection.
-        /// During initialization, the worker will return generated funciton metadata instead of relying on the Azure Functions host for function indexing.
+        /// During initialization, the worker will return generated function metadata instead of relying on the Azure Functions host for function indexing.
         ///</summary>
         public static IHostBuilder ConfigureGeneratedFunctionMetadataProvider(this IHostBuilder builder)
         {


### PR DESCRIPTION
### Issue describing the changes in this PR

This PR ensures we will report a consistent `FunctionId` for the same function between worker instances.

#### Update:
New changes to PR:

- Addressed some warnings and typos.
- DefaultFunctionMetadata now computes its `FunctionId` based on a stable hash of `Name`, `EntryPoint`, and `ScriptFile`.
    - The implementation is adapted from https://github.com/Azure/azure-functions-host/blob/71ecbb2c303214f96d7e17310681fd717180bdbb/src/WebJobs.Script/Utility.cs#L847-L863

resolves #1102

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] **IN PROGRESS** I have added all required tests (Unit tests, E2E tests) 

### Additional information

The source gen is yet to be released, so documentation updates unnecessary.

/cc: @satvu 