### PR TITLE
upgrade kafka extension from 3.5.0 to 3.6.0

### DIFF
--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -7,8 +7,3 @@
 - Confluent library upgrade from 1.6.3 to 1.9.0 for fixing duplicate record processing issue (https://github.com/Azure/azure-functions-kafka-extension/pull/357)
 - Fixed the bug for accessing the certificate from relative path instead of absolute path (https://github.com/Azure/azure-functions-kafka-extension/pull/386)
 
-### 3.5.0
-- Added the improvement for the producer logging to app insights & filesystem. (https://github.com/Azure/azure-functions-kafka-extension/pull/377)
-- Added the support for the retry feature (https://github.com/Azure/azure-functions-kafka-extension/pull/363/ https://github.com/Azure/azure-functions-kafka-extension/issues/122)
-- Added the support for keys for triggers & output bindings (https://github.com/Azure/azure-functions-kafka-extension/pull/328/ https://github.com/Azure/azure-functions-kafka-extension/issues/326)
-- Added the support for auto.offset.reset config (https://github.com/Azure/azure-functions-kafka-extension/pull/364/ https://github.com/Azure/azure-functions-kafka-extension/issues/249)

--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -3,6 +3,10 @@
 - My change description (#PR/#issue)
 -->
 
+### 3.6.0
+- Confluent library upgrade from 1.6.3 to 1.9.0 for fixing duplicate record processing issue (https://github.com/Azure/azure-functions-kafka-extension/pull/357)
+- Fixed the bug for accessing the certificate from relative path instead of absolute path (https://github.com/Azure/azure-functions-kafka-extension/pull/386)
+
 ### 3.5.0
 - Added the improvement for the producer logging to app insights & filesystem. (https://github.com/Azure/azure-functions-kafka-extension/pull/377)
 - Added the support for the retry feature (https://github.com/Azure/azure-functions-kafka-extension/pull/363/ https://github.com/Azure/azure-functions-kafka-extension/issues/122)

--- a/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.5.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Kafka", "3.6.0")]

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -6,7 +6,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.6.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
Issue describing the changes in this PR
resolves :-

- https://github.com/Azure/azure-functions-kafka-extension/pull/386 -- fail to load certificate location for Kafka Trigger
- https://github.com/Azure/azure-functions-kafka-extension/pull/357 -- upgrading the confluent kafka dotnet library where duplicate processing of events bug is fixed

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
