### PR TITLE
Add  "workerIndexing": "true" in nativehost worker config

### DIFF
--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.0-preview5</version>
+    <version>1.0.0-preview6</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>

--- a/host/tools/build/worker.config.json
+++ b/host/tools/build/worker.config.json
@@ -3,6 +3,7 @@
     "language": "dotnet-isolated",
     "extensions": [ ".dll" ],
     "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost.exe",
-    "defaultWorkerPath": "bin/FunctionsNetHost.exe"
+    "defaultWorkerPath": "bin/FunctionsNetHost.exe",
+    "workerIndexing": "true"
   }
 }


### PR DESCRIPTION
Add  "workerIndexing": "true" in nativehost worker config. This is needed for the host to use worker indexing.

This change is a follow up to #1258 