### PR TITLE
Worker-indexing duplicate binding info fix

### DIFF
--- a/src/DotNetWorker.Grpc/FunctionMetadata/DefaultFunctionMetadataProvider.cs
+++ b/src/DotNetWorker.Grpc/FunctionMetadata/DefaultFunctionMetadataProvider.cs
@@ -60,12 +60,6 @@ namespace Microsoft.Azure.Functions.Worker
                     foreach (var binding in rawBindings.EnumerateArray())
                     {
                         functionMetadata.RawBindings.Add(binding.GetRawText());
-
-                        BindingInfo bindingInfo = FunctionMetadataRpcExtensions.CreateBindingInfo(binding);
-
-                        binding.TryGetProperty("name", out JsonElement jsonName);
-
-                        functionMetadata.Bindings.Add(jsonName.ToString(), bindingInfo);
                     }
 
                     functionMetadataResults.Add(functionMetadata);

--- a/src/DotNetWorker.Grpc/GrpcWorker.cs
+++ b/src/DotNetWorker.Grpc/GrpcWorker.cs
@@ -261,7 +261,8 @@ namespace Microsoft.Azure.Functions.Worker
                         _ => BuildRpc(func),
                     };
 
-                    // add BindingInfo
+                    // add BindingInfo here instead of in the providers  
+                    // because we need access to gRPC types in proto-file and source-gen won't have access
                     rpcFuncMetadata.Bindings.Add(func.GetBindingInfoList());
 
                     response.FunctionMetadataResults.Add(rpcFuncMetadata);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves Function metadata loading error where duplicate `BindingInfo` dictionaries are created for `RpcFunctionMetadata` in `GrpcWorker.cs`. 

This occurs when you use an SDK that has the worker-indexing version that reads `functions.metadata` (not the source-gen version) combined with the latest worker package. The latest package has some components related to source-generated Function metadata that is not compatible with the first worker-indexing iteration.

Repro steps:

1. Use worker SDK package 1.7.0 (does not have source gen).
2. Use worker package 1.11.0-preview2.
3. Set MSBuild property `FunctionsEnableWorkerIndexing` to true in `.csproj` file.
4. Run app. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

### Additional information

May need to discuss work item for E2E testing for different function metadata generation options and different preview options? Could be in this PR or we can create a new work item.
