### PR TITLE
Fixed incorrect type of CosmosDBTriggerAttribute's `StartFromTime` property(bool to string).

### DIFF
--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -2,4 +2,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
-- 4.0.0 release of Microsoft.Azure.Functions.Worker.Extensions.CosmosDB
+- Fixed incorrect type of CosmosDBTriggerAttribute's `StartFromTime` property.

--- a/extensions/Worker.Extensions.CosmosDB/src/CosmosDBTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/CosmosDBTriggerAttribute.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Functions.Worker
         /// The recommended format is ISO 8601 with the UTC designator. 
         /// For example: "2021-02-16T14:19:29Z"
         /// </summary>
-        public bool? StartFromTime { get; set; }
+        public string? StartFromTime { get; set; }
 
         /// <summary>
         /// Optional.

--- a/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
+++ b/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Cosmos DB extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
Fixed incorrect type of CosmosDBTriggerAttribute's `StartFromTime` property(bool to string) so that it matches with the web-jobs version.

https://github.com/Azure/azure-webjobs-sdk-extensions/blob/cosmos-v4.0.0/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs#L123

