### PR TITLE
Standardize json strings from source-gen and functions.metadata file

### DIFF
--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Emitter.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Emitter.cs
@@ -77,6 +77,14 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 indentedTextWriter.WriteLine("{");
                 indentedTextWriter.Indent++;
 
+                // add JsonSerializer Options
+                indentedTextWriter.WriteLine("var jsonOptions = new JsonSerializerOptions");
+                indentedTextWriter.WriteLine("{");
+                indentedTextWriter.Indent++;
+                indentedTextWriter.WriteLine("PropertyNamingPolicy = JsonNamingPolicy.CamelCase");
+                indentedTextWriter.Indent--;
+                indentedTextWriter.WriteLine("};");
+
                 // create list of IFunctionMetadata and populate it
                 indentedTextWriter.WriteLine("var metadataList = new List<IFunctionMetadata>();");
                 AddFunctionMetadataInfo(indentedTextWriter, functionMetadata, cancellationToken);
@@ -133,7 +141,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
                     indentedTextWriter.Indent--;
                     indentedTextWriter.WriteLine("};");
-                    indentedTextWriter.WriteLine($"var {bindingVarName}JSON = JsonSerializer.Serialize({bindingVarName});");
+                    indentedTextWriter.WriteLine($"var {bindingVarName}JSON = JsonSerializer.Serialize({bindingVarName}, jsonOptions);");
                     indentedTextWriter.WriteLine($"{functionBindingsListVarName}.Add({bindingVarName}JSON);");
 
                     bindingCount++;

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
@@ -94,6 +94,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -112,7 +116,7 @@ namespace Microsoft.Azure.Functions.Worker
 
                 expectedOutputBuilder.Append(@"
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -223,6 +227,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -242,7 +250,7 @@ namespace Microsoft.Azure.Functions.Worker
 
                 expectedOutputBuilder.Append(@"
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -324,6 +332,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -334,7 +346,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -468,6 +480,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -479,7 +495,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Cardinality = 'Many',
                 DataType = 'String',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -500,7 +516,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Cardinality = 'Many',
                 DataType = 'String',
             };
-            var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
+            var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0, jsonOptions);
             Function1RawBindings.Add(Function1binding0JSON);
             var Function1 = new DefaultFunctionMetadata
             {
@@ -521,7 +537,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Cardinality = 'Many',
                 DataType = 'String',
             };
-            var Function2binding0JSON = JsonSerializer.Serialize(Function2binding0);
+            var Function2binding0JSON = JsonSerializer.Serialize(Function2binding0, jsonOptions);
             Function2RawBindings.Add(Function2binding0JSON);
             var Function2 = new DefaultFunctionMetadata
             {
@@ -542,7 +558,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Cardinality = 'Many',
                 DataType = 'String',
             };
-            var Function3binding0JSON = JsonSerializer.Serialize(Function3binding0);
+            var Function3binding0JSON = JsonSerializer.Serialize(Function3binding0, jsonOptions);
             Function3RawBindings.Add(Function3binding0JSON);
             var Function3 = new DefaultFunctionMetadata
             {
@@ -649,6 +665,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -660,7 +680,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Cardinality = 'Many',
                 DataType = 'Binary',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -681,7 +701,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Cardinality = 'Many',
                 DataType = 'Binary',
             };
-            var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
+            var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0, jsonOptions);
             Function1RawBindings.Add(Function1binding0JSON);
             var Function1 = new DefaultFunctionMetadata
             {
@@ -775,6 +795,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -785,7 +809,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -805,7 +829,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Connection = 'EventHubConnectionAppSetting',
                 Cardinality = 'Many',
             };
-            var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
+            var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0, jsonOptions);
             Function1RawBindings.Add(Function1binding0JSON);
             var Function1 = new DefaultFunctionMetadata
             {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
@@ -76,6 +76,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -85,14 +89,14 @@ namespace Microsoft.Azure.Functions.Worker
                 AuthLevel = (AuthorizationLevel)0,
                 Methods = new List<string> { 'get','post' },
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
                 Name = '$return',
                 Type = 'http',
                 Direction = 'Out',
             };
-            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
+            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1, jsonOptions);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -172,6 +176,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -182,7 +190,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Methods = new List<string> { 'get','post' },
                 Route = ""/api2"",
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -267,6 +275,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -276,14 +288,14 @@ namespace Microsoft.Azure.Functions.Worker
                 Methods = new List<string> { 'get' },
                 DataType = 'String',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
                 Name = ""httpResponseProp"",
                 Type = ""http"",
                 Direction = ""Out"",
             };
-            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
+            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1, jsonOptions);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
@@ -99,6 +99,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -108,7 +112,7 @@ namespace Microsoft.Azure.Functions.Worker
                 AuthLevel = (AuthorizationLevel)0,
                 Methods = new List<string> { 'get','post' },
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
                 Name = 'Name',
@@ -117,14 +121,14 @@ namespace Microsoft.Azure.Functions.Worker
                 QueueName = 'functionstesting2',
                 Connection = 'AzureWebJobsStorage',
             };
-            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
+            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1, jsonOptions);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0binding2 = new {
                 Name = 'HttpResponse',
                 Type = 'http',
                 Direction = 'Out',
             };
-            var Function0binding2JSON = JsonSerializer.Serialize(Function0binding2);
+            var Function0binding2JSON = JsonSerializer.Serialize(Function0binding2, jsonOptions);
             Function0RawBindings.Add(Function0binding2JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -230,6 +234,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -239,7 +247,7 @@ namespace Microsoft.Azure.Functions.Worker
                 AuthLevel = (AuthorizationLevel)0,
                 Methods = new List<string> { 'get','post' },
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
                 Name = 'myBlob',
@@ -249,7 +257,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Connection = 'AzureWebJobsStorage',
                 DataType = 'String',
             };
-            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
+            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1, jsonOptions);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0binding2 = new {
                 Name = 'Book',
@@ -258,14 +266,14 @@ namespace Microsoft.Azure.Functions.Worker
                 QueueName = 'functionstesting2',
                 Connection = 'AzureWebJobsStorage',
             };
-            var Function0binding2JSON = JsonSerializer.Serialize(Function0binding2);
+            var Function0binding2JSON = JsonSerializer.Serialize(Function0binding2, jsonOptions);
             Function0RawBindings.Add(Function0binding2JSON);
             var Function0binding3 = new {
                 Name = 'HttpResponse',
                 Type = 'http',
                 Direction = 'Out',
             };
-            var Function0binding3JSON = JsonSerializer.Serialize(Function0binding3);
+            var Function0binding3JSON = JsonSerializer.Serialize(Function0binding3, jsonOptions);
             Function0RawBindings.Add(Function0binding3JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -358,6 +366,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -367,14 +379,14 @@ namespace Microsoft.Azure.Functions.Worker
                 AuthLevel = (AuthorizationLevel)0,
                 Methods = new List<string> { 'get' },
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
                 Name = '$return',
                 Type = 'http',
                 Direction = 'Out',
             };
-            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
+            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1, jsonOptions);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -454,6 +466,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -463,7 +479,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Schedule = '0 0 0 * * *',
                 RunOnStartup = 'False',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -544,6 +560,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -554,14 +574,14 @@ namespace Microsoft.Azure.Functions.Worker
                 Methods = new List<string> { 'get','Post' },
                 Route = '/api2',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
                 Name = 'Result',
                 Type = 'http',
                 Direction = 'Out',
             };
-            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
+            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1, jsonOptions);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -83,6 +83,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -91,7 +95,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Direction = 'Out',
                 QueueName = 'test-output-dotnet-isolated',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
                 Name = 'message',
@@ -100,7 +104,7 @@ namespace Microsoft.Azure.Functions.Worker
                 QueueName = 'test-input-dotnet-isolated',
                 DataType = 'String',
             };
-            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
+            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1, jsonOptions);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -191,6 +195,10 @@ namespace Microsoft.Azure.Functions.Worker
     {
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
             var Function0binding0 = new {
@@ -200,7 +208,7 @@ namespace Microsoft.Azure.Functions.Worker
                 BlobPath = 'container1/hello.txt',
                 Connection = 'MyOtherConnection',
             };
-            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0);
+            var Function0binding0JSON = JsonSerializer.Serialize(Function0binding0, jsonOptions);
             Function0RawBindings.Add(Function0binding0JSON);
             var Function0binding1 = new {
                 Name = 'queuePayload',
@@ -210,7 +218,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Connection = 'MyConnection',
                 DataType = 'String',
             };
-            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1);
+            var Function0binding1JSON = JsonSerializer.Serialize(Function0binding1, jsonOptions);
             Function0RawBindings.Add(Function0binding1JSON);
             var Function0 = new DefaultFunctionMetadata
             {
@@ -228,7 +236,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Direction = 'Out',
                 QueueName = 'queue2',
             };
-            var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0);
+            var Function1binding0JSON = JsonSerializer.Serialize(Function1binding0, jsonOptions);
             Function1RawBindings.Add(Function1binding0JSON);
             var Function1binding1 = new {
                 Name = 'blob',
@@ -237,7 +245,7 @@ namespace Microsoft.Azure.Functions.Worker
                 Path = 'container2/%file%',
                 DataType = 'String',
             };
-            var Function1binding1JSON = JsonSerializer.Serialize(Function1binding1);
+            var Function1binding1JSON = JsonSerializer.Serialize(Function1binding1, jsonOptions);
             Function1RawBindings.Add(Function1binding1JSON);
             var Function1 = new DefaultFunctionMetadata
             {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Casing of `functions.metadata` JSON file is camel case. Refactoring source-gen to serialize with a camel case policy. Relevant downstream sections that care about casing include [this worker function metadata extension](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/src/DotNetWorker.Grpc/FunctionMetadata/FunctionMetadataRpcExtensions.cs) and [binding metadata](https://github.com/Azure/azure-functions-host/blob/02b161d931e5eeae1d14dc363cafedb4be876c36/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs#L120) in the host. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

Future work in this area to be tracked in #1188 - let's avoid serializing and create the JSON string directly. Also tracking testing improvements in #1189.
