### PR TITLE
Bump protobuf version to v1.7.0-protofile

### DIFF
--- a/src/DotNetWorker.Grpc/protobuf/src/proto/FunctionRpc.proto
+++ b/src/DotNetWorker.Grpc/protobuf/src/proto/FunctionRpc.proto
@@ -326,7 +326,7 @@ message RpcFunctionMetadata {
   // Properties for function metadata
   // They're usually specific to a worker and largely passed along to the controller API for use
   // outside the host
-   map<string,string> Properties = 16;
+   map<string,string> properties = 16;
 }
 
 // Host tells worker it is ready to receive metadata
@@ -431,6 +431,7 @@ message TypedData {
     CollectionDouble collection_double = 10;
     CollectionSInt64 collection_sint64 = 11;
     ModelBindingData model_binding_data = 12;
+    CollectionModelBindingData collection_model_binding_data = 13;
   }
 }
 
@@ -668,4 +669,9 @@ message ModelBindingData
 
     // The binding data content
     bytes content = 4;
+}
+
+// Used to encapsulate collection model_binding_data
+message CollectionModelBindingData {
+  repeated ModelBindingData model_binding_data = 1;
 }


### PR DESCRIPTION
Updated subtree from https://github.com/azure/azure-functions-language-worker-protobuf. Tag: v1.7.0-protofile. Commit: e861ab8f08cf4e2c5dd25341b7fa8a62c5d02645

Related issue - https://github.com/Azure/azure-functions-dotnet-worker/issues/1156

It also includes changes from this commit - https://github.com/Azure/azure-functions-language-worker-protobuf/commit/47dc95e8e23b1868dcc10a0af89da4a1551b1c2a