### PR TITLE
Update SignalR samples

### DIFF
--- a/samples/Extensions/SignalR/SignalRNegotiationFunctions.cs
+++ b/samples/Extensions/SignalR/SignalRNegotiationFunctions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 
@@ -8,22 +9,34 @@ namespace Extensions.SignalR
 {
     public static class SignalRNegotiationFunctions
     {
+        // <snippet_negotiate>
         [Function("Negotiate")]
-        public static SignalRConnectionInfo Negotiate(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req,
-            [SignalRConnectionInfoInput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")] SignalRConnectionInfo connectionInfo)
+        public static string Negotiate([HttpTrigger(AuthorizationLevel.Anonymous)] HttpRequestData req,
+            [SignalRConnectionInfoInput(HubName = "serverless")] string connectionInfo)
         {
+            // The serialization of the connection info object is done by the framework. It should be camel case. The SignalR client respects the camel case response only.
             return connectionInfo;
         }
+        // </snippet_negotiate>
+
 
         // When you have multiple SignalR service instances and you want to customize the rule that route a client
+        // <snippet_negotiate_multiple_endpoint>
+        public static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
         [Function("NegotiateWithMultipleEndpoints")]
-        public static SignalRConnectionInfo NegotiateWithMultipleEndpoints(
+        public static string NegotiateWithMultipleEndpoints(
             [HttpTrigger(AuthorizationLevel.Anonymous)] HttpRequestData req,
             [SignalRNegotiationInput("chatHub", "SignalRConnection")] SignalRNegotiationContext negotiationContext)
         {
-            // customize your rule here
-            return negotiationContext.Endpoints[0].ConnectionInfo;
+            // Customize your rule here
+            var connectionInfo = negotiationContext.Endpoints[0].ConnectionInfo;
+            // The SignalR client respects the camel case response only.
+            return JsonSerializer.Serialize(connectionInfo, SerializerOptions);
         }
+        // </snippet_negotiate_multiple_endpoint>
+
     }
 }

--- a/samples/Extensions/SignalR/SignalROutputBindingFunctions.cs
+++ b/samples/Extensions/SignalR/SignalROutputBindingFunctions.cs
@@ -12,7 +12,8 @@ namespace SampleApp
     {
         [Function("BroadcastToAll")]
         [SignalROutput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")]
-        public static SignalRMessageAction BroadcastToAll([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+        public static SignalRMessageAction BroadcastToAll(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
         {
             using var bodyReader = new StreamReader(req.Body);
             return new SignalRMessageAction("newMessage")
@@ -24,7 +25,8 @@ namespace SampleApp
 
         [Function("SendToConnection")]
         [SignalROutput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")]
-        public static SignalRMessageAction SendToConnection([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+        public static SignalRMessageAction SendToConnection(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
         {
             using var bodyReader = new StreamReader(req.Body);
             return new SignalRMessageAction("newMessage")

--- a/samples/Extensions/SignalR/SignalROutputBindingFunctions2.cs
+++ b/samples/Extensions/SignalR/SignalROutputBindingFunctions2.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace SampleApp
+{
+    /// <summary>
+    /// The class is the same as SignalROutputBindingFunctions except the comments. Just keep the original one because the learn website refers to it.
+    /// </summary>
+    public static class SignalROutputBindingFunctions2
+    {
+        // <snippet_broadcast_to_all>
+        [Function("BroadcastToAll")]
+        [SignalROutput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")]
+        public static SignalRMessageAction BroadcastToAll([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+        {
+            using var bodyReader = new StreamReader(req.Body);
+            return new SignalRMessageAction("newMessage")
+            {
+                // broadcast to all the connected clients without specifying any connection, user or group.
+                Arguments = new[] { bodyReader.ReadToEnd() },
+            };
+        }
+        // </snippet_broadcast_to_all>
+
+        // <snippet_send_to_connection>
+        [Function("SendToConnection")]
+        [SignalROutput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")]
+        public static SignalRMessageAction SendToConnection([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+        {
+            using var bodyReader = new StreamReader(req.Body);
+            return new SignalRMessageAction("newMessage")
+            {
+                Arguments = new[] { bodyReader.ReadToEnd() },
+                ConnectionId = "connectionToSend",
+            };
+        }
+        // </snippet_send_to_connection>
+
+        // <snippet_send_to_user>
+        [Function("SendToUser")]
+        [SignalROutput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")]
+        public static SignalRMessageAction SendToUser([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+        {
+            using var bodyReader = new StreamReader(req.Body);
+            return new SignalRMessageAction("newMessage")
+            {
+                Arguments = new[] { bodyReader.ReadToEnd() },
+                UserId = "userToSend",
+            };
+        }
+        // </snippet_send_to_user>
+
+        // <snippet_send_to_group>
+        [Function("SendToGroup")]
+        [SignalROutput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")]
+        public static SignalRMessageAction SendToGroup([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+        {
+            using var bodyReader = new StreamReader(req.Body);
+            return new SignalRMessageAction("newMessage")
+            {
+                Arguments = new[] { bodyReader.ReadToEnd() },
+                GroupName = "groupToSend"
+            };
+        }
+        // </snippet_send_to_group>
+
+        // <snippet_send_to_endpoint>
+        [Function("SendToEndpoint")]
+        [SignalROutput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")]
+        public static SignalRMessageAction SendToEndpoint(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req,
+            [SignalREndpointsInput("chat", ConnectionStringSetting = "SignalRConnection")] SignalREndpoint[] endpoints)
+        {
+            using var bodyReader = new StreamReader(req.Body);
+            return new SignalRMessageAction("newMessage")
+            {
+                Arguments = new[] { bodyReader.ReadToEnd() },
+                // Only send to primary endpoint if you have configured multiple SignalR Service instances.
+                // The use of 'Endpoints' can be combined with other properties such as UserId, GroupName, ConnectionID.
+                Endpoints = endpoints.Where(e => e.EndpointType == SignalREndpointType.Primary).ToArray()
+            };
+        }
+        // </snippet_send_to_endpoint>
+
+        // <snippet_remove_from_group>
+        [Function("RemoveFromGroup")]
+        [SignalROutput(HubName = "chat", ConnectionStringSetting = "SignalRConnection")]
+        public static SignalRGroupAction RemoveFromGroup([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+        {
+            return new SignalRGroupAction(SignalRGroupActionType.Remove)
+            {
+                GroupName = "group1",
+                UserId = "user1"
+            };
+        }
+        // </snippet_remove_from_group>
+    }
+}

--- a/samples/Extensions/SignalR/SignalRTriggerFunctions.cs
+++ b/samples/Extensions/SignalR/SignalRTriggerFunctions.cs
@@ -9,25 +9,31 @@ namespace Extensions.SignalR
 {
     public static class SignalRTriggerFunctions
     {
+        // <snippet_on_connected>
         [Function("OnConnected")]
         public static void OnConnected([SignalRTrigger("chat", "connections", "connected", ConnectionStringSetting = "SignalRConnection")] SignalRInvocationContext invocationContext, FunctionContext functionContext)
         {
             var logger = functionContext.GetLogger("OnConnected");
             logger.LogInformation($"Connection {invocationContext.ConnectionId} is connected");
         }
+        // </snippet_on_connected>
 
+        // <snippet_on_disconnected>
         [Function("OnDisconnected")]
         public static void OnDisconnected([SignalRTrigger("chat", "connections", "disconnected", ConnectionStringSetting = "SignalRConnection")] SignalRInvocationContext invocationContext, FunctionContext functionContext)
         {
             var logger = functionContext.GetLogger("OnDisconnected");
             logger.LogInformation($"Connection {invocationContext.ConnectionId} is disconnected. Error: {invocationContext.Error}");
         }
+        // </snippet_on_disconnected>
 
+        // <snippet_on_message>
         [Function("OnClientMessage")]
         public static void OnClientMessage([SignalRTrigger("Hub", "messages", "sendMessage", "content", ConnectionStringSetting = "SignalRConnection")] SignalRInvocationContext invocationContext, string content, FunctionContext functionContext)
         {
             var logger = functionContext.GetLogger("OnClientMessage");
             logger.LogInformation($"Connection {invocationContext.ConnectionId} sent a message. Message content: {content}");
         }
+        // </snippet_on_message>
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

* Update SignalR samples. 
* `SignalROutputBindingFunctions` is referred by docs, so I add a new file instead of updating it.
* The changes in Azure#1072 breaks the doc [SignalR output binding reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-output?tabs=isolated-process&pivots=programming-language-csharp) starting from "sending to user". Will first revert the changes, and then update the doc to refer code snippet instead of lines.
### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR #995
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

