### PR TITLE
Update cancellation sample to show valid use case

### DIFF
--- a/samples/Configuration/Configuration.csproj
+++ b/samples/Configuration/Configuration.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
   </ItemGroup>

--- a/samples/CustomMiddleware/CustomMiddleware.csproj
+++ b/samples/CustomMiddleware/CustomMiddleware.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />

--- a/samples/EntityFramework/EntityFramework.csproj
+++ b/samples/EntityFramework/EntityFramework.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Extensions/Extensions.csproj
+++ b/samples/Extensions/Extensions.csproj
@@ -6,7 +6,7 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="3.0.9" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="5.1.0" />

--- a/samples/Net7Worker/EventHubCancellationToken.cs
+++ b/samples/Net7Worker/EventHubCancellationToken.cs
@@ -17,7 +17,7 @@ namespace Net7Worker
 
         [Function(nameof(EventHubCancellationToken))]
         public void Run(
-            [EventHubTrigger("src", Connection = "EventHubConnection")] string[] messages,
+            [EventHubTrigger("sample-workitems", Connection = "EventHubConnection")] string[] messages,
             FunctionContext context,
             CancellationToken cancellationToken)
         {
@@ -27,23 +27,13 @@ namespace Net7Worker
             {
                 foreach (var message in messages)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        _logger.LogInformation("A cancellation token was received. Taking precautionary actions.");
-                        // Take precautions like noting how far along you are with processing the batch
-                        _logger.LogInformation("Precautionary activities --complete--.");
-                        break;
-                    }
-                    else
-                    {
-                        // Business logic as usual
-                        _logger.LogInformation($"Message: {message} was processed.");
-                    }
+                    cancellationToken.ThrowIfCancellationRequested();
+                    _logger.LogInformation($"Message: {message} was processed.");
                 }
             }
-            catch (Exception ex)
+            catch (OperationCanceledException)
             {
-                _logger.LogInformation($"Something unexpected happened: {ex.Message}");
+                _logger.LogInformation("A cancellation token was received - invocation cancelled.");
             }
         }
     }

--- a/samples/Net7Worker/EventHubCancellationToken.cs
+++ b/samples/Net7Worker/EventHubCancellationToken.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Net7Worker
+{
+    public class EventHubCancellationToken
+    {
+        private readonly ILogger _logger;
+
+        public EventHubCancellationToken(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<EventHubCancellationToken>();
+        }
+
+        [Function(nameof(EventHubCancellationToken))]
+        public void Run(
+            [EventHubTrigger("src", Connection = "EventHubConnection")] string[] messages,
+            FunctionContext context,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("C# EventHub trigger function processing a request.");
+
+            try
+            {
+                foreach (var message in messages)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        _logger.LogInformation("A cancellation token was received. Taking precautionary actions.");
+                        // Take precautions like noting how far along you are with processing the batch
+                        _logger.LogInformation("Precautionary activities --complete--.");
+                        break;
+                    }
+                    else
+                    {
+                        // Business logic as usual
+                        _logger.LogInformation($"Message: {message} was processed.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogInformation($"Something unexpected happened: {ex.Message}");
+            }
+        }
+    }
+}

--- a/samples/Net7Worker/EventHubCancellationToken.cs
+++ b/samples/Net7Worker/EventHubCancellationToken.cs
@@ -17,19 +17,19 @@ namespace Net7Worker
 
         // Sample showing how to handle a cancellation token being received
         // In this example, the function invocation status will be "Cancelled"
-        [Function(nameof(EventHubCancellationToken))]
+        [Function(nameof(ThrowOnCancellation))]
         public async Task ThrowOnCancellation(
             [EventHubTrigger("sample-workitem-1", Connection = "EventHubConnection")] string[] messages,
             FunctionContext context,
             CancellationToken cancellationToken)
         {
-            _logger.LogInformation("C# EventHub ThrowOnCancellation trigger function processing a request.");
+            _logger.LogInformation("C# EventHub {functionName} trigger function processing a request.", nameof(ThrowOnCancellation));
 
             foreach (var message in messages)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 await Task.Delay(6000); // task delay to simulate message processing
-                _logger.LogInformation($"Message: {message} was processed.");
+                _logger.LogInformation("Message '{msg}' was processed.", message);
             }
         }
 
@@ -41,20 +41,20 @@ namespace Net7Worker
             FunctionContext context,
             CancellationToken cancellationToken)
         {
-            _logger.LogInformation("C# EventHub HandleCancellationCleanup trigger function processing a request.");
+            _logger.LogInformation("C# EventHub {functionName} trigger function processing a request.", nameof(HandleCancellationCleanup));
 
             foreach (var message in messages)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    _logger.LogInformation("A cancellation token was received. Taking precautionary actions.");
+                    _logger.LogInformation("A cancellation token was received, taking precautionary actions.");
                     // Take precautions like noting how far along you are with processing the batch
-                    _logger.LogInformation("Precautionary activities --complete--.");
+                    _logger.LogInformation("Precautionary activities complete.");
                     break;
                 }
 
                 await Task.Delay(6000); // task delay to simulate message processing
-                _logger.LogInformation($"Message: {message} was processed.");
+                _logger.LogInformation("Message '{msg}' was processed.", message);
             }
         }
     }

--- a/samples/Net7Worker/HttpFunction.cs
+++ b/samples/Net7Worker/HttpFunction.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -23,31 +20,15 @@ namespace Net7Worker
         [Function(nameof(HttpFunction))]
         public HttpResponseData Run(
             [HttpTrigger(AuthorizationLevel.Anonymous,"get", "post", Route = null)] HttpRequestData req,
-            FunctionContext executionContext,
-            CancellationToken cancellationToken)
+            FunctionContext executionContext)
         {
-            _logger.LogInformation("C# HTTP trigger function processed a request.");
+            _logger.LogInformation("C# HTTP trigger function processing a request.");
 
-            try
-            {
-                cancellationToken.ThrowIfCancellationRequested();
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
+            response.WriteString("Welcome to Azure Functions - Isolated .NET 7!");
 
-                var response = req.CreateResponse(HttpStatusCode.OK);
-                response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
-                response.WriteString("Welcome to Azure Functions - Isolated .NET 7!");
-                return response;
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogInformation("A cancellation token was received. Taking precautionary actions.");
-
-                // Take precautions like noting how far along you are with processing the batch
-
-                var response = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
-                response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
-                response.WriteString("Invocation cancelled, precautionary actions taken.");
-                return response;
-            }
+            return response;
         }
     }
 }

--- a/samples/Net7Worker/Net7Worker.csproj
+++ b/samples/Net7Worker/Net7Worker.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="5.1.0" />

--- a/samples/Net7Worker/Net7Worker.csproj
+++ b/samples/Net7Worker/Net7Worker.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/Net7Worker/README.md
+++ b/samples/Net7Worker/README.md
@@ -1,3 +1,28 @@
 # .NET Framework Worker
 
 This sample demonstrates how to create a .NET 7 project using the Isolated model.
+
+## Function Samples
+
+### HTTPFunction.cs
+
+Demonstrates basic HTTP trigger function.
+
+### EventHubCancellationToken.cs
+
+Demonstrates how to use the Cancellation Token parameter binding in the context of an
+EventHub trigger sample where we are processing multiple messages.
+
+- `ThrowOnCancellation`
+  - shows how to throw when a cancellation token is received
+  - the status of the function will be "Cancelled"
+- `HandleCancellationCleanup`
+  - shows how to take precautionary/clean up actions if a cancellation token is received
+  - the status of the function will be "Successful"
+
+Cancellation tokens are signalled by the platform, the use cases supported today are:
+
+1. Host shutdown
+2. Function timeout
+   1. You can try this out by setting function timeout to 5 seconds in
+      the host.json file: `"functionTimeout": "00:00:05"`

--- a/samples/Net7Worker/README.md
+++ b/samples/Net7Worker/README.md
@@ -22,7 +22,7 @@ EventHub trigger sample where we are processing multiple messages.
 
 Cancellation tokens are signalled by the platform, the use cases supported today are:
 
-1. Host shutdown
-2. Function timeout
+1. Sudden host shutdown or host restart
+2. Function timeout (where function execution has exceeded the timeout limit)
    1. You can try this out by setting function timeout to 5 seconds in
       the host.json file: `"functionTimeout": "00:00:05"`

--- a/samples/Net7Worker/local.settings.json
+++ b/samples/Net7Worker/local.settings.json
@@ -3,6 +3,6 @@
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "EventHubConnection": ""
+    "EventHubConnection": "<EventHubConnectionString>"
   }
 }

--- a/samples/Net7Worker/local.settings.json
+++ b/samples/Net7Worker/local.settings.json
@@ -2,6 +2,7 @@
   "IsEncrypted": false,
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "AzureWebJobsStorage": "UseDevelopmentStorage=true"
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "EventHubConnection": ""
   }
 }

--- a/samples/NetFxWorker/NetFxWorker.csproj
+++ b/samples/NetFxWorker/NetFxWorker.csproj
@@ -8,7 +8,7 @@
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Cancellation tokens are signaled by the platform when there is a sudden restart or shutdown of the host, or when a function invocation exceeds its timeout limit.

Also using this PR to bump all samples to the latest worker version