### PR TITLE
Adding copyright headers & minor other cleanups

### DIFF
--- a/host/.gitignore
+++ b/host/.gitignore
@@ -4,3 +4,6 @@ out/
 .idea/
 cmake-build-*/
 /src/.idea/
+
+#Ignore the proto files we temporarily copy for build
+/src/Protos/**/*.proto

--- a/host/src/CMakeLists.txt
+++ b/host/src/CMakeLists.txt
@@ -15,17 +15,13 @@ set(CMAKE_TOOLCHAIN_FILE "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake" 
 
 set(VCPKG_INSTALL_OPTIONS "--debug")
 
-string(TIMESTAMP CURRENT_TIME "%m%d%H%M")
-# May replace with git commit id once hooked up to GH actions.
-project ("FunctionsNetHost" VERSION 0.0.0.${CURRENT_TIME})
+project ("FunctionsNetHost")
 set(CMAKE_CXX_STANDARD 20)
 
 # Include sub-projects.
 add_subdirectory("Protos")
 add_subdirectory ("FunctionsNetHost")
 add_subdirectory("funcgrpc")
-
-configure_file(appconfig.h.in appconfig.h)
 
 target_include_directories(FunctionsNetHost PUBLIC
         "${PROJECT_BINARY_DIR}"

--- a/host/src/FunctionsNetHost/main.cpp
+++ b/host/src/FunctionsNetHost/main.cpp
@@ -3,7 +3,6 @@
 
 #include "../funcgrpc/func_bidi_reactor.h"
 #include "../funcgrpc/func_perf_marker.h"
-#include "appconfig.h"
 #include <boost/program_options.hpp>
 #include <exception>
 #include <iostream>

--- a/host/src/FunctionsNetHost/main.cpp
+++ b/host/src/FunctionsNetHost/main.cpp
@@ -3,7 +3,6 @@
 
 #include "../funcgrpc/func_bidi_reactor.h"
 #include "../funcgrpc/func_perf_marker.h"
-#include "../funcgrpc/funcgrpc.h"
 #include "appconfig.h"
 #include <boost/program_options.hpp>
 #include <exception>
@@ -20,7 +19,7 @@ unique_ptr<funcgrpc::GrpcWorkerStartupOptions> getWorkerStartupOptions(int argc,
 int main(int argc, char *argv[])
 {
     funcgrpc::Log::Init();
-    FUNC_LOG_INFO("Starting FunctionsNetHost main.Build:{}", FunctionsNetHost_VERSION);
+    FUNC_LOG_INFO("Starting FunctionsNetHost.");
 
     try
     {

--- a/host/src/FunctionsNetHost/managedexports.cpp
+++ b/host/src/FunctionsNetHost/managedexports.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #include "../funcgrpc/byte_buffer_helper.h"
 #include "../funcgrpc/func_log.h"
 #include "../funcgrpc/nativehostapplication.h"

--- a/host/src/appconfig.h.in
+++ b/host/src/appconfig.h.in
@@ -1,2 +1,0 @@
-
-#define FunctionsNetHost_VERSION "@FunctionsNetHost_VERSION@-${CMAKE_BUILD_TYPE}"

--- a/host/src/funcgrpc/func_bidi_reactor.cpp
+++ b/host/src/funcgrpc/func_bidi_reactor.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #include "func_bidi_reactor.h"
 #include "byte_buffer_helper.h"
 #include "func_log.h"

--- a/host/src/funcgrpc/func_bidi_reactor.h
+++ b/host/src/funcgrpc/func_bidi_reactor.h
@@ -1,12 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #pragma once
 
 #include <future>
+#include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/generic/generic_stub.h>
-#include <grpc/byte_buffer.h>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -25,10 +28,10 @@ using AzureFunctionsRpcMessages::StartStream;
 using AzureFunctionsRpcMessages::StatusResult;
 using AzureFunctionsRpcMessages::StreamingMessage;
 using AzureFunctionsRpcMessages::WorkerInitResponse;
+using grpc::ByteBuffer;
 using grpc::Channel;
 using grpc::ClientContext;
 using grpc::Status;
-using grpc::ByteBuffer;
 
 using namespace AzureFunctionsRpc;
 using namespace grpc;
@@ -90,13 +93,13 @@ class FunctionBidiReactor : public grpc::ClientBidiReactor<ByteBuffer, ByteBuffe
     /// Message to read from server.
     /// This should not be modified while a read operation( StartRead(&read_) ) is in progress.
     /// </summary>
-	ByteBuffer read_;
+    ByteBuffer read_;
 
     /// <summary>
     /// Message to write to server.
     /// This should not be modified while a write operation( StartWrite(&write_) ) is in progress.
     /// </summary>
-	ByteBuffer write_;
+    ByteBuffer write_;
 
     std::atomic_bool write_inprogress_{false};
 

--- a/host/src/funcgrpc/func_log.cpp
+++ b/host/src/funcgrpc/func_log.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #include "func_log.h"
 
 namespace funcgrpc

--- a/host/src/funcgrpc/func_log.h
+++ b/host/src/funcgrpc/func_log.h
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #pragma once
 
 #include "spdlog/sinks/stdout_color_sinks.h"

--- a/host/src/funcgrpc/func_perf_marker.h
+++ b/host/src/funcgrpc/func_perf_marker.h
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #ifndef FUNCTIONSNETHOST_FUNC_PERF_MARKER_H
 #define FUNCTIONSNETHOST_FUNC_PERF_MARKER_H
 

--- a/host/src/funcgrpc/funcgrpc.h
+++ b/host/src/funcgrpc/funcgrpc.h
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #ifndef FUNC_WORKER
 #define FUNC_WORKER
 

--- a/host/src/funcgrpc/funcgrpc_handlers.h
+++ b/host/src/funcgrpc/funcgrpc_handlers.h
@@ -1,13 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #ifndef FUNC_HANDLERS
 #define FUNC_HANDLERS
 
 #include <FunctionRpc.pb.h>
+#include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/generic/generic_stub.h>
-#include <grpc/byte_buffer.h>
 
 using AzureFunctionsRpcMessages::StreamingMessage;
 using grpc::ByteBuffer;

--- a/host/src/funcgrpc/funcgrpc_worker_config_handle.cpp
+++ b/host/src/funcgrpc/funcgrpc_worker_config_handle.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 
 #include "funcgrpc_worker_config_handle.h"
 #include "func_log.h"

--- a/host/src/funcgrpc/funcgrpc_worker_config_handle.h
+++ b/host/src/funcgrpc/funcgrpc_worker_config_handle.h
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #pragma once
 
 #include <string>

--- a/host/src/funcgrpc/handlers/funcgrpc_native_handler.cpp
+++ b/host/src/funcgrpc/handlers/funcgrpc_native_handler.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #include "funcgrpc_native_handler.h"
 #include "../byte_buffer_helper.h"
 #include "../func_log.h"

--- a/host/src/funcgrpc/handlers/funcgrpc_native_handler.h
+++ b/host/src/funcgrpc/handlers/funcgrpc_native_handler.h
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #ifndef FUNC_NATIVEHANDLER
 #define FUNC_NATIVEHANDLER
 

--- a/host/src/funcgrpc/messaging_channel.cpp
+++ b/host/src/funcgrpc/messaging_channel.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #include "messaging_channel.h"
 #include <iostream>
 

--- a/host/src/funcgrpc/messaging_channel.h
+++ b/host/src/funcgrpc/messaging_channel.h
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #pragma once
 #include <boost/fiber/unbuffered_channel.hpp>
 #include <future>

--- a/host/src/funcgrpc/nativehostapplication.cpp
+++ b/host/src/funcgrpc/nativehostapplication.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #include "nativehostapplication.h"
 #include "func_log.h"
 #include <nethost.h>

--- a/host/src/funcgrpc/nativehostapplication.h
+++ b/host/src/funcgrpc/nativehostapplication.h
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 #pragma once
 #include "messaging_channel.h"
 #include <FunctionRpc.pb.h>
@@ -9,9 +12,9 @@
 #include <string>
 #include <windows.h>
 
+#include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
-#include <grpc/byte_buffer.h>
 
 using grpc::ByteBuffer;
 using namespace std;

--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.0-preview1</version>
+    <version>1.0.0-preview2</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

- Adding copyright headers to all files.
- Removed the **_temp_** code which generated a unique build number using current timestamp. We do not need this anymore as we will use the build numbers from the nuspec file. All changes are basically released with a nuget package release & from the package version we can always track down the snapshot of the code running.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
