### PR TITLE
[Sdk] Avoid registering metadata loader extension when running in the native worker

### DIFF
--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>8</MinorProductVersion>
-    <VersionSuffix>-preview3</VersionSuffix>
+    <VersionSuffix>-preview4</VersionSuffix>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -35,6 +35,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       
         <FunctionsEnableWorkerIndexing Condition="$(FunctionsEnableWorkerIndexing) == ''">false</FunctionsEnableWorkerIndexing>
         <FunctionsMetadataSourceGen_Enabled Condition="$(FunctionsMetadataSourceGen_Enabled) == ''">true</FunctionsMetadataSourceGen_Enabled>
+        <FunctionsEnablePlaceholder Condition="$(FunctionsEnablePlaceholder) == ''">false</FunctionsEnablePlaceholder>
     </PropertyGroup>
 
     <UsingTask TaskName="GenerateFunctionMetadata"
@@ -75,7 +76,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           TargetFrameworkVersion="$(TargetFrameworkVersion)"
           OutputPath="$(TargetDir)"/>
 
+        <!-- Do not copy _FunctionsMetadataLoaderExtensionFile when in placeholder mode, as we don't want the FunctionMetadataLoader entry in extensions.json-->
         <Copy
+          Condition="!$(FunctionsEnablePlaceholder)"
           SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
           DestinationFolder="$(ExtensionsCsProjFilePath)\buildout"
           OverwriteReadOnlyFiles="true" />
@@ -104,8 +107,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
           TargetFrameworkVersion="$(TargetFrameworkVersion)"
           OutputPath="$(TargetDir)"/>
-
+        <!-- Do not copy _FunctionsMetadataLoaderExtensionFile when in placeholder mode, as we don't want the FunctionMetadataLoader entry in extensions.json--> 
         <Copy
+          Condition="!$(FunctionsEnablePlaceholder)"
           SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
           DestinationFolder="$(ExtensionsCsProjFilePath)\buildout"
           OverwriteReadOnlyFiles="true" />

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -6,3 +6,4 @@
 - Support sdk-type binding reference type (#1107)
 - Add MS Build property to disable source generation of function metadata (it is enabled automatically) (#1200)
   - Prop name: `FunctionsMetadataSourceGen_Enabled`
+- Avoid registering metadata loader extension when running in the native worker (#1216)


### PR DESCRIPTION
Avoid registering metadata loader extension when running in the native worker

Fixes #1216 

Currently the extensions.json file has an entry for the FunctionMetadataLoader startup class. The host executes Configure method from this startup class, which [registers an implementation of `IFunctionProvider`, which provides function metadata using a Json reading approach](https://github.com/Azure/azure-functions-dotnet-worker/blob/14cc88859a1b7bbf68ee43409a1ad45a6e8362cb/sdk/FunctionMetadataLoaderExtension/Startup.cs#L62)(reading the functions.metadata file). With the native placeholder case, we do not need this as we will be relying on the source gen version of worker indexing. 

To remove this entry, we are introducing a new setting `FunctionsEnablePlaceholder` which can be applied on the csproj file like below.

```
<FunctionsEnablePlaceholder>true</FunctionsEnablePlaceholder>
```

In our sdk targets, we are using this to conditionally copy the `Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll` from the `microsoft.azure.functions.worker.sdk` package to the `buildout` folder of the temp directory we use for `WorkerExtensions.csproj`

Extensions.json before the change (from a sample app with just http trigger)
```
{
  "extensions": [
    {
      "name": "Startup",
      "typeName": "Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.Startup, Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=551316b6919f366c",
      "hintPath": "./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll"
    }
  ]
}
```
After this change:

```
{
  "extensions": []
}
```
Currently this is an explicit opt-in behavior (user needs to update csproj to get this behavior). Once other pieces of placeholder work fall in place & everything is validated, we will enabled this behavior as default. 

