### PR TITLE
check if log show function executed

### DIFF
--- a/test/DotNetWorkerTests/Converters/DateTimeConverterTests.cs
+++ b/test/DotNetWorkerTests/Converters/DateTimeConverterTests.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Azure.Functions.Worker.Tests.Converters
             var convertedDateTimeOffset = TestUtility.AssertIsTypeAndConvert<DateTimeOffset>(conversionResult.Value);
 
             // when no offset info is present in input value, offset of local timezone will be set as the offset of the DateTimeOffSet instance.
-            var expectedOffSetHours = expectedOffsetHours ?? TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).Hours;
+            var expectedOffSetHours =  expectedOffsetHours ?? TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).Hours
+                + (TimeZoneInfo.Local.IsDaylightSavingTime(convertedDateTimeOffset) ? 1 : 0);
+
             Assert.Equal(expectedOffSetHours, convertedDateTimeOffset.Offset.Hours);
             Assert.Equal(DateTimeOffset.Parse(source.ToString()), convertedDateTimeOffset);
         }

--- a/test/DotNetWorkerTests/Features/DefaultInputConversionFeatureTests.cs
+++ b/test/DotNetWorkerTests/Features/DefaultInputConversionFeatureTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core.Serialization;
@@ -57,7 +58,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests.Features
             Assert.Equal(ConversionStatus.Succeeded, actual.Status);
 
             var value = TestUtility.AssertIsTypeAndConvert<DateTime>(actual.Value);
-            Assert.Equal("04/13/2022", value.ToString("MM/dd/yyyy"));
+            Assert.Equal("04/13/2022", value.ToString("MM/dd/yyyy", CultureInfo.InvariantCulture));
         }
 
         [Fact]

--- a/test/E2ETests/E2EApps/E2EApp/Cosmos/CosmosFunction.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Cosmos/CosmosFunction.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
+
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Functions.Worker.E2EApp

--- a/test/E2ETests/E2ETests/Constants.cs
+++ b/test/E2ETests/E2ETests/Constants.cs
@@ -82,5 +82,9 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
 
         // Xunit Fixtures and Collections
         public const string FunctionAppCollectionName = "FunctionAppCollection";
+
+        public const string StorageFunctionAppCollectionName = "StorageFunctionAppCollection";
+        
+        public const string CosmosFunctionAppCollectionName = "CosmosFunctionAppCollection";
     }
 }

--- a/test/E2ETests/E2ETests/Fixtures/StorageFunctionAppFixture.cs
+++ b/test/E2ETests/E2ETests/Fixtures/StorageFunctionAppFixture.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Functions.Tests.E2ETests
+{
+    public class StorageFunctionAppFixture : FunctionAppFixture
+    {
+        public StorageFunctionAppFixture(IMessageSink messageSink) : base(messageSink)
+        {
+        }
+
+        #region Implementation of IAsyncLifetime
+
+        public override async Task InitializeAsync()
+        {
+            await StorageHelpers.CreateBlobContainers();
+            await StorageHelpers.CreateQueues();
+
+            await base.InitializeAsync();
+        }
+
+        public override async Task DisposeAsync()
+        {
+            await base.DisposeAsync();
+
+            //NOTE: Comment this out if you want to keep during local testing.
+            await StorageHelpers.DeleteQueues();
+            await StorageHelpers.DeleteBlobContainers();
+        }
+
+        #endregion
+    }
+
+    [CollectionDefinition(Constants.StorageFunctionAppCollectionName)]
+    public class StorageFunctionAppCollection : ICollectionFixture<StorageFunctionAppFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/test/E2ETests/E2ETests/TimerEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/TimerEndToEndTests.cs
@@ -12,15 +12,13 @@ using Xunit.Abstractions;
 namespace Microsoft.Azure.Functions.Tests.E2ETests
 {
     [Collection(Constants.FunctionAppCollectionName)]
-    public class TimerEndToEndTests : IDisposable
+    public class TimerEndToEndTests
     {
-        private readonly IDisposable _disposeLog;
         private readonly FunctionAppFixture _fixture;
 
         public TimerEndToEndTests(FunctionAppFixture fixture, ITestOutputHelper testOutput)
         {
             _fixture = fixture;
-            _disposeLog = _fixture.TestLogs.UseTestLogger(testOutput);
         }
 
         [Fact]
@@ -47,11 +45,6 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
 
             // This will throw if it's not there or is not a bool.
             doc.RootElement.GetProperty("IsPastDue").GetBoolean();
-        }
-
-        public void Dispose()
-        {
-            _disposeLog?.Dispose();
         }
     }
 }


### PR DESCRIPTION
Perform verification function was actually triggered/executed

Leverage `Fixture` to initialize storage containers and queues
Move Cosmos initialization to separate fixture, and not use `static` reference to `DocumentClient`

Reduce setup/teardown code for storage/queue tests.

### Issue describing the changes in this PR

resolves #1236 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
