### PR TITLE
Redo shared file inclusion via MSBuild task

### DIFF
--- a/build/SharedReferences.targets
+++ b/build/SharedReferences.targets
@@ -1,15 +1,42 @@
 <Project>
 
-  <Target Name="IncludeSharedItems" BeforeTargets="BeforeCompile" Condition="'@(SharedReference)' != ''">
+  <Target Name="IncludeSharedItems"
+    BeforeTargets="BeforeCompile"
+    DependsOnTargets="_IncludeSharedCompile;_IncludeSharedEmbeddedResource"
+    Condition="'@(SharedReference)' != ''" />
 
-    <PropertyGroup>
-      <_SharedReferenceCompileIncludes>@(SharedReference->'%(RelativeDir)**/*.cs')</_SharedReferenceCompileIncludes>
-    </PropertyGroup>
-
+  <Target Name="_IncludeSharedCompile">
+    <MSBuild Projects="@(SharedReference)" Targets="GetSharedCompileItems" RebaseOutputs="true">
+      <Output TaskParameter="TargetOutputs" ItemName="SharedCompile" />
+    </MSBuild>
     <ItemGroup>
-      <Compile Include="$(_SharedReferenceCompileIncludes)" LinkBase="Shared" Visible="false" />
+      <Compile Include="@(SharedCompile)" LinkBase="%(SharedCompile.SharedLinkBase)" Visible="false" />
     </ItemGroup>
+  </Target>
 
+  <Target Name="_IncludeSharedEmbeddedResource">
+    <MSBuild Projects="@(SharedReference)" Targets="GetSharedEmbeddedResourceItems" RebaseOutputs="true">
+      <Output TaskParameter="TargetOutputs" ItemName="SharedEmbeddedResource" />
+    </MSBuild>
+    <ItemGroup>
+      <EmbeddedResource Include="@(SharedEmbeddedResource)" LinkBase="%(SharedEmbeddedResource.SharedLinkBase)" Visible="false" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetSharedCompileItems" Outputs="@(_SharedCompile)">
+    <ItemGroup>
+      <_SharedCompile Include="@(Compile)" SharedLinkBase="$(MSBuildProjectName)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetSharedEmbeddedResourceItems" Outputs="@(_SharedEmbeddedResource)">
+    <ItemGroup>
+      <_SharedEmbeddedResource Include="@(EmbeddedResource)" SharedLinkBase="$(MSBuildProjectName)">
+        <!-- We need to explicitly set LogicalName to ensure the recieving project will get the same logical name our designer .cs file was generated with -->
+        <RecursiveNamespace>$([System.String]::Copy('%(RecursiveDir)').Replace($([System.IO.Path]::DirectorySeparatorChar.ToString()), '.'))</RecursiveNamespace>
+        <LogicalName Condition="'%(EmbeddedResource.LogicalName)' == ''">$(RootNamespace).%(_SharedEmbeddedResource.RecursiveNamespace)%(Filename).resources</LogicalName>
+      </_SharedEmbeddedResource>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/build/SharedReferences.targets
+++ b/build/SharedReferences.targets
@@ -32,7 +32,7 @@
   <Target Name="GetSharedEmbeddedResourceItems" Outputs="@(_SharedEmbeddedResource)">
     <ItemGroup>
       <_SharedEmbeddedResource Include="@(EmbeddedResource)" SharedLinkBase="$(MSBuildProjectName)">
-        <!-- We need to explicitly set LogicalName to ensure the recieving project will get the same logical name our designer .cs file was generated with -->
+        <!-- We need to explicitly set LogicalName to ensure the receiving project will get the same logical name our designer .cs file was generated with -->
         <RecursiveNamespace>$([System.String]::Copy('%(RecursiveDir)').Replace($([System.IO.Path]::DirectorySeparatorChar.ToString()), '.'))</RecursiveNamespace>
         <LogicalName Condition="'%(EmbeddedResource.LogicalName)' == ''">$(RootNamespace).%(_SharedEmbeddedResource.RecursiveNamespace)%(Filename).resources</LogicalName>
       </_SharedEmbeddedResource>

--- a/extensions/Worker.Extensions.Shared/Worker.Extensions.Shared.csproj
+++ b/extensions/Worker.Extensions.Shared/Worker.Extensions.Shared.csproj
@@ -12,6 +12,7 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <EnableDefaultCompileItems>true</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>true</EnableDefaultEmbeddedResourceItems>
+    <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/Worker.Extensions.Shared/readme.md
+++ b/extensions/Worker.Extensions.Shared/readme.md
@@ -13,12 +13,11 @@ Include helpers, utility classes, or extension methods here. Keep in mind the de
 
 ## Adding files
 
-Just add any `.cs` file here as needed. Some things to keep in mind:
+Just add any `.cs` or `.resx` file here as needed. Some things to keep in mind:
 
-❌ `.resx` files are not yet supported. Additional work is needed to transform how they are included into the target projects.
 ❌ **never** include `public` types. \
 ✅ `internal` or `private` are fine. \
-⚠️ consider always rooting the namespace as `Microsoft.Azure.Functions.Worker`. \
+⚠️ consider rooting the namespace of shared types as `Microsoft.Azure.Functions.Worker.Extensions`. \
 
 ## How to reference
 
@@ -37,3 +36,7 @@ Just add any `.cs` file here as needed. Some things to keep in mind:
   <SharedReference Include="../../Worker.Extensions.Shared/Worker.Extensions.Shared.csproj" />
 </ItemGroup>
 ```
+
+## How does it work?
+
+The `.csproj` in this directly only exists for showing these files in Visual Studio and for design-time builds (intellisense). This project uses `Microsoft.Build.NoTargets` SDK, which means it has absolutely **zero** build output. There is no `dll` and no `nupkg` package produced from this project. Instead, all files are directly linked into projects that reference this via a `SharedReference Include=".."` msbuild item.

--- a/extensions/Worker.Extensions.Shared/readme.md
+++ b/extensions/Worker.Extensions.Shared/readme.md
@@ -39,4 +39,6 @@ Just add any `.cs` or `.resx` file here as needed. Some things to keep in mind:
 
 ## How does it work?
 
-The `.csproj` in this directly only exists for showing these files in Visual Studio and for design-time builds (intellisense). This project uses `Microsoft.Build.NoTargets` SDK, which means it has absolutely **zero** build output. There is no `dll` and no `nupkg` package produced from this project. Instead, all files are directly linked into projects that reference this via a `SharedReference Include=".."` msbuild item.
+The `.csproj` in this directly exists for two purposes: (1) showing files in Visual Studio. and (2) listing _what_ items to include via `MSBuild` targets. When you include `<SharedReference>`, that project will call into project in the `Include` to ask it "What are your compile items?" "What are your embedded resources?" and then the calling project will include those directly into its own compile and embedded resource item groups.
+
+This project uses `Microsoft.Build.NoTargets` SDK, which means it has absolutely **zero** build output. There is no `dll` and no `nupkg` package produced from this project. Instead, all files are directly linked into projects that reference this via a `SharedReference Include=".."` msbuild item.


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Re-does #1308 to use the `MSBuild` task to call into the shared project and have it explicitly list its compile items. This also adds support for sharing `.resx` files so we can have shared localized strings, particularly error strings.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

