### PR TITLE
Exposing IFunctionExecutor and IModelBindingFeature as public types

### DIFF
--- a/src/DotNetWorker.Core/Context/Features/DefaultBindingFeatureProvider.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultBindingFeatureProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
     internal class DefaultBindingFeatureProvider : IInvocationFeatureProvider
     {
         private readonly IConverterContextFactory _converterContextFactory;
-        private static readonly Type _featureType = typeof(IModelBindingFeature);
+        private static readonly Type _featureType = typeof(IFunctionInputBindingFeature);
 
         public DefaultBindingFeatureProvider(IConverterContextFactory converterContextFactory)
         {
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
         public bool TryCreate(Type type, out object? feature)
         {
             feature = type == _featureType
-                ? new DefaultModelBindingFeature(_converterContextFactory)
+                ? new DefaultFunctionInputBindingFeature(_converterContextFactory)
                 : null;
 
             return feature is not null;

--- a/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
@@ -4,14 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Converters;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.Functions.Worker.Context.Features
 {
-    internal class DefaultFunctionInputBindingFeature : IFunctionInputBindingFeature
+    internal class DefaultFunctionInputBindingFeature : IFunctionInputBindingFeature, IDisposable
     {
+        private readonly SemaphoreSlim _semaphoreSlim = new(1, 1);
         private FunctionInputBindingResult? _inputBindingResult;
         private readonly IConverterContextFactory _converterContextFactory;
 
@@ -23,83 +25,97 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
         public async ValueTask<FunctionInputBindingResult> BindFunctionInputAsync(FunctionContext context)
         {
+            await _semaphoreSlim.WaitAsync();
+
             if (_inputBindingResult is not null)
             {
                 // Return the cached value if BindFunctionInputAsync is called a second time during invocation.
                 return _inputBindingResult!;
             }
 
-            IFunctionBindingsFeature functionBindings = context.GetBindings();
-            var inputBindingCache = context.InstanceServices.GetService<IBindingCache<ConversionResult>>();
-            var inputConversionFeature = context.Features.Get<IInputConversionFeature>();
-
-            if (inputConversionFeature == null)
+            try
             {
-                throw new InvalidOperationException("Input conversion feature is missing.");
-            }
+                IFunctionBindingsFeature functionBindings = context.GetBindings();
+                var inputBindingCache = context.InstanceServices.GetService<IBindingCache<ConversionResult>>();
+                var inputConversionFeature = context.Features.Get<IInputConversionFeature>();
 
-            var parameterValues = new object?[context.FunctionDefinition.Parameters.Length];
-            List<string>? errors = null;
-
-            for (int i = 0; i < parameterValues.Length; i++)
-            {
-                FunctionParameter param = context.FunctionDefinition.Parameters[i];
-
-                // Check InputData first, then TriggerMetadata
-                if (!functionBindings.InputData.TryGetValue(param.Name, out object? source))
+                if (inputConversionFeature == null)
                 {
-                    functionBindings.TriggerMetadata.TryGetValue(param.Name, out source);
+                    throw new InvalidOperationException("Input conversion feature is missing.");
                 }
 
-                ConversionResult bindingResult;
-                var cacheKey = param.Name;
-                if (inputBindingCache!.TryGetValue(param.Name, out var cachedResult))
-                {
-                    bindingResult = cachedResult;
-                }
-                else
-                {
-                    IReadOnlyDictionary<string, object> properties = ImmutableDictionary<string, object>.Empty;
+                var parameterValues = new object?[context.FunctionDefinition.Parameters.Length];
+                List<string>? errors = null;
 
-                    // Pass info about specific input converter type defined for this parameter, if present.
-                    if (param.Properties.TryGetValue(PropertyBagKeys.ConverterType, out var converterTypeAssemblyFullName))
+                for (int i = 0; i < parameterValues.Length; i++)
+                {
+                    FunctionParameter param = context.FunctionDefinition.Parameters[i];
+
+                    // Check InputData first, then TriggerMetadata
+                    if (!functionBindings.InputData.TryGetValue(param.Name, out object? source))
                     {
-                        properties = new Dictionary<string, object>()
+                        functionBindings.TriggerMetadata.TryGetValue(param.Name, out source);
+                    }
+
+                    ConversionResult bindingResult;
+                    var cacheKey = param.Name;
+                    if (inputBindingCache!.TryGetValue(param.Name, out var cachedResult))
+                    {
+                        bindingResult = cachedResult;
+                    }
+                    else
+                    {
+                        IReadOnlyDictionary<string, object> properties = ImmutableDictionary<string, object>.Empty;
+
+                        // Pass info about specific input converter type defined for this parameter, if present.
+                        if (param.Properties.TryGetValue(PropertyBagKeys.ConverterType, out var converterTypeAssemblyFullName))
+                        {
+                            properties = new Dictionary<string, object>()
                         {
                             { PropertyBagKeys.ConverterType, converterTypeAssemblyFullName }
                         };
+                        }
+
+                        var converterContext = _converterContextFactory.Create(param.Type, source, context, properties);
+
+                        bindingResult = await inputConversionFeature.ConvertAsync(converterContext);
+                        inputBindingCache[cacheKey] = bindingResult;
                     }
 
-                    var converterContext = _converterContextFactory.Create(param.Type, source, context, properties);
+                    if (bindingResult.Status == ConversionStatus.Succeeded)
+                    {
+                        parameterValues[i] = bindingResult.Value;
+                    }
+                    else if (bindingResult.Status == ConversionStatus.Failed && source is not null)
+                    {
+                        // Don't initialize this list unless we have to
+                        errors ??= new List<string>();
 
-                    bindingResult = await inputConversionFeature.ConvertAsync(converterContext);
-                    inputBindingCache[cacheKey] = bindingResult;
+                        errors.Add(
+                            $"Cannot convert input parameter '{param.Name}' to type '{param.Type.FullName}' from type '{source.GetType().FullName}'. Error:{bindingResult.Error}");
+                    }
                 }
 
-                if (bindingResult.Status == ConversionStatus.Succeeded)
+                // found errors
+                if (errors is not null)
                 {
-                    parameterValues[i] = bindingResult.Value;
+                    throw new FunctionInputConverterException(
+                        $"Error converting {errors.Count} input parameters for Function '{context.FunctionDefinition.Name}': {string.Join(Environment.NewLine, errors)}");
                 }
-                else if (bindingResult.Status == ConversionStatus.Failed && source is not null)
-                {
-                    // Don't initialize this list unless we have to
-                    errors ??= new List<string>();
 
-                    errors.Add(
-                        $"Cannot convert input parameter '{param.Name}' to type '{param.Type.FullName}' from type '{source.GetType().FullName}'. Error:{bindingResult.Error}");
-                }
+                _inputBindingResult = new FunctionInputBindingResult(parameterValues);
+
+                return _inputBindingResult;
             }
-
-            // found errors
-            if (errors is not null)
+            finally
             {
-                throw new FunctionInputConverterException(
-                    $"Error converting {errors.Count} input parameters for Function '{context.FunctionDefinition.Name}': {string.Join(Environment.NewLine, errors)}");
+                _semaphoreSlim.Release();
             }
+        }
 
-            _inputBindingResult = new FunctionInputBindingResult(parameterValues);
-
-            return _inputBindingResult;
+        public void Dispose()
+        {
+            _semaphoreSlim.Dispose();
         }
     }
 }

--- a/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
@@ -31,14 +31,14 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
             await _semaphoreSlim.WaitAsync(WaitTimeInMilliSeconds, context.CancellationToken);
 
-            if (_inputBindingResult is not null)
-            {
-                // Return the cached value if BindFunctionInputAsync is called a second time during invocation.
-                return _inputBindingResult!;
-            }
-
             try
             {
+                if (_inputBindingResult is not null)
+                {
+                    // Return the cached value if BindFunctionInputAsync is called a second time during invocation.
+                    return _inputBindingResult!;
+                }
+                
                 IFunctionBindingsFeature functionBindings = context.GetBindings();
                 var inputBindingCache = context.InstanceServices.GetService<IBindingCache<ConversionResult>>();
                 var inputConversionFeature = context.Features.Get<IInputConversionFeature>();

--- a/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
@@ -10,12 +10,12 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.Functions.Worker.Context.Features
 {
-    internal class DefaultModelBindingFeature : IModelBindingFeature
+    internal class DefaultFunctionInputBindingFeature : IFunctionInputBindingFeature
     {
         private FunctionInputBindingResult? _inputBindingResult;
         private readonly IConverterContextFactory _converterContextFactory;
 
-        public DefaultModelBindingFeature(IConverterContextFactory converterContextFactory)
+        public DefaultFunctionInputBindingFeature(IConverterContextFactory converterContextFactory)
         {
             _converterContextFactory = converterContextFactory ??
                                        throw new ArgumentNullException(nameof(converterContextFactory));

--- a/src/DotNetWorker.Core/Context/Features/DefaultModelBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultModelBindingFeature.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
             var parameterValues = new object?[context.FunctionDefinition.Parameters.Length];
             List<string>? errors = null;
-            
+
             for (int i = 0; i < parameterValues.Length; i++)
             {
                 FunctionParameter param = context.FunctionDefinition.Parameters[i];
@@ -62,8 +62,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                     IReadOnlyDictionary<string, object> properties = ImmutableDictionary<string, object>.Empty;
 
                     // Pass info about specific input converter type defined for this parameter, if present.
-                    if (param.Properties.TryGetValue(PropertyBagKeys.ConverterType,
-                            out var converterTypeAssemblyFullName))
+                    if (param.Properties.TryGetValue(PropertyBagKeys.ConverterType, out var converterTypeAssemblyFullName))
                     {
                         properties = new Dictionary<string, object>()
                         {

--- a/src/DotNetWorker.Core/Context/Features/FunctionInputBindingResult.cs
+++ b/src/DotNetWorker.Core/Context/Features/FunctionInputBindingResult.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker.Context.Features
+{
+    /// <summary>
+    /// A type representing the result of binding function inputs.
+    /// </summary>
+    public class FunctionInputBindingResult
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="FunctionInputBindingResult"/>
+        /// </summary>
+        /// <param name="values">An array of function input values.</param>
+        public FunctionInputBindingResult(object?[] values)
+        {
+            Values = values;
+        }
+        
+        /// <summary>
+        /// Gets the values of bound function inputs.
+        /// </summary>
+        public object?[] Values { get; set; }
+    }
+}

--- a/src/DotNetWorker.Core/Context/Features/FunctionInputBindingResult.cs
+++ b/src/DotNetWorker.Core/Context/Features/FunctionInputBindingResult.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
         }
 
         /// <summary>
-        /// Gets or sets the values of bound function inputs.
+        /// Gets the values of bound function inputs.
         /// </summary>
-        public object?[] Values { get; set; }
+        public object?[] Values { get; }
     }
 }

--- a/src/DotNetWorker.Core/Context/Features/FunctionInputBindingResult.cs
+++ b/src/DotNetWorker.Core/Context/Features/FunctionInputBindingResult.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
         {
             Values = values;
         }
-        
+
         /// <summary>
-        /// Gets the values of bound function inputs.
+        /// Gets or sets the values of bound function inputs.
         /// </summary>
         public object?[] Values { get; set; }
     }

--- a/src/DotNetWorker.Core/Context/Features/IFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/IFunctionInputBindingFeature.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
     public interface IFunctionInputBindingFeature
     {
         /// <summary>
-        /// Binds function inputs.
+        /// Asynchronously binds the function inputs.
         /// </summary>
         /// <param name="context">The <see cref="FunctionContext"/> instance.</param>
-        /// <returns>An array of bounded input values.</returns>
+        /// <returns>A <see cref="ValueTask{TResult}"/>that will contain an instance of the <see cref="FunctionInputBindingResult"/>.</returns>
         ValueTask<FunctionInputBindingResult> BindFunctionInputAsync(FunctionContext context);
     }
 }

--- a/src/DotNetWorker.Core/Context/Features/IFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/IFunctionInputBindingFeature.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
     /// <summary>
     /// Provides a mechanism to bind function inputs.
     /// </summary>
-    public interface IModelBindingFeature
+    public interface IFunctionInputBindingFeature
     {
         /// <summary>
         /// Binds function inputs.

--- a/src/DotNetWorker.Core/Context/Features/IModelBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/IModelBindingFeature.cs
@@ -5,10 +5,16 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Functions.Worker.Context.Features
 {
-    internal interface IModelBindingFeature
+    /// <summary>
+    /// Provides a mechanism to bind function inputs.
+    /// </summary>
+    public interface IModelBindingFeature
     {
-        object?[]? InputArguments { get; }
-
-        ValueTask<object?[]> BindFunctionInputAsync(FunctionContext context);
+        /// <summary>
+        /// Binds function inputs.
+        /// </summary>
+        /// <param name="context">The <see cref="FunctionContext"/> instance.</param>
+        /// <returns>An array of bounded input values.</returns>
+        ValueTask<FunctionInputBindingResult> BindFunctionInputAsync(FunctionContext context);
     }
 }

--- a/src/DotNetWorker.Core/DotNetWorker.Core.csproj
+++ b/src/DotNetWorker.Core/DotNetWorker.Core.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Core</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>10</MinorProductVersion>
+    <MinorProductVersion>11</MinorProductVersion>
     <VersionSuffix>-preview1</VersionSuffix>
   </PropertyGroup>
 

--- a/src/DotNetWorker.Core/Helpers/ThrowHelpers/ObjectDisposedThrowHelper.cs
+++ b/src/DotNetWorker.Core/Helpers/ThrowHelpers/ObjectDisposedThrowHelper.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    internal static class ObjectDisposedThrowHelper
+    {
+        /// <summary>Throws an <see cref="ObjectDisposedException"/> if the specified <paramref name="condition"/> is <see langword="true"/>.</summary>
+        /// <param name="condition">The condition to evaluate.</param>
+        /// <param name="instance">The object whose type's full name should be included in any resulting <see cref="ObjectDisposedException"/>.</param>
+        /// <exception cref="ObjectDisposedException">The <paramref name="condition"/> is <see langword="true"/>.</exception>
+        internal static void ThrowIf(bool condition, object instance)
+        {
+#if NET7_0_OR_GREATER
+            ObjectDisposedException.ThrowIf(condition, instance);
+#else
+            if (condition)
+            {
+                throw new ObjectDisposedException(instance?.GetType().FullName);
+            }
+#endif
+        }
+
+    }
+}

--- a/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.Log.cs
+++ b/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.Log.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Azure.Functions.Worker.Invocation
         private static class Log
         {
             private static readonly Action<ILogger, string, string, Exception?> _modelBindingFeatureUnavailable =
-                WorkerMessage.Define<string, string>(LogLevel.Warning, new EventId(2, nameof(ModelBindingFeatureUnavailable)),
-                    "The feature " + nameof(IModelBindingFeature) + " was not available for invocation '{invocationId}' of function '{functionName}'. Unable to process input bindings.");
+                WorkerMessage.Define<string, string>(LogLevel.Warning, new EventId(2, nameof(FunctionInputFeatureUnavailable)),
+                    "The feature " + nameof(IFunctionInputBindingFeature) + " was not available for invocation '{invocationId}' of function '{functionName}'. Unable to process input bindings.");
 
-            public static void ModelBindingFeatureUnavailable(ILogger<DefaultFunctionExecutor> logger, FunctionContext context)
+            public static void FunctionInputFeatureUnavailable(ILogger<DefaultFunctionExecutor> logger, FunctionContext context)
             {
                 _modelBindingFeatureUnavailable(logger, context.InvocationId, context.FunctionId, null);
             }

--- a/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.cs
+++ b/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.cs
@@ -28,18 +28,18 @@ namespace Microsoft.Azure.Functions.Worker.Invocation
                 _ => _invokerFactory.Create(context.FunctionDefinition));
 
             object? instance = invoker.CreateInstance(context);
-            var modelBindingFeature = context.Features.Get<IModelBindingFeature>();
+            var inputBindingFeature = context.Features.Get<IFunctionInputBindingFeature>();
 
             FunctionInputBindingResult inputBindingResult;
-            if (modelBindingFeature is null)
+            if (inputBindingFeature is null)
             {
-                Log.ModelBindingFeatureUnavailable(_logger, context);
+                Log.FunctionInputFeatureUnavailable(_logger, context);
                 var emptyArgsArray = new object?[context.FunctionDefinition.Parameters.Length];
                 inputBindingResult = new(emptyArgsArray);
             }
             else
             {
-                inputBindingResult = await modelBindingFeature.BindFunctionInputAsync(context);
+                inputBindingResult = await inputBindingFeature.BindFunctionInputAsync(context);
             }
 
             context.GetBindings().InvocationResult = await invoker.InvokeAsync(instance, inputBindingResult.Values);

--- a/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.cs
+++ b/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Functions.Worker.Invocation
 
             object? instance = invoker.CreateInstance(context);
             var modelBindingFeature = context.Features.Get<IModelBindingFeature>();
-            
+
             FunctionInputBindingResult inputBindingResult;
             if (modelBindingFeature is null)
             {

--- a/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.cs
+++ b/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.cs
@@ -22,26 +22,27 @@ namespace Microsoft.Azure.Functions.Worker.Invocation
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task ExecuteAsync(FunctionContext context)
+        public async ValueTask ExecuteAsync(FunctionContext context)
         {
             var invoker = _invokerCache.GetOrAdd(context.FunctionId,
                 _ => _invokerFactory.Create(context.FunctionDefinition));
 
             object? instance = invoker.CreateInstance(context);
             var modelBindingFeature = context.Features.Get<IModelBindingFeature>();
-
-            object?[] inputArguments;
+            
+            FunctionInputBindingResult inputBindingResult;
             if (modelBindingFeature is null)
             {
                 Log.ModelBindingFeatureUnavailable(_logger, context);
-                inputArguments = new object?[context.FunctionDefinition.Parameters.Length];
+                var emptyArgsArray = new object?[context.FunctionDefinition.Parameters.Length];
+                inputBindingResult = new(emptyArgsArray);
             }
             else
             {
-                inputArguments = await modelBindingFeature.BindFunctionInputAsync(context);
+                inputBindingResult = await modelBindingFeature.BindFunctionInputAsync(context);
             }
 
-            context.GetBindings().InvocationResult = await invoker.InvokeAsync(instance, inputArguments);
+            context.GetBindings().InvocationResult = await invoker.InvokeAsync(instance, inputBindingResult.Values);
         }
     }
 }

--- a/src/DotNetWorker.Core/Invocation/IFunctionExecutor.cs
+++ b/src/DotNetWorker.Core/Invocation/IFunctionExecutor.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Azure.Functions.Worker.Invocation
     public interface IFunctionExecutor
     {
         /// <summary>
-        /// Executes the function code.
+        /// Asynchronously executes the function code.
         /// </summary>
         /// <param name="context">The <see cref="FunctionContext"/> instance.</param>
-        /// <returns>A <see cref="Task"/> representing the result of execute operation.</returns>
+        /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
         ValueTask ExecuteAsync(FunctionContext context);
     }
 }

--- a/src/DotNetWorker.Core/Invocation/IFunctionExecutor.cs
+++ b/src/DotNetWorker.Core/Invocation/IFunctionExecutor.cs
@@ -1,13 +1,20 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.Azure.Functions.Worker.Pipeline;
 
 namespace Microsoft.Azure.Functions.Worker.Invocation
 {
-    internal interface IFunctionExecutor
+    /// <summary>
+    /// Provides a mechanism to execute function code.
+    /// </summary>
+    public interface IFunctionExecutor
     {
-        Task ExecuteAsync(FunctionContext context);
+        /// <summary>
+        /// Executes the function code.
+        /// </summary>
+        /// <param name="context">The <see cref="FunctionContext"/> instance.</param>
+        /// <returns>A <see cref="Task"/> representing the result of execute operation.</returns>
+        ValueTask ExecuteAsync(FunctionContext context);
     }
 }

--- a/src/DotNetWorker.Core/Pipeline/FunctionExecutionMiddleware.cs
+++ b/src/DotNetWorker.Core/Pipeline/FunctionExecutionMiddleware.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Functions.Worker.Pipeline
 
         public Task Invoke(FunctionContext context)
         {
-            return _functionExecutor.ExecuteAsync(context);
+            return _functionExecutor.ExecuteAsync(context).AsTask();
         }
     }
 }

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -8,8 +8,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>12</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
+    <MinorProductVersion>13</MinorProductVersion>
     <VersionSuffix>-preview1</VersionSuffix>
   </PropertyGroup>
 

--- a/test/DotNetWorkerTests/DefaultFunctionInvokerTests.cs
+++ b/test/DotNetWorkerTests/DefaultFunctionInvokerTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
                 new TypeConverter()
             };
             context.Features.Set<IInputConversionFeature>(_mockInputConversionFeature.Object);
-            context.Features.Set<IModelBindingFeature>(new DefaultModelBindingFeature(_mockConvertContextFactory.Object));
+            context.Features.Set<IFunctionInputBindingFeature>(new DefaultFunctionInputBindingFeature(_mockConvertContextFactory.Object));
             context.Features.Set<IFunctionBindingsFeature>(_functionBindings);
 
             await _executor.ExecuteAsync(context);
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var context = CreateContext(invocation: new TestFunctionInvocation());
             context.Features.Set<IFunctionBindingsFeature>(_functionBindings);
             context.Features.Set<IInputConversionFeature>(_mockInputConversionFeature.Object);
-            context.Features.Set<IModelBindingFeature>(new DefaultModelBindingFeature(_mockConvertContextFactory.Object));
+            context.Features.Set<IFunctionInputBindingFeature>(new DefaultFunctionInputBindingFeature(_mockConvertContextFactory.Object));
 
             await _executor.ExecuteAsync(context);
 

--- a/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
+++ b/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
@@ -50,13 +50,51 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var functionContext = new TestFunctionContext(definition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
 
             // Act
-            var parameterValuesArray = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
-
+            var bindingResult = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
+            var parameterValuesArray = bindingResult.Values;
             // Assert
             var book = TestUtility.AssertIsTypeAndConvert<Book>(parameterValuesArray[0]);
             Assert.Equal("foo", book.Id);
             var guid = TestUtility.AssertIsTypeAndConvert<Guid>(parameterValuesArray[1]);
             Assert.Equal("0ab4800e-1308-4e9f-be5f-4372717e68eb", guid.ToString());
+        }
+
+        [Fact]
+        public async void BindFunctionInputAsync_Returns_Cached_Value_When_Called_SecondTime()
+        {
+            // Arrange
+            var parameters = new List<FunctionParameter>()
+            {
+                new("myQueueItem",typeof(Book))
+            };
+            IInvocationFeatures features = new InvocationFeatures(Enumerable.Empty<IInvocationFeatureProvider>());
+            features.Set(_serviceProvider.GetService<IInputConversionFeature>());
+            features.Set<IFunctionBindingsFeature>(new TestFunctionBindingsFeature()
+            {
+                InputData = new Dictionary<string, object>
+                {
+                    { "myQueueItem","{\"id\":\"foo\"}" }
+                }
+            });
+
+            var definition = new TestFunctionDefinition(parameters: parameters, inputBindings: new Dictionary<string, BindingMetadata>
+            {
+                { "myQueueItem", new TestBindingMetadata("myQueueItem","queueTrigger",BindingDirection.In) }
+            });
+            var functionContext = new TestFunctionContext(definition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
+
+            // Act
+            var bindingResult1 = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
+            var parameterValuesArray = bindingResult1.Values;
+            // Assert
+            var book = TestUtility.AssertIsTypeAndConvert<Book>(parameterValuesArray[0]);
+            Assert.Equal("foo", book.Id);
+
+            // Update the result from caller side.
+            bindingResult1.Values[0] = new Book { Id = "bar" };
+            // Call Bind again. This should return the same result(bindingResult1) instead of rebinding everything from scratch.
+            var bindingResult2 = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
+            Assert.Same(bindingResult1, bindingResult2);
         }
 
         /// <summary>
@@ -109,8 +147,8 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Same(otherBook, bookInputBindingData2.Value);
 
             // Get all parameters from ModelBindingFeature. This should also reflect what we set above.
-            var parameterValuesArray = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
-            Assert.Same(otherBook, parameterValuesArray[0] as Book);
+            var bindingResult = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
+            Assert.Same(otherBook, bindingResult.Values[0] as Book);
         }
     }
 }

--- a/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
+++ b/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
         /// <summary>
         /// This UT simulates a case where the input binding entry is being updated (could be in a middleware) using the
-        /// BindInputAsync extension method result and that change is reflected when the ModelBindingFeature
+        /// BindInputAsync extension method result and that change is reflected when the FunctionInputBindingFeature
         /// returns the parameter values array for the function definition.
         /// </summary>
         [Fact]
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var bookInputBindingData2 = await functionContext.BindInputAsync<Book>(queueBindingMetaData);
             Assert.Same(otherBook, bookInputBindingData2.Value);
 
-            // Get all parameters from ModelBindingFeature. This should also reflect what we set above.
+            // Get all parameters from FunctionInputBindingFeature. This should also reflect what we set above.
             var bindingResult = await _functionInputBindingFeature.BindFunctionInputAsync(functionContext);
             Assert.Same(otherBook, bindingResult.Values[0] as Book);
         }

--- a/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
+++ b/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.Azure.Functions.Worker.Tests
 {
-    public class DefaultModelBindingFeatureTests
+    public class DefaultModelBindingFeatureTests : IDisposable
     {
         private readonly ServiceProvider _serviceProvider;
         private readonly DefaultFunctionInputBindingFeature _functionInputBindingFeature;
@@ -149,6 +149,12 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             // Get all parameters from FunctionInputBindingFeature. This should also reflect what we set above.
             var bindingResult = await _functionInputBindingFeature.BindFunctionInputAsync(functionContext);
             Assert.Same(otherBook, bindingResult.Values[0] as Book);
+        }
+
+        public void Dispose()
+        {
+            _serviceProvider?.Dispose();
+            _functionInputBindingFeature?.Dispose();
         }
     }
 }

--- a/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
+++ b/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Azure.Functions.Worker.Tests
     public class DefaultModelBindingFeatureTests
     {
         private readonly ServiceProvider _serviceProvider;
-        private readonly DefaultModelBindingFeature _modelBindingFeature;
+        private readonly DefaultFunctionInputBindingFeature _functionInputBindingFeature;
         public DefaultModelBindingFeatureTests()
         {
             var serializer = new JsonObjectSerializer(new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             _serviceProvider = TestUtility.GetServiceProviderWithInputBindingServices(o => o.Serializer = serializer);
-            _modelBindingFeature = _serviceProvider.GetService<DefaultModelBindingFeature>();
+            _functionInputBindingFeature = _serviceProvider.GetService<DefaultFunctionInputBindingFeature>();
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var functionContext = new TestFunctionContext(definition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
 
             // Act
-            var bindingResult = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
+            var bindingResult = await _functionInputBindingFeature.BindFunctionInputAsync(functionContext);
             var parameterValuesArray = bindingResult.Values;
             // Assert
             var book = TestUtility.AssertIsTypeAndConvert<Book>(parameterValuesArray[0]);
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var functionContext = new TestFunctionContext(definition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
 
             // Act
-            var bindingResult1 = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
+            var bindingResult1 = await _functionInputBindingFeature.BindFunctionInputAsync(functionContext);
             var parameterValuesArray = bindingResult1.Values;
             // Assert
             var book = TestUtility.AssertIsTypeAndConvert<Book>(parameterValuesArray[0]);
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             // Update the result from caller side.
             bindingResult1.Values[0] = new Book { Id = "bar" };
             // Call Bind again. This should return the same result(bindingResult1) instead of rebinding everything from scratch.
-            var bindingResult2 = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
+            var bindingResult2 = await _functionInputBindingFeature.BindFunctionInputAsync(functionContext);
             Assert.Same(bindingResult1, bindingResult2);
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Same(otherBook, bookInputBindingData2.Value);
 
             // Get all parameters from ModelBindingFeature. This should also reflect what we set above.
-            var bindingResult = await _modelBindingFeature.BindFunctionInputAsync(functionContext);
+            var bindingResult = await _functionInputBindingFeature.BindFunctionInputAsync(functionContext);
             Assert.Same(otherBook, bindingResult.Values[0] as Book);
         }
     }

--- a/test/DotNetWorkerTests/TestUtility.cs
+++ b/test/DotNetWorkerTests/TestUtility.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
                 .AddScoped<IBindingCache<ConversionResult>, DefaultBindingCache<ConversionResult>>()
                 .AddSingleton<IInputConversionFeature, DefaultInputConversionFeature>()
                 .Configure<WorkerOptions>(o => configure?.Invoke(o))
-                .AddSingleton<DefaultModelBindingFeature>()
+                .AddSingleton<DefaultFunctionInputBindingFeature>()
                 .AddDefaultInputConvertersToWorkerOptions()
                 .BuildServiceProvider();
         }


### PR DESCRIPTION
Renamed `IModelBindingFeature` to `IFunctionInputBindingFeature`

Exposes these 3 types as public(which is needed for #1284).

1. `IFunctionInputBindingFeature` (_existing type, changing from internal to public, also renamed_)
2. `IFunctionExecutor` (_existing type, changing from internal to public_)
3. `FunctionInputBindingResult` (_new type created_)

Also updated the DefaultFunctionInputBindingFeature (previously DefaultModelBindingFeature) to return cached result of `BindFunctionInputAsync` if called more than once. Previous behavior was to throw an exception.

API review : https://apiview.dev/Assemblies/Review/be448b28ba5842b9b4263de506641bdf/9d6979dae5024c4793b720caee527d5f?diffRevisionId=f44b689b998c47c5809b801fc5103617&doc=True&diffOnly=True

An early version of these changes were originally added in #1309. Once this change is merged, I will rebase that PR branch.