### PR TITLE
Implement SupportsDeferredBindingAttribute

### DIFF
--- a/extensions/Worker.Extensions.Abstractions/src/ExtensionInformationAttribute.cs
+++ b/extensions/Worker.Extensions.Abstractions/src/ExtensionInformationAttribute.cs
@@ -14,24 +14,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Abstractions
 
         public bool EnableImplicitRegistration { get; }
 
-        public bool SupportsDeferredBinding { get; }
-
         public ExtensionInformationAttribute(string extensionPackage, string extensionVersion)
-            : this(extensionPackage, extensionVersion, false, false)
+            : this(extensionPackage, extensionVersion, false)
         {
         }
 
         public ExtensionInformationAttribute(string extensionPackage, string extensionVersion, bool enableImplicitRegistration)
-            : this(extensionPackage, extensionVersion, enableImplicitRegistration, false)
-        {
-        }
-
-        public ExtensionInformationAttribute(string extensionPackage, string extensionVersion, bool enableImplicitRegistration, bool supportsDeferredBinding)
         {
             ExtensionPackage = extensionPackage;
             ExtensionVersion = extensionVersion;
             EnableImplicitRegistration = enableImplicitRegistration;
-            SupportsDeferredBinding = supportsDeferredBinding;
         }
     }
 }

--- a/extensions/Worker.Extensions.Abstractions/src/SupportsDeferredBindingAttribute.cs
+++ b/extensions/Worker.Extensions.Abstractions/src/SupportsDeferredBindingAttribute.cs
@@ -5,6 +5,10 @@ using System;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Abstractions
 {
+    /// <summary>
+    /// Specifies if a binding attribute supports deferred binding when generating function metadata.
+    /// This is to be used on input, output or trigger attributes that support deferred binding.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public class SupportsDeferredBindingAttribute : Attribute
     {

--- a/extensions/Worker.Extensions.Abstractions/src/SupportsDeferredBindingAttribute.cs
+++ b/extensions/Worker.Extensions.Abstractions/src/SupportsDeferredBindingAttribute.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Abstractions
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SupportsDeferredBindingAttribute : Attribute
+    {
+    }
+}

--- a/sdk/Sdk/Constants.cs
+++ b/sdk/Sdk/Constants.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         internal const string FixedDelayRetryAttributeType = "Microsoft.Azure.Functions.Worker.FixedDelayRetryAttribute";
         internal const string ExponentialBackoffRetryAttributeType = "Microsoft.Azure.Functions.Worker.ExponentialBackoffRetryAttribute";
         internal const string BindingPropertyNameAttributeType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.BindingPropertyNameAttribute";
+        internal const string SupportsDeferredBindingAttributeType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.SupportsDeferredBindingAttribute";
 
         // System types
         internal const string IEnumerableType = "System.Collections.IEnumerable";

--- a/sdk/Sdk/FunctionMetadataGenerator.cs
+++ b/sdk/Sdk/FunctionMetadataGenerator.cs
@@ -574,12 +574,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             return binding;
         }
 
-        private static bool SupportsDeferredBinding(CustomAttribute attribute)
-        {
-            var typeDefinition = attribute.AttributeType.Resolve();
-            return typeDefinition.CustomAttributes.Any(a => a.AttributeType.FullName == Constants.SupportsDeferredBindingAttributeType);
-        }
-
         private static bool IsIterableCollection(TypeReference type, out DataType dataType)
         {
             // Array and not byte array
@@ -799,6 +793,19 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             }
 
             return Constants.InputBindingDirection;
+        }
+
+        private static bool SupportsDeferredBinding(CustomAttribute attribute)
+        {
+            var typeDefinition = attribute?.AttributeType?.Resolve();
+
+            if (typeDefinition is null)
+            {
+                return false;
+            }
+
+            return typeDefinition.CustomAttributes
+                                 .Any(a => string.Equals(a.AttributeType.FullName, Constants.SupportsDeferredBindingAttributeType, StringComparison.Ordinal));
         }
 
         private static bool IsOutputBindingType(CustomAttribute attribute)

--- a/sdk/Sdk/FunctionMetadataGenerator.cs
+++ b/sdk/Sdk/FunctionMetadataGenerator.cs
@@ -7,9 +7,7 @@ using System.Diagnostics;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Mono.Cecil;
-using Mono.Collections.Generic;
 
 namespace Microsoft.Azure.Functions.Worker.Sdk
 {
@@ -120,7 +118,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
                 functions.AddRange(functionsResult);
             }
 
-            if (!moduleExtensionRegistered && TryAddExtensionInfo(_extensions, module.Assembly, out bool supportsDeferredBinding, usedByFunction: false))
+            if (!moduleExtensionRegistered && TryAddExtensionInfo(_extensions, module.Assembly, usedByFunction: false))
             {
                 _logger.LogMessage($"Implicitly registered {module.FileName} as an extension.");
             }
@@ -347,7 +345,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
                     foundOutputAttribute = true;
 
                     AddOutputBindingMetadata(bindingMetadata, propertyAttribute, property.PropertyType, property.Name);
-                    AddExtensionInfo(_extensions, propertyAttribute, out bool supportsDeferredBinding);
+                    AddExtensionInfo(_extensions, propertyAttribute);
                 }
             }
         }
@@ -367,7 +365,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
                     }
 
                     AddOutputBindingMetadata(bindingMetadata, methodAttribute, methodAttribute.AttributeType, Constants.ReturnBindingName);
-                    AddExtensionInfo(_extensions, methodAttribute, out bool supportsDeferredBinding);
+                    AddExtensionInfo(_extensions, methodAttribute);
 
                     foundBinding = true;
                 }
@@ -384,8 +382,8 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
                 {
                     if (IsFunctionBindingType(parameterAttribute))
                     {
-                        AddExtensionInfo(_extensions, parameterAttribute, out bool supportsDeferredBinding);
-                        AddBindingMetadata(bindingMetadata, parameterAttribute, parameter.ParameterType, parameter.Name, supportsDeferredBinding);
+                        AddExtensionInfo(_extensions, parameterAttribute);
+                        AddBindingMetadata(bindingMetadata, parameterAttribute, parameter.ParameterType, parameter.Name);
                     }
                 }
             }
@@ -416,10 +414,10 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             AddBindingMetadata(bindingMetadata, attribute, parameterType, parameterName: name);
         }
 
-        private static void AddBindingMetadata(IList<ExpandoObject> bindingMetadata, CustomAttribute attribute, TypeReference parameterType, string? parameterName, bool supportsReferenceType = false)
+        private static void AddBindingMetadata(IList<ExpandoObject> bindingMetadata, CustomAttribute attribute, TypeReference parameterType, string? parameterName)
         {
             string bindingType = GetBindingType(attribute);
-            ExpandoObject binding = BuildBindingMetadataFromAttribute(attribute, bindingType, parameterType, parameterName, supportsReferenceType);
+            ExpandoObject binding = BuildBindingMetadataFromAttribute(attribute, bindingType, parameterType, parameterName);
             bindingMetadata.Add(binding);
         }
 
@@ -471,7 +469,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             return bindingNameAliasMap;
         }
 
-        private static ExpandoObject BuildBindingMetadataFromAttribute(CustomAttribute attribute, string bindingType, TypeReference parameterType, string? parameterName, bool supportsDeferredBinding)
+        private static ExpandoObject BuildBindingMetadataFromAttribute(CustomAttribute attribute, string bindingType, TypeReference parameterType, string? parameterName)
         {
             ExpandoObject binding = new ExpandoObject();
 
@@ -489,7 +487,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
 
             // For extensions that support deferred binding, set the supportsDeferredBinding property so parameters are bound by the worker
             // Only use deferred binding for input and trigger bindings, output is out not currently supported
-            if (supportsDeferredBinding && direction != Constants.OutputBindingDirection)
+            if (SupportsDeferredBinding(attribute) && direction != Constants.OutputBindingDirection)
             {
                 bindingProperties.Add(Constants.SupportsDeferredBindingProperty, Boolean.TrueString);
             }
@@ -574,6 +572,12 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             bindingDict["Properties"] = bindingProperties;
 
             return binding;
+        }
+
+        private static bool SupportsDeferredBinding(CustomAttribute attribute)
+        {
+            var typeDefinition = attribute.AttributeType.Resolve();
+            return typeDefinition.CustomAttributes.Any(a => a.AttributeType.FullName == Constants.SupportsDeferredBindingAttributeType);
         }
 
         private static bool IsIterableCollection(TypeReference type, out DataType dataType)
@@ -752,16 +756,14 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             bindingMetadata.Add((ExpandoObject)returnBinding);
         }
 
-        private static void AddExtensionInfo(IDictionary<string, string> extensions, CustomAttribute attribute, out bool supportsDeferredBinding)
+        private static void AddExtensionInfo(IDictionary<string, string> extensions, CustomAttribute attribute)
         {
             AssemblyDefinition extensionAssemblyDefinition = attribute.AttributeType.Resolve().Module.Assembly;
-            TryAddExtensionInfo(extensions, extensionAssemblyDefinition, out supportsDeferredBinding);
+            TryAddExtensionInfo(extensions, extensionAssemblyDefinition);
         }
 
-        private static bool TryAddExtensionInfo(IDictionary<string, string> extensions, AssemblyDefinition extensionAssemblyDefinition, out bool supportsDeferredBinding, bool usedByFunction = true)
+        private static bool TryAddExtensionInfo(IDictionary<string, string> extensions, AssemblyDefinition extensionAssemblyDefinition, bool usedByFunction = true)
         {
-            supportsDeferredBinding = false;
-
             foreach (var assemblyAttribute in extensionAssemblyDefinition.CustomAttributes)
             {
                 if (string.Equals(assemblyAttribute.AttributeType.FullName, Constants.ExtensionsInformationType, StringComparison.Ordinal))
@@ -774,11 +776,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
                     {
                         // EnableImplicitRegistration
                         implicitlyRegister = (bool)assemblyAttribute.ConstructorArguments[2].Value;
-                    }
-                    
-                    if (assemblyAttribute.ConstructorArguments.Count >= 4)
-                    {
-                        supportsDeferredBinding = (bool)assemblyAttribute.ConstructorArguments[3].Value;
                     }
 
                     if (usedByFunction || implicitlyRegister)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1266

Today we have have a single SupportsDeferredBinding attribute that extensions can set to indicate that ParameterBindingData can be used (i.e. the extension supports sdk-type bindings). This is used by the FunctionMetadataGenerator to set the "supportsDeferringBinding" property for every function.

The goal for this issue is to refactor the SupportsDeferredBinding attribute so that instead of being a blanket "all or nothing" approach for extensions, we can set the supportsDeferredBinding flag per binding instead. For example, the CosmosDBTrigger does not support deferred binding but we can use deferred binding for the input binding.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
