### PR TITLE
[SourceGen] Handle default values in binding attributes

### DIFF
--- a/sdk/Sdk.Generators/Constants.cs
+++ b/sdk/Sdk.Generators/Constants.cs
@@ -11,8 +11,12 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
         internal const string FunctionNameType = "Microsoft.Azure.Functions.Worker.FunctionAttribute";
         internal const string HttpResponseType = "Microsoft.Azure.Functions.Worker.Http.HttpResponseData";
         internal const string EventHubsTriggerType = "Microsoft.Azure.Functions.Worker.EventHubTriggerAttribute";
+<<<<<<< HEAD
         internal const string BindingPropertyNameAttributeType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.BindingPropertyNameAttribute";
         internal const string DefaultValueType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions";
+=======
+        internal const string DefaultValueType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.DefaultValueAttribute";
+>>>>>>> 8d65547 (resolve comment, add event hubs check)
 
         // System types
         internal const string IEnumerableType = "System.Collections.IEnumerable";

--- a/sdk/Sdk.Generators/Constants.cs
+++ b/sdk/Sdk.Generators/Constants.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
         internal const string HttpResponseType = "Microsoft.Azure.Functions.Worker.Http.HttpResponseData";
         internal const string EventHubsTriggerType = "Microsoft.Azure.Functions.Worker.EventHubTriggerAttribute";
         internal const string BindingPropertyNameAttributeType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.BindingPropertyNameAttribute";
+        internal const string DefaultValueType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions";
 
         // System types
         internal const string IEnumerableType = "System.Collections.IEnumerable";

--- a/sdk/Sdk.Generators/Constants.cs
+++ b/sdk/Sdk.Generators/Constants.cs
@@ -11,12 +11,8 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
         internal const string FunctionNameType = "Microsoft.Azure.Functions.Worker.FunctionAttribute";
         internal const string HttpResponseType = "Microsoft.Azure.Functions.Worker.Http.HttpResponseData";
         internal const string EventHubsTriggerType = "Microsoft.Azure.Functions.Worker.EventHubTriggerAttribute";
-<<<<<<< HEAD
         internal const string BindingPropertyNameAttributeType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.BindingPropertyNameAttribute";
-        internal const string DefaultValueType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions";
-=======
         internal const string DefaultValueType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.DefaultValueAttribute";
->>>>>>> 8d65547 (resolve comment, add event hubs check)
 
         // System types
         internal const string IEnumerableType = "System.Collections.IEnumerable";

--- a/sdk/Sdk.Generators/Extensions/StringExtensions.cs
+++ b/sdk/Sdk.Generators/Extensions/StringExtensions.cs
@@ -38,8 +38,16 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 return string.Empty;
             }
 
-            // Return char and concat substring.
-            return char.ToUpper(str[0]) + str.Substring(1);
+            if (!char.IsUpper(str[0]))
+            {
+                // Return char and concat substring.
+                return char.ToUpper(str[0]) + str.Substring(1);
+            }
+            else
+            {
+                return str;
+            }
+
         }
     }
 }

--- a/sdk/Sdk.Generators/Extensions/StringExtensions.cs
+++ b/sdk/Sdk.Generators/Extensions/StringExtensions.cs
@@ -29,5 +29,17 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
             return result; 
         }
+
+        public static string UppercaseFirst(this string str)
+        {
+            // Check for empty string.
+            if (string.IsNullOrEmpty(str))
+            {
+                return string.Empty;
+            }
+
+            // Return char and concat substring.
+            return char.ToUpper(str[0]) + str.Substring(1);
+        }
     }
 }

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -523,10 +523,9 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
                     if (defaultValAttrList.SingleOrDefault() is { } defaultValAttr) // list will only be of size one b/c there cannot be duplicates of an attribute on one piece of syntax
                     {
-                        // only one constructor argument in DefaultValue attribute
                         if (!attrProperties.Keys.Any(a => string.Equals(a, default, StringComparison.OrdinalIgnoreCase))) // check if this property has been assigned a value already in constructor or named args
                         {
-                            attrProperties[member.Name.ToString()] = defaultValAttr.ConstructorArguments.SingleOrDefault().Value!.ToString(); // add property with default value to func metadata, using binding property as the arg name
+                            attrProperties[member.Name.ToString()] = defaultValAttr.ConstructorArguments.SingleOrDefault().Value!.ToString(); // only one constructor arg in DefaultValue attribute (the default value)
                         }
                     }
                 }
@@ -622,7 +621,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     }
                 }
 
-                // Check the default value of IsBatched, if it is by default false, we find the data type and return
+                // Check the default value of IsBatched
                 var eventHubsAttr = attribute.AttributeClass;
                 var isBatchedProp = eventHubsAttr!.GetMembers().Where(m => string.Equals(m.Name, Constants.IsBatchedKey, StringComparison.OrdinalIgnoreCase)).SingleOrDefault();
                 AttributeData defaultValAttr = isBatchedProp.GetAttributes().Where(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, Compilation.GetTypeByMetadataName(Constants.DefaultValueType))).SingleOrDefault();

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -534,7 +534,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     }
                 }
 
-                    return true;
+                return true;
             }
 
             private bool TryLoadConstructorArguments(AttributeData attributeData, IDictionary<string, object?> dict, Location? attribLocation)

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                             
                             if (dataType is not DataType.Undefined)
                             {
-                                bindingDict!.Add("dataType", FormatObject(Enum.GetName(typeof(DataType), dataType)));
+                                bindingDict!.Add("DataType", FormatObject(Enum.GetName(typeof(DataType), dataType)));
                             }
 
                             // special handling for EventHubsTrigger - we need to define a property called "Cardinality"
@@ -433,9 +433,9 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
             {
                 var httpBinding = new Dictionary<string, string>();
 
-                httpBinding.Add("name", FormatObject(returnBindingName));
-                httpBinding.Add("type", FormatObject("http"));
-                httpBinding.Add("direction", FormatObject("Out"));
+                httpBinding.Add("Name", FormatObject(returnBindingName));
+                httpBinding.Add("Type", FormatObject("http"));
+                httpBinding.Add("Direction", FormatObject("Out"));
 
                 return httpBinding;
             }
@@ -460,9 +460,9 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
                 var bindingCount = attributeProperties!.Count + 3;
                 bindings = new Dictionary<string, string>(capacity: bindingCount);
-                bindings.Add("name", FormatObject(bindingName));
-                bindings.Add("type", FormatObject(bindingType));
-                bindings.Add("direction", FormatObject(bindingDirection));
+                bindings.Add("Name", FormatObject(bindingName));
+                bindings.Add("Type", FormatObject(bindingType));
+                bindings.Add("Direction", FormatObject(bindingDirection));
 
                 // Add additional bindingInfo to the anonymous type because some functions have more properties than others
                 foreach (var prop in attributeProperties!) // attributeProperties won't be null here b/c we would've exited this method earlier if it was during TryGetAttributeProperties check
@@ -472,14 +472,14 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     if (prop.Value?.GetType().IsArray ?? false)
                     {
                         string arr = FormatArray((IEnumerable)prop.Value);
-                        bindings[propertyName] = arr;
+                        bindings[propertyName.UppercaseFirst()] = arr; // Uppercase first to use PascalCase in generated file's anonymous type
                     }
                     else
                     {
                         bool isEnum = string.Equals(prop.Key, "authLevel", StringComparison.OrdinalIgnoreCase); // prop keys come from Azure Functions defined attributes so we can check directly for authLevel
 
                         var propertyValue = FormatObject(prop.Value, isEnum);
-                        bindings[propertyName] = propertyValue;
+                        bindings[propertyName.UppercaseFirst()] = propertyValue;
                     }
                 }
 
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                         }
                         else
                         {
-                            attrProperties[namedArgument.Key] = namedArgument.Value.Value;
+                            attrProperties[namedArgument.Key.UppercaseFirst()] = namedArgument.Value.Value;
                         }
                     }
                 }
@@ -534,7 +534,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                         }
                         else if (!attrProperties.Keys.Any(a => string.Equals(a, argName, StringComparison.OrdinalIgnoreCase))) // check if this property has been assigned a value already in constructor or named args
                         {
-                            attrProperties[argName] = arg;
+                            attrProperties[argName.UppercaseFirst()] = arg;
                         }
                     }
                 }

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 {
                     if (namedArgument.Value.Value != null)
                     {
-                        if (String.Equals(namedArgument.Key, Constants.IsBatchedKey) && !attrProperties.Keys.Contains("Cardinality"))
+                        if (string.Equals(namedArgument.Key, Constants.IsBatchedKey) && !attrProperties.Keys.Any(k => string.Equals(k, "Cardinality", StringComparison.OrdinalIgnoreCase)))
                         {
                             var argValue = (bool)namedArgument.Value.Value; // isBatched only takes in booleans and the generator will parse it as a bool so we can type cast this to use in the next line
 
@@ -523,9 +523,22 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
                     if (defaultValAttrList.SingleOrDefault() is { } defaultValAttr) // list will only be of size one b/c there cannot be duplicates of an attribute on one piece of syntax
                     {
-                        if (!attrProperties.Keys.Any(a => string.Equals(a, default, StringComparison.OrdinalIgnoreCase))) // check if this property has been assigned a value already in constructor or named args
+                        var argName = member.Name;
+                        var argDefaultVal = defaultValAttr.ConstructorArguments.SingleOrDefault().Value!.ToString(); // only one constructor arg in DefaultValue attribute (the default value)
+                        
+                        if (string.Equals(argName, Constants.IsBatchedKey))
                         {
-                            attrProperties[member.Name.ToString()] = defaultValAttr.ConstructorArguments.SingleOrDefault().Value!.ToString(); // only one constructor arg in DefaultValue attribute (the default value)
+                            if (!attrProperties.Keys.Contains("Cardinality"))
+                            {
+                                attrProperties["Cardinality"] = string.Equals(argDefaultVal, "true", StringComparison.OrdinalIgnoreCase) ? "Many" : "One";
+                            }
+                        }
+                        else
+                        {
+                            if (!attrProperties.Keys.Any(a => string.Equals(a, default, StringComparison.OrdinalIgnoreCase))) // check if this property has been assigned a value already in constructor or named args
+                            {
+                                attrProperties[argName] = argDefaultVal; 
+                            }
                         }
                     }
                 }

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                             // special handling for EventHubsTrigger - we need to define a property called "Cardinality"
                             if (validEventHubs)
                             {
-                                if (!bindingDict!.Keys.Contains("Cardinality"))
+                                if (!bindingDict!.ContainsKey("Cardinality"))
                                 {
                                     bindingDict["Cardinality"] = cardinality is Cardinality.Many ? FormatObject("Many") : FormatObject("One");
                                 }
@@ -503,7 +503,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 {
                     if (namedArgument.Value.Value != null)
                     {
-                        if (String.Equals(namedArgument.Key, Constants.IsBatchedKey) && !attrProperties.Keys.Contains("Cardinality"))
+                        if (string.Equals(namedArgument.Key, Constants.IsBatchedKey) && !attrProperties.ContainsKey("Cardinality"))
                         {
                             var argValue = (bool)namedArgument.Value.Value; // isBatched only takes in booleans and the generator will parse it as a bool so we can type cast this to use in the next line
 
@@ -525,7 +525,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     {
                         var argName = member.Name;
                         object arg = defaultValAttr.ConstructorArguments.SingleOrDefault().Value!; // only one constructor arg in DefaultValue attribute (the default value)
-                        if ( arg is bool b && string.Equals(argName, Constants.IsBatchedKey))
+                        if (arg is bool b && string.Equals(argName, Constants.IsBatchedKey))
                         {
                             if (!attrProperties.Keys.Contains("Cardinality"))
                             {
@@ -635,7 +635,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 var isBatchedProp = eventHubsAttr!.GetMembers().Where(m => string.Equals(m.Name, Constants.IsBatchedKey, StringComparison.OrdinalIgnoreCase)).SingleOrDefault();
                 AttributeData defaultValAttr = isBatchedProp.GetAttributes().Where(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, Compilation.GetTypeByMetadataName(Constants.DefaultValueType))).SingleOrDefault();
                 var defaultVal = defaultValAttr.ConstructorArguments.SingleOrDefault().Value!.ToString(); // there is only one constructor arg, the default value
-                if (!bool.Parse(defaultVal))
+                if (!bool.TryParse(defaultVal, out bool b) || !b)
                 {
                     dataType = GetDataType(parameterSymbol.Type);
                     cardinality = Cardinality.One;

--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -97,7 +97,7 @@ if (Test-Path $output)
   Remove-Item $output -Recurse -Force -ErrorAction Ignore
 }
 
-.\tools\devpack.ps1 -E2E -AdditionalPackArgs @("-c","Release")
+.\tools\devpack.ps1 -E2E -AdditionalPackArgs @("-c","Release", "-p:FunctionsRuntimeVersion=$FunctionsRuntimeVersion")
 
 if ($SkipStorageEmulator -And $SkipCosmosDBEmulator)
 {

--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -97,7 +97,7 @@ if (Test-Path $output)
   Remove-Item $output -Recurse -Force -ErrorAction Ignore
 }
 
-.\tools\devpack.ps1 -E2E -AdditionalPackArgs @("-c","Release", "-p:FunctionsRuntimeVersion=$FunctionsRuntimeVersion")
+.\tools\devpack.ps1 -E2E -AdditionalPackArgs @("-c","Release")
 
 if ($SkipStorageEmulator -And $SkipCosmosDBEmulator)
 {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
@@ -230,7 +230,8 @@ namespace Microsoft.Azure.Functions.Worker
                 type = ""EventHubTrigger"",
                 direction = ""In"",
                 eventHubName = ""test"",
-                Connection = ""EventHubConnectionAppSetting"","
+                Connection = ""EventHubConnectionAppSetting"",
+                Cardinality = ""Many"","
                 );
 
                 if (!string.Equals(dataType, ""))
@@ -240,7 +241,6 @@ namespace Microsoft.Azure.Functions.Worker
                 }
 
                 expectedOutputBuilder.Append(@"
-                Cardinality = ""Many"",
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
@@ -476,8 +476,8 @@ namespace Microsoft.Azure.Functions.Worker
                 direction = 'In',
                 eventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
-                dataType = 'String',
                 Cardinality = 'Many',
+                dataType = 'String',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
@@ -497,8 +497,8 @@ namespace Microsoft.Azure.Functions.Worker
                 direction = 'In',
                 eventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
-                dataType = 'String',
                 Cardinality = 'Many',
+                dataType = 'String',
             };
             var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
             Function1RawBindings.Add(Function1binding0JSON);
@@ -518,8 +518,8 @@ namespace Microsoft.Azure.Functions.Worker
                 direction = 'In',
                 eventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
-                dataType = 'String',
                 Cardinality = 'Many',
+                dataType = 'String',
             };
             var Function2binding0JSON = JsonSerializer.Serialize(Function2binding0);
             Function2RawBindings.Add(Function2binding0JSON);
@@ -539,8 +539,8 @@ namespace Microsoft.Azure.Functions.Worker
                 direction = 'In',
                 eventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
-                dataType = 'String',
                 Cardinality = 'Many',
+                dataType = 'String',
             };
             var Function3binding0JSON = JsonSerializer.Serialize(Function3binding0);
             Function3RawBindings.Add(Function3binding0JSON);
@@ -657,8 +657,8 @@ namespace Microsoft.Azure.Functions.Worker
                 direction = 'In',
                 eventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
-                dataType = 'Binary',
                 Cardinality = 'Many',
+                dataType = 'Binary',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
@@ -678,8 +678,8 @@ namespace Microsoft.Azure.Functions.Worker
                 direction = 'In',
                 eventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
-                dataType = 'Binary',
                 Cardinality = 'Many',
+                dataType = 'Binary',
             };
             var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
             Function1RawBindings.Add(Function1binding0JSON);

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
@@ -97,17 +97,17 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = ""input"",
-                type = ""EventHubTrigger"",
-                direction = ""In"",
-                eventHubName = ""test"",
+                Name = ""input"",
+                Type = ""EventHubTrigger"",
+                Direction = ""In"",
+                EventHubName = ""test"",
                 Connection = ""EventHubConnectionAppSetting"",
                 Cardinality = ""One"",");
              
                 if(!string.Equals(dataType, ""))
                 {
                     expectedOutputBuilder.Append(@"
-                dataType = """ + dataType + "\",");
+                DataType = """ + dataType + "\",");
                 }
 
                 expectedOutputBuilder.Append(@"
@@ -226,10 +226,10 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = ""input"",
-                type = ""EventHubTrigger"",
-                direction = ""In"",
-                eventHubName = ""test"",
+                Name = ""input"",
+                Type = ""EventHubTrigger"",
+                Direction = ""In"",
+                EventHubName = ""test"",
                 Connection = ""EventHubConnectionAppSetting"",
                 Cardinality = ""Many"","
                 );
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.Functions.Worker
                 if (!string.Equals(dataType, ""))
                 {
                     expectedOutputBuilder.Append(@"
-                dataType = """ + dataType + "\",");
+                DataType = """ + dataType + "\",");
                 }
 
                 expectedOutputBuilder.Append(@"
@@ -327,10 +327,10 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
             };
@@ -471,13 +471,13 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
-                dataType = 'String',
+                DataType = 'String',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
@@ -492,13 +492,13 @@ namespace Microsoft.Azure.Functions.Worker
             metadataList.Add(Function0);
             var Function1RawBindings = new List<string>();
             var Function1binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
-                dataType = 'String',
+                DataType = 'String',
             };
             var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
             Function1RawBindings.Add(Function1binding0JSON);
@@ -513,13 +513,13 @@ namespace Microsoft.Azure.Functions.Worker
             metadataList.Add(Function1);
             var Function2RawBindings = new List<string>();
             var Function2binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
-                dataType = 'String',
+                DataType = 'String',
             };
             var Function2binding0JSON = JsonSerializer.Serialize(Function2binding0);
             Function2RawBindings.Add(Function2binding0JSON);
@@ -534,13 +534,13 @@ namespace Microsoft.Azure.Functions.Worker
             metadataList.Add(Function2);
             var Function3RawBindings = new List<string>();
             var Function3binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
-                dataType = 'String',
+                DataType = 'String',
             };
             var Function3binding0JSON = JsonSerializer.Serialize(Function3binding0);
             Function3RawBindings.Add(Function3binding0JSON);
@@ -652,13 +652,13 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
-                dataType = 'Binary',
+                DataType = 'Binary',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
@@ -673,13 +673,13 @@ namespace Microsoft.Azure.Functions.Worker
             metadataList.Add(Function0);
             var Function1RawBindings = new List<string>();
             var Function1binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
-                dataType = 'Binary',
+                DataType = 'Binary',
             };
             var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
             Function1RawBindings.Add(Function1binding0JSON);
@@ -778,10 +778,10 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
             };
@@ -798,10 +798,10 @@ namespace Microsoft.Azure.Functions.Worker
             metadataList.Add(Function0);
             var Function1RawBindings = new List<string>();
             var Function1binding0 = new {
-                name = 'input',
-                type = 'EventHubTrigger',
-                direction = 'In',
-                eventHubName = 'test',
+                Name = 'input',
+                Type = 'EventHubTrigger',
+                Direction = 'In',
+                EventHubName = 'test',
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
             };

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/ExtensionsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/ExtensionsTests.cs
@@ -33,6 +33,15 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 Assert.Equal(expectedOutput, actual);
             }
+
+            [Theory]
+            [InlineData("isBatched", "IsBatched")]
+            [InlineData("MyProperty", "MyProperty")]
+            [InlineData("myproperty", "Myproperty")]
+            public void UpperCaseFirstLetter(string input, string expectedOutput)
+            {
+                Assert.Equal(input.UppercaseFirst(), expectedOutput);
+            }
         }
     }
 }

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
@@ -79,18 +79,18 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'req',
-                type = 'HttpTrigger',
-                direction = 'In',
-                authLevel = (AuthorizationLevel)0,
-                methods = new List<string> { 'get','post' },
+                Name = 'req',
+                Type = 'HttpTrigger',
+                Direction = 'In',
+                AuthLevel = (AuthorizationLevel)0,
+                Methods = new List<string> { 'get','post' },
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
-                name = '$return',
-                type = 'http',
-                direction = 'Out',
+                Name = '$return',
+                Type = 'http',
+                Direction = 'Out',
             };
             var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
             Function0RawBindings.Add(Function0binding1JSON);
@@ -175,11 +175,11 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'req',
-                type = 'HttpTrigger',
-                direction = 'In',
-                authLevel = (AuthorizationLevel)4,
-                methods = new List<string> { 'get','post' },
+                Name = 'req',
+                Type = 'HttpTrigger',
+                Direction = 'In',
+                AuthLevel = (AuthorizationLevel)4,
+                Methods = new List<string> { 'get','post' },
                 Route = ""/api2"",
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
@@ -270,18 +270,18 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'req',
-                type = 'HttpTrigger',
-                direction = 'In',
-                methods = new List<string> { 'get' },
-                dataType = 'String',
+                Name = 'req',
+                Type = 'HttpTrigger',
+                Direction = 'In',
+                Methods = new List<string> { 'get' },
+                DataType = 'String',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
-                name = ""httpResponseProp"",
-                type = ""http"",
-                direction = ""Out"",
+                Name = ""httpResponseProp"",
+                Type = ""http"",
+                Direction = ""Out"",
             };
             var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
             Function0RawBindings.Add(Function0binding1JSON);

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
@@ -102,27 +102,27 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'req',
-                type = 'HttpTrigger',
-                direction = 'In',
-                authLevel = (AuthorizationLevel)0,
-                methods = new List<string> { 'get','post' },
+                Name = 'req',
+                Type = 'HttpTrigger',
+                Direction = 'In',
+                AuthLevel = (AuthorizationLevel)0,
+                Methods = new List<string> { 'get','post' },
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
-                name = 'Name',
-                type = 'Queue',
-                direction = 'Out',
-                queueName = 'functionstesting2',
+                Name = 'Name',
+                Type = 'Queue',
+                Direction = 'Out',
+                QueueName = 'functionstesting2',
                 Connection = 'AzureWebJobsStorage',
             };
             var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0binding2 = new {
-                name = 'HttpResponse',
-                type = 'http',
-                direction = 'Out',
+                Name = 'HttpResponse',
+                Type = 'http',
+                Direction = 'Out',
             };
             var Function0binding2JSON = JsonSerializer.Serialize(Function0binding2);
             Function0RawBindings.Add(Function0binding2JSON);
@@ -233,37 +233,37 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'req',
-                type = 'HttpTrigger',
-                direction = 'In',
-                authLevel = (AuthorizationLevel)0,
-                methods = new List<string> { 'get','post' },
+                Name = 'req',
+                Type = 'HttpTrigger',
+                Direction = 'In',
+                AuthLevel = (AuthorizationLevel)0,
+                Methods = new List<string> { 'get','post' },
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
-                name = 'myBlob',
-                type = 'Blob',
-                direction = 'In',
-                blobPath = 'test-samples/sample1.txt',
+                Name = 'myBlob',
+                Type = 'Blob',
+                Direction = 'In',
+                BlobPath = 'test-samples/sample1.txt',
                 Connection = 'AzureWebJobsStorage',
-                dataType = 'String',
+                DataType = 'String',
             };
             var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0binding2 = new {
-                name = 'Book',
-                type = 'Queue',
-                direction = 'Out',
-                queueName = 'functionstesting2',
+                Name = 'Book',
+                Type = 'Queue',
+                Direction = 'Out',
+                QueueName = 'functionstesting2',
                 Connection = 'AzureWebJobsStorage',
             };
             var Function0binding2JSON = JsonSerializer.Serialize(Function0binding2);
             Function0RawBindings.Add(Function0binding2JSON);
             var Function0binding3 = new {
-                name = 'HttpResponse',
-                type = 'http',
-                direction = 'Out',
+                Name = 'HttpResponse',
+                Type = 'http',
+                Direction = 'Out',
             };
             var Function0binding3JSON = JsonSerializer.Serialize(Function0binding3);
             Function0RawBindings.Add(Function0binding3JSON);
@@ -361,18 +361,18 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'req',
-                type = 'HttpTrigger',
-                direction = 'In',
-                authLevel = (AuthorizationLevel)0,
-                methods = new List<string> { 'get' },
+                Name = 'req',
+                Type = 'HttpTrigger',
+                Direction = 'In',
+                AuthLevel = (AuthorizationLevel)0,
+                Methods = new List<string> { 'get' },
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
-                name = '$return',
-                type = 'http',
-                direction = 'Out',
+                Name = '$return',
+                Type = 'http',
+                Direction = 'Out',
             };
             var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
             Function0RawBindings.Add(Function0binding1JSON);
@@ -457,10 +457,10 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'timer',
-                type = 'TimerTrigger',
-                direction = 'In',
-                schedule = '0 0 0 * * *',
+                Name = 'timer',
+                Type = 'TimerTrigger',
+                Direction = 'In',
+                Schedule = '0 0 0 * * *',
                 RunOnStartup = 'False',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
@@ -547,19 +547,19 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = 'myReq',
-                type = 'HttpTrigger',
-                direction = 'In',
-                authLevel = (AuthorizationLevel)4,
-                methods = new List<string> { 'get','Post' },
+                Name = 'myReq',
+                Type = 'HttpTrigger',
+                Direction = 'In',
+                AuthLevel = (AuthorizationLevel)4,
+                Methods = new List<string> { 'get','Post' },
                 Route = '/api2',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
-                name = 'Result',
-                type = 'http',
-                direction = 'Out',
+                Name = 'Result',
+                Type = 'http',
+                Direction = 'Out',
             };
             var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
             Function0RawBindings.Add(Function0binding1JSON);

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -86,19 +86,19 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = '$return',
-                type = 'Queue',
-                direction = 'Out',
-                queueName = 'test-output-dotnet-isolated',
+                Name = '$return',
+                Type = 'Queue',
+                Direction = 'Out',
+                QueueName = 'test-output-dotnet-isolated',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
-                name = 'message',
-                type = 'QueueTrigger',
-                direction = 'In',
-                queueName = 'test-input-dotnet-isolated',
-                dataType = 'String',
+                Name = 'message',
+                Type = 'QueueTrigger',
+                Direction = 'In',
+                QueueName = 'test-input-dotnet-isolated',
+                DataType = 'String',
             };
             var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
             Function0RawBindings.Add(Function0binding1JSON);
@@ -194,21 +194,21 @@ namespace Microsoft.Azure.Functions.Worker
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
-                name = '$return',
-                type = 'Blob',
-                direction = 'Out',
-                blobPath = 'container1/hello.txt',
+                Name = '$return',
+                Type = 'Blob',
+                Direction = 'Out',
+                BlobPath = 'container1/hello.txt',
                 Connection = 'MyOtherConnection',
             };
             var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
-                name = 'queuePayload',
-                type = 'QueueTrigger',
-                direction = 'In',
-                queueName = 'queueName',
+                Name = 'queuePayload',
+                Type = 'QueueTrigger',
+                Direction = 'In',
+                QueueName = 'queueName',
                 Connection = 'MyConnection',
-                dataType = 'String',
+                DataType = 'String',
             };
             var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
             Function0RawBindings.Add(Function0binding1JSON);
@@ -223,19 +223,19 @@ namespace Microsoft.Azure.Functions.Worker
             metadataList.Add(Function0);
             var Function1RawBindings = new List<string>();
             var Function1binding0 = new {
-                name = '$return',
-                type = 'Queue',
-                direction = 'Out',
-                queueName = 'queue2',
+                Name = '$return',
+                Type = 'Queue',
+                Direction = 'Out',
+                QueueName = 'queue2',
             };
             var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
             Function1RawBindings.Add(Function1binding0JSON);
             var Function1binding1 = new {
-                name = 'blob',
-                type = 'BlobTrigger',
-                direction = 'In',
-                path = 'container2/%file%',
-                dataType = 'String',
+                Name = 'blob',
+                Type = 'BlobTrigger',
+                Direction = 'In',
+                Path = 'container2/%file%',
+                DataType = 'String',
             };
             var Function1binding1JSON = JsonSerializer.Serialize(Function1binding1);
             Function1RawBindings.Add(Function1binding1JSON);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1101 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

Currently, only EventHubsTrigger has a property with "DefaultValue" on it. This PR additionally standardizes casing for bindings on the source-generated file by choosing PascalCase when creating fields on the anonymous types we represent bindings with (before serializing them). 

Values taken from properties with DefaultValue attributes keep their casing, and values whose names come from constructor parameters will uppercase the first letter. 