### PR TITLE
Hosted service for logging a function's resolved binding types

### DIFF
--- a/src/DotNetWorker.Core/Diagnostics/FunctionInvocationScope.cs
+++ b/src/DotNetWorker.Core/Diagnostics/FunctionInvocationScope.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
 
         private string? _cachedToString;
 
-        public FunctionInvocationScope(string functionName, string invocationid)
+        public FunctionInvocationScope(string functionName, string invocationId)
         {
             _functionName = functionName;
-            _invocationId = invocationid;
+            _invocationId = invocationId;
         }
 
         public KeyValuePair<string, object> this[int index]

--- a/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
@@ -70,6 +70,9 @@ namespace Microsoft.Extensions.DependencyInjection
             // Worker initialization service
             services.AddSingleton<IHostedService, WorkerHostedService>();
 
+            // Binding logger service
+            services.AddSingleton<IHostedService, BindingLoggerHostedService>();
+
             // Default serializer settings
             services.AddOptions<WorkerOptions>()
                 .PostConfigure<IOptions<JsonSerializerOptions>>((workerOptions, serializerOptions) =>

--- a/src/DotNetWorker.Core/Logging/BindingLoggerHostedService.cs
+++ b/src/DotNetWorker.Core/Logging/BindingLoggerHostedService.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace  Microsoft.Azure.Functions.Worker.Logging
+{
+    /// <summary>
+    /// Service responsible for logging the binding type that has been resolved for each function.
+    /// This log only occurs once 10 seconds the worker has been initialized to avoid cold start
+    /// impact.
+    /// </summary>
+    public class BindingLoggerHostedService : IHostedService, IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly Timer _timer;
+        private readonly int _due = 10000; // 10 seconds
+        private bool _disposed;
+
+        /// <summary>
+        /// TODO: should we be using IWorkerDiagnostics?
+        /// </summary>
+        public BindingLoggerHostedService(ILogger<BindingLoggerHostedService> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _timer = new Timer(PublishLogs);
+        }
+
+        /// <inheritdoc/>
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (_disposed || _timer is null)
+            {
+                return Task.FromException(new InvalidOperationException("Service has already been disposed"));
+            }
+
+            try
+            {
+                // start the timer by setting the due time
+                _timer.Change(_due, Timeout.Infinite);
+            }
+            catch (Exception exc)
+            {
+                _logger.LogWarning(exc, "Unable to set timer interval");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            // stop the timer if it has been started
+            _timer?.Change(Timeout.Infinite, Timeout.Infinite);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Log the binding type that has been resolved for each function
+        /// </summary>
+        private void PublishLogs(object? state)
+        {
+            try
+            {
+                // TODO: figure out how to get the resolved binding type
+                _logger.LogInformation("Function 'blah' resolved binding to 'blah'");
+                // or
+                // _diagnostics.BindingResolved();
+            }
+            catch (Exception exc)
+            {
+                _logger.LogWarning(exc, "Failed to publish binding logs");
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _timer?.Dispose();
+            _disposed = true;
+        }
+    }
+}


### PR DESCRIPTION
Would love some early feedback on:

1. Is this the right approach for logging something once?
2. What is a good timeframe for sending this log out to avoid cold start impact?
3. Should I be using WorkerDiagnostics or something else?
4. Any ideas on how I can get the resolved binding information here so I can log it out properly?

### Issue describing the changes in this PR

resolves #1257

We need a way to determine what we are resolving the ParameterBindingData type to on the worker side. For example, if a user binds to a BlobClient are we correctly hydrating and returning a BlobClient to the user when we use the ParameterBindingData reference type. This aim of this is to give us telemetry to better understand the SDK-binding feature adoption and what customers are most commonly binding to.

- Data: what customers are binding to in their Functions i.e. BlobClient, string, etc.
- Interval: once, we only need this information once per function app
- Usage: telemetry on feature adoption and most commonly used bindings
    - This will help us figure out what to prioritize in terms of building out more extension support using SDK-type bindings
    - Currently we can't know if the work is actually being leveraged for SDK types, people can still be using strings even with the deferred binding feature which doesn't indicate value of the Azure SDKs themselves.
    - Potentially helpful for debugging if customers bind to BlobClient and we provide them a string or other type
    -  (I can get more information from our PMs about what else they want to use this for)

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
