### PR TITLE
[SourceGen] Add support for overriding binding property name

### DIFF
--- a/sdk/Sdk.Generators/Constants.cs
+++ b/sdk/Sdk.Generators/Constants.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
         internal const string FunctionNameType = "Microsoft.Azure.Functions.Worker.FunctionAttribute";
         internal const string HttpResponseType = "Microsoft.Azure.Functions.Worker.Http.HttpResponseData";
         internal const string EventHubsTriggerType = "Microsoft.Azure.Functions.Worker.EventHubTriggerAttribute";
+        internal const string BindingPropertyNameAttributeType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.BindingPropertyNameAttribute";
 
         // System types
         internal const string IEnumerableType = "System.Collections.IEnumerable";

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 // that the constructor names would match the property names
                 for (int i = 0; i < attributeData.ConstructorArguments.Length; i++)
                 {
-                    string argumentName = attribMethodSymbol.Parameters[i].Name;// going to have to do something here to get the attribute on the parameter?
+                    string argumentName = attribMethodSymbol.Parameters[i].Name;
 
                     if (TryOverrideBindingName(attributeData.AttributeClass, argumentName, out string? newName))
                     {

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -574,9 +574,8 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     {
                         var bindingNameAttrList = prop.GetAttributes().Where(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, bindingPropertyNameSymbol));
 
-                        if (bindingNameAttrList.SingleOrDefault() is { } bindingNameAttr)
+                        if (bindingNameAttrList.SingleOrDefault() is { } bindingNameAttr) // there will only be one BindingAttributeName attribute b/c there can't be duplicate attributes on a piece of syntax
                         {
-                            bindingNameAttr = bindingNameAttrList.FirstOrDefault(); // there will only be one BindingAttributeName attribute b/c there can't be duplicate attributes on a piece of syntax
                             argumentName = bindingNameAttr.ConstructorArguments.First().Value!.ToString(); // there is only one constructor argument for this binding attribute (the binding name override)
                         }
                     }

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -586,7 +586,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                         if (bindingNameAttrList.Count() > 0)
                         {
                             var bindingNameAttr = bindingNameAttrList.FirstOrDefault(); // there will only be one BindingAttributeName attribute b/c there can't be duplicate attributes on a piece of syntax
-                            newName = bindingNameAttr.ConstructorArguments.First().ToString(); // there is only one constructor argument for this binding attribute (the binding name override)
+                            newName = bindingNameAttr.ConstructorArguments.First().Value!.ToString(); // there is only one constructor argument for this binding attribute (the binding name override)
                             return true;
                         }
 

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Functions.Worker
                 name = '$return',
                 type = 'Blob',
                 direction = 'Out',
-                blobPath = 'container1/hello.txt',
+                path = 'container1/hello.txt',
                 Connection = 'MyOtherConnection',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.Functions.Worker
                 name = 'blob',
                 type = 'BlobTrigger',
                 direction = 'In',
-                blobPath = 'container2/%file%',
+                path = 'container2/%file%',
                 dataType = 'String',
             };
             var Function1binding1JSON = JsonSerializer.Serialize(Function1binding1);

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Functions.Worker
                 name = '$return',
                 type = 'Blob',
                 direction = 'Out',
-                path = 'container1/hello.txt',
+                blobPath = 'container1/hello.txt',
                 Connection = 'MyOtherConnection',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1087

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

[Example usage](https://github.com/Azure/azure-functions-dotnet-worker/blob/2b7986b81eb72da91468291b80a9cd51c470eb97/extensions/Worker.Extensions.Storage.Blobs/src/BlobTriggerAttribute.cs#L30) of the attribute that overrides binding property names. 

On the issue thread you can find a comment on the [design assumptions](https://github.com/Azure/azure-functions-dotnet-worker/issues/1087#issuecomment-1282658117). Given the limitations of Roslyn analyzers, this design relies on the convention that attribute constructor parameter names will match the name of the property they are assigned to (matching is NOT case-sensitive).