### PR TITLE
Assign cardinality correctly for Blob collection scenarios

### DIFF
--- a/extensions/Worker.Extensions.Storage.Blobs/src/BlobInputAttribute.cs
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/BlobInputAttribute.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Azure.Functions.Worker
             get { return _blobPath; }
         }
 
+        /// <summary>
+        /// Gets or sets the configuration to enable batch processing of blobs. Default value is "false".
+        /// </summary>
         [DefaultValue(false)]
         public bool IsBatched
         {

--- a/extensions/Worker.Extensions.Storage.Blobs/src/BlobInputAttribute.cs
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/BlobInputAttribute.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Functions.Worker
     {
         private readonly string _blobPath;
 
+        private bool _isBatched = false;
+
         /// <summary>Initializes a new instance of the <see cref="BlobInputAttribute"/> class.</summary>
         /// <param name="blobPath">The path of the blob to which to bind.</param>
         public BlobInputAttribute(string blobPath)
@@ -23,6 +25,13 @@ namespace Microsoft.Azure.Functions.Worker
         public string BlobPath
         {
             get { return _blobPath; }
+        }
+
+        [DefaultValue(false)]
+        public bool IsBatched
+        {
+            get => _isBatched;
+            set => _isBatched = value;
         }
 
         /// <summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
                             Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""methods"":[""get"",""post""]}");
-                            Function0RawBindings.Add(@"{""name"":""myBlob"",""type"":""Blob"",""direction"":""In"",""blobPath"":""test-samples/sample1.txt"",""connection"":""AzureWebJobsStorage"",""dataType"":""String""}");
+                            Function0RawBindings.Add(@"{""name"":""myBlob"",""type"":""Blob"",""direction"":""In"",""blobPath"":""test-samples/sample1.txt"",""connection"":""AzureWebJobsStorage"",""cardinality"":""One"",""dataType"":""String""}");
                             Function0RawBindings.Add(@"{""name"":""Book"",""type"":""Queue"",""direction"":""Out"",""queueName"":""functionstesting2"",""connection"":""AzureWebJobsStorage""}");
                             Function0RawBindings.Add(@"{""name"":""HttpResponse"",""type"":""http"",""direction"":""Out""}");
 

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -158,7 +158,14 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         [QueueOutput("queue2")]
                         public object BlobToQueue(
                             [BlobTrigger("container2/%file%")] string blob)
+                        {
+                            throw new NotImplementedException();
+                        }
 
+                        [Function("BlobsToQueueFunction")]
+                        [QueueOutput("queue2")]
+                        public object BlobsToQueue(
+                            [BlobInput("container2", IsBatched = true)] IEnumerable<string> blobs)
                         {
                             throw new NotImplementedException();
                         }
@@ -212,6 +219,19 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                                 ScriptFile = "TestProject.dll"
                             };
                             metadataList.Add(Function1);
+                            var Function2RawBindings = new List<string>();
+                            Function2RawBindings.Add(@"{""name"":""$return"",""type"":""Queue"",""direction"":""Out"",""queueName"":""queue2""}");
+                            Function2RawBindings.Add(@"{""name"":""blobs"",""type"":""Blob"",""direction"":""In"",""blobPath"":""container2"",""cardinality"":""Many""}");
+                
+                            var Function2 = new DefaultFunctionMetadata
+                            {
+                                Language = "dotnet-isolated",
+                                Name = "BlobsToQueueFunction",
+                                EntryPoint = "TestProject.QueueTriggerAndOutput.BlobsToQueue",
+                                RawBindings = Function2RawBindings,
+                                ScriptFile = "TestProject.dll"
+                            };
+                            metadataList.Add(Function2);
 
                             return Task.FromResult(metadataList.ToImmutableArray());
                         }

--- a/test/SdkE2ETests/Contents/functions.metadata
+++ b/test/SdkE2ETests/Contents/functions.metadata
@@ -53,6 +53,7 @@
         "dataType": "String",
         "blobPath": "test-samples/sample1.txt",
         "connection": "AzureWebJobsStorage",
+        "cardinality": "One",
         "properties": {}
       },
       {
@@ -190,6 +191,7 @@
         "dataType": "String",
         "blobPath": "test-samples/sample1.txt",
         "connection": "AzureWebJobsStorage",
+        "cardinality": "One",
         "properties": {}
       }
     ],


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1204

Adding isBatched attribute as the [FunctionMetadataGenerator](https://github.com/Azure/azure-functions-dotnet-worker/blob/7b0860ade7ec3ac362e3e80cfe16fb36d67afac1/sdk/Sdk/FunctionMetadataGenerator.cs#L541) already has the logic to correctly assign the `cardinality` to `Many` if `isBatched = true`

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
