### PR TITLE
[Build]Switching from EsrpCodeSigning@1 to EsrpCodeSigning@2

### DIFF
--- a/build/pipelines/templates/extensions-ci.yml
+++ b/build/pipelines/templates/extensions-ci.yml
@@ -40,7 +40,7 @@ jobs:
       arguments: '--no-build -c Release -o packages -p:BuildNumber=$(buildNumber) -p:IsLocalBuild=False'
       projects: ${{ parameters.ExtensionDirectory }}/src/*.csproj
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
     displayName: 'ESRP CodeSigning - Authenticode'
     condition: eq(variables.isReleaseBuild, true)
     inputs:
@@ -72,7 +72,7 @@ jobs:
           }
         ]
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
     displayName: 'ESRP CodeSigning: Nupkg'
     condition: eq(variables.isReleaseBuild, true)
     inputs:

--- a/build/pipelines/templates/extensions-variables.yml
+++ b/build/pipelines/templates/extensions-variables.yml
@@ -4,7 +4,7 @@
     ${{ if contains(variables['Build.SourceBranch'], '/release/' ) }}:
       isReleaseBuildTemp: true
     buildNumber: $[variables.buildNumberTemp]
-    isReleaseBuild: true
+    isReleaseBuild: $[variables.isReleaseBuildTemp]
     solution: '**/*.sln'
     buildPlatform: 'Any CPU'
     buildConfiguration: 'Release'

--- a/build/pipelines/templates/extensions-variables.yml
+++ b/build/pipelines/templates/extensions-variables.yml
@@ -4,7 +4,7 @@
     ${{ if contains(variables['Build.SourceBranch'], '/release/' ) }}:
       isReleaseBuildTemp: true
     buildNumber: $[variables.buildNumberTemp]
-    isReleaseBuild: $[variables.isReleaseBuildTemp]
+    isReleaseBuild: true
     solution: '**/*.sln'
     buildPlatform: 'Any CPU'
     buildConfiguration: 'Release'

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -68,7 +68,7 @@ jobs:
       projects: |
         test/**/*Tests.csproj
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
     displayName: 'Sdk: ESRP CodeSigning - Authenticode'
     condition: eq(variables.isReleaseBuild, true)
     inputs:
@@ -100,7 +100,7 @@ jobs:
           }
         ]
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
     displayName: 'Sdk: ESRP CodeSigning - Authenticode'
     condition: eq(variables.isReleaseBuild, true)
     inputs:
@@ -132,7 +132,7 @@ jobs:
           }
         ]
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
     displayName: 'DotnetWorker: ESRP CodeSigning - Authenticode'
     condition: eq(variables.isReleaseBuild, true)
     inputs:


### PR DESCRIPTION
Currently the codesigning task if failing as it requires 'Microsoft.NETCore.App', version '2.1.0 framework and looks like the agents does not have that anymore.  To fix this we are  switching from EsrpCodeSigning@1 to EsrpCodeSigning@2 which apparently relies on a newer version of the framework which exists in these agents.

Ran [a build from this branch](https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=109951&view=logs&j=1372d9e0-5cd3-5ef5-5e82-7ce7a218d320&t=1feb0bf3-42d9-589d-4ed2-1daf6527b607) and CodeSigning step works now.