### PR TITLE
[Sdk] Fixing publish code path - Avoid registering metadata loader extension when running in the native worker

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -296,6 +296,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           OutputPath="$(PublishDir)"/>
 
         <Copy
+          Condition="!$(FunctionsEnablePlaceholder)"
           SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
           DestinationFolder="$(ExtensionsCsProjFilePath)\publishout"
           OverwriteReadOnlyFiles="true" />
@@ -326,6 +327,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           OutputPath="$(PublishDir)"/>
 
         <Copy
+          Condition="!$(FunctionsEnablePlaceholder)"
           SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
           DestinationFolder="$(ExtensionsCsProjFilePath)\publishout"
           OverwriteReadOnlyFiles="true" />


### PR DESCRIPTION
Same changes as in #1258 , but for the dotnet publish code path.

in 1258, I tested it only for build (dotnet build), so it was not applicable to dotnet publish code path.