### PR TITLE
Introducing IInputConverterProvider interface 

### DIFF
--- a/extensions/Worker.Extensions.Abstractions/release_notes.md
+++ b/extensions/Worker.Extensions.Abstractions/release_notes.md
@@ -1,0 +1,5 @@
+## Release notes
+<!-- Please add your release notes in the following format:
+- My change description (#PR/#issue)
+-->
+- Introducing `IInputConverterProvider` interface (#1121)

--- a/extensions/Worker.Extensions.Abstractions/src/IInputConverterProvider.cs
+++ b/extensions/Worker.Extensions.Abstractions/src/IInputConverterProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Abstractions
+{
+    /// <summary>
+    /// Provides information about which input converters to be used.
+    /// </summary>
+    /// <remarks>
+    /// Input bindings/trigger binding shall implement this interface to provide information
+    /// about which specific converters to be used when input conversion is performed for that binding.
+    /// </remarks>
+    public interface IInputConverterProvider
+    {
+        /// <summary>
+        /// Gets an ordered collection of <see cref="System.Type"/> instances representing the converters to be used.
+        /// Each entry in the collection should be the <see cref="System.Type"/> of a class which implements
+        /// the Microsoft.Azure.Functions.Worker.Converters.IInputConverter interface.
+        /// </summary>
+        public IList<Type> ConverterTypes { get; }
+    }
+}

--- a/extensions/Worker.Extensions.Abstractions/src/Worker.Extensions.Abstractions.csproj
+++ b/extensions/Worker.Extensions.Abstractions/src/Worker.Extensions.Abstractions.csproj
@@ -6,7 +6,8 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Abstractions</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Abstractions</RootNamespace>
     <Description>Abstractions for Azure Functions .NET Worker</Description>
-    <MinorProductVersion>1</MinorProductVersion>
+    <MinorProductVersion>2</MinorProductVersion>
+    <VersionSuffix>-preview1</VersionSuffix>
   </PropertyGroup>
 
   <Import Project="..\..\..\build\Common.props" />


### PR DESCRIPTION
Introducing `IInputConverterProvider` interface  to provide information about what converters to be used for bindings. This will allow binding authors to provide information about what specific converter to be used during the input conversion of that binding entry.

This is part 1 of the fix for #1121. I will have a follow up PR which consumes this version of the `Microsoft.Azure.Functions.Worker.Extensions.Abstractions` nuget package in the Grpc layer and use it.

