### PR TITLE
small improvements to ci

### DIFF
--- a/build/install-dotnet.yml
+++ b/build/install-dotnet.yml
@@ -2,11 +2,13 @@ steps:
 - pwsh: |
     Invoke-WebRequest 'https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
     ./dotnet-install.ps1 -InstallDir "$env:ProgramFiles/dotnet" -Version "6.0.100" -Channel 'release'
+    dotnet --info
   displayName: 'Install the .Net version used by the Core Tools for Windows'
   condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq(variables['FUNCTIONSRUNTIMEVERSION'], '4'))
 
 - bash: |
     curl -sSL https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh | bash /dev/stdin -v '6.0.100' -c 'release' --install-dir /usr/share/dotnet
+    dotnet --info
   displayName: 'Install the .Net version used by the Core Tools for Linux'
   condition: and(eq( variables['Agent.OS'], 'Linux' ), eq(variables['FUNCTIONSRUNTIMEVERSION'], '4'))
   

--- a/tools/devpack.ps1
+++ b/tools/devpack.ps1
@@ -40,7 +40,7 @@ if (!(Test-Path $localPack))
 Write-Host
 Write-Host "---Updating project with local SDK pack---"
 Write-Host "Packing Core .NET Worker projects to $localPack"
-& "dotnet" "pack" $sdkProject "-o" "$localPack" "-nologo" "-p:BuildNumber=$buildNumber" $AdditionalPackArgs
+& "dotnet" "pack" $sdkProject "-p:PackageOutputPath=$localPack" "-nologo" "-p:BuildNumber=$buildNumber" $AdditionalPackArgs
 Write-Host
 
 Write-Host "Removing SDK package reference in $project"

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -57,7 +57,7 @@ if (!$SkipCosmosDBEmulator)
     $cosmosStatus = Get-CosmosDbEmulatorStatus
     Write-Host "CosmosDB emulator status: $cosmosStatus"
 
-    if ($waitSuccess -eq "StartPending")
+    if ($cosmosStatus -eq "StartPending")
     {        
         $startedCosmos = $true
     }
@@ -116,7 +116,7 @@ if (!$SkipCosmosDBEmulator -and $startedCosmos -eq $true)
 {
     Write-Host "---Waiting for CosmosDB emulator to be running---"
     $cosmosStatus = Get-CosmosDbEmulatorStatus
-    Write-Host "Cosmos status: $cosmosStatus"
+    Write-Host "CosmosDB emulator status: $cosmosStatus"
 
     $waitSuccess = Wait-CosmosDbEmulator -Status Running -Timeout 60
 

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -57,7 +57,7 @@ if (!$SkipCosmosDBEmulator)
     $cosmosStatus = Get-CosmosDbEmulatorStatus
     Write-Host "CosmosDB emulator status: $cosmosStatus"
 
-    if ($cosmosStatus -eq "StartPending")
+    if ($waitSuccess -eq "StartPending")
     {        
         $startedCosmos = $true
     }
@@ -115,13 +115,19 @@ if ($NoWait -eq $true)
 if (!$SkipCosmosDBEmulator -and $startedCosmos -eq $true)
 {
     Write-Host "---Waiting for CosmosDB emulator to be running---"
-    while ($cosmosStatus -ne "Running")
-    {
-        Write-Host "Cosmos emulator not ready. Status: $cosmosStatus"
-        $cosmosStatus = Get-CosmosDbEmulatorStatus
-        Start-Sleep -Seconds 5
-    }
+    $cosmosStatus = Get-CosmosDbEmulatorStatus
     Write-Host "Cosmos status: $cosmosStatus"
+
+    $waitSuccess = Wait-CosmosDbEmulator -Status Running -Timeout 60
+
+    if ($waitSuccess -ne $true)
+    {
+        Write-Host "CosmosDB emulator not yet running after waiting 60 seconds. Restarting."
+        Stop-CosmosDbEmulator
+        Write-Host "Restarting CosmosDB emulator"
+        Start-CosmosDbEmulator -NoUI
+    }
+
     Write-Host "------"
     Write-Host
 }

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -10,6 +10,8 @@ param(
     $NoWait
 )
 
+$DebugPreference = 'Continue'
+
 Write-Host "Skip CosmosDB Emulator: $SkipCosmosDBEmulator"
 Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 
@@ -53,8 +55,13 @@ if (!$SkipCosmosDBEmulator)
     Write-Host ""
     Write-Host "---Starting CosmosDB emulator---"
     $cosmosStatus = Get-CosmosDbEmulatorStatus
+    Write-Host "CosmosDB emulator status: $cosmosStatus"
 
-    if ($cosmosStatus -ne "Running")
+    if ($cosmosStatus -eq "StartPending")
+    {        
+        $startedCosmos = $true
+    }
+    elseif ($cosmosStatus -ne "Running")
     {
         Write-Host "CosmosDB emulator is not running. Starting emulator."
         Start-CosmosDbEmulator -NoWait -NoUI


### PR DESCRIPTION
- write out `dotnet --info` to help with debugging
- don't start the cosmos emulator if it's already starting
- kill/restart the cosmos emulator if it hasn't started after 60 seconds (in ci it is actually much longer than that b/c it happens in two stages)
- remove `-o` usage from the `dotnet pack` command. this was made into an error in .NET 7.0.200 SDK