### PR TITLE
Initialize new GrpcModelBindingData & bump Sdk to 1.8.0 preview 3

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,3 +2,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
+
+- Bump protobuf version to v1.5.9-protofile (#1148)

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>8</MinorProductVersion>
-    <VersionSuffix>-preview2</VersionSuffix>
+    <VersionSuffix>-preview3</VersionSuffix>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -2,3 +2,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
+
+- Support sdk-type binding reference type (#1107)

--- a/src/DotNetWorker.Grpc/Features/GrpcFunctionBindingsFeature.cs
+++ b/src/DotNetWorker.Grpc/Features/GrpcFunctionBindingsFeature.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Functions.Worker.Grpc.Features
             TypedData.DataOneofCase.CollectionString => typedData.CollectionString.String,
             TypedData.DataOneofCase.CollectionDouble => typedData.CollectionDouble.Double,
             TypedData.DataOneofCase.CollectionSint64 => typedData.CollectionSint64.Sint64,
-            TypedData.DataOneofCase.ModelBindingData => typedData.ModelBindingData,
+            TypedData.DataOneofCase.ModelBindingData => new GrpcModelBindingData(typedData.ModelBindingData),
             _ => throw new NotSupportedException($"{typedData.DataCase} is not supported."),
         };
     }


### PR DESCRIPTION
- Initialize new GrpcModelBindingData when converting from gRPC
- Update release notes
- Bump SDK version to preview 3