### PR TITLE
Added additional EventHub trigger samples

### DIFF
--- a/samples/Extensions/EventHubs/EventHubsTriggerMetadata.cs
+++ b/samples/Extensions/EventHubs/EventHubsTriggerMetadata.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 
@@ -50,5 +52,44 @@ namespace SampleApp
                 Dictionary<string, JsonElement> systemProperties = systemPropertiesArray[i];
             }
         }
+
+        // batched scenarios
+        [Function("EventHubsTriggerMetadata-ByteParameter-Batched")]
+        public static void UsingByteParameterBatched([EventHubTrigger("src-parameters", Connection = "EventHubConnectionAppSetting")] IEnumerable<byte[]> batchedMessages,
+           DateTime[] enqueuedTimeUtcArray,
+           long[] sequenceNumberArray,
+           string[] offsetArray,
+           Dictionary<string, JsonElement>[] propertiesArray,
+           Dictionary<string, JsonElement>[] systemPropertiesArray)
+        {
+            // You can directly access binding data via parameters.
+            for (int i = 0; i < batchedMessages.Count(); i++)
+            {
+                string message = Encoding.ASCII.GetString(batchedMessages.ElementAt(i));
+                DateTime enqueuedTimeUtc = enqueuedTimeUtcArray[i];
+                long sequenceNumber = sequenceNumberArray[i];
+                string offset = offsetArray[i];
+                Dictionary<string, JsonElement> properties = propertiesArray[i];
+                Dictionary<string, JsonElement> systemProperties = systemPropertiesArray[i];
+            }
+        }
+
+        // non-batched scenarios
+        [Function("EventHubsTriggerMetadata-ByteParameter-NotBatched")]
+        public static void UsingByteParameterNotBatched([EventHubTrigger("src-parameters", Connection = "EventHubConnectionAppSetting", IsBatched = false)] byte[] message,
+           DateTime enqueuedTimeUtc,
+           long sequenceNumber,
+           string offset,
+           Dictionary<string, JsonElement> properties,
+           Dictionary<string, JsonElement> systemProperties)
+        {
+            string _message = Encoding.ASCII.GetString(message);
+            DateTime _enqueuedTimeUtc = enqueuedTimeUtc;
+            long _sequenceNumber = sequenceNumber;
+            string _offset = offset;
+            Dictionary<string, JsonElement> _properties = properties;
+            Dictionary<string, JsonElement> _systemProperties = systemProperties;
+        }
     }
 }
+


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1354

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Added EventHub triggered samples to account for scenarios where messages are dequeued as `IEnumerable<byte[]>` and `byte[]`. 