### PR TITLE
more ci improvements

### DIFF
--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -15,7 +15,10 @@ param(
     $SkipCoreTools,
 
     [Switch]
-    $UseCoreToolsBuildFromIntegrationTests
+    $UseCoreToolsBuildFromIntegrationTests,
+
+    [Switch]
+    $SkipBuildOnPack
 )
 
 # A function that checks exit codes and fails script if an error is found 
@@ -97,7 +100,14 @@ if (Test-Path $output)
   Remove-Item $output -Recurse -Force -ErrorAction Ignore
 }
 
-.\tools\devpack.ps1 -E2E -AdditionalPackArgs @("-c","Release", "-p:FunctionsRuntimeVersion=$FunctionsRuntimeVersion")
+$AdditionalPackArgs = @("-c", "Release", "-p:FunctionsRuntimeVersion=$FunctionsRuntimeVersion")
+
+if ($SkipBuildOnPack -eq $true)
+{
+    $AdditionalPackArgs += "--no-build"
+}
+
+.\tools\devpack.ps1 -E2E -AdditionalPackArgs $AdditionalPackArgs
 
 if ($SkipStorageEmulator -And $SkipCosmosDBEmulator)
 {

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -43,6 +43,7 @@ jobs:
     displayName: "Start emulators (-NoWait)"
 
   - template: ../build/install-dotnet.yml
+  
   - task: DotNetCoreCLI@2
     displayName: 'Build projects'
     inputs:
@@ -57,7 +58,8 @@ jobs:
         throw "UseCoreToolsBuildFromIntegrationTests can only be set to True or False. Current value is set to $env:USECORETOOLSBUILDFROMINTEGRATIONTESTS"
       }
       ./setup-e2e-tests.ps1 -FunctionsRuntimeVersion $env:FUNCTIONSRUNTIMEVERSION `
-                            -UseCoreToolsBuildFromIntegrationTests:$useIntegrationTestingCoreTools
+                            -UseCoreToolsBuildFromIntegrationTests:$useIntegrationTestingCoreTools `
+                            -SkipBuildOnPack
     displayName: "Setup E2E tests"
 
   - task: DotNetCoreCLI@2
@@ -175,7 +177,7 @@ jobs:
     inputs:
       command: 'custom'
       custom: 'pack'
-      arguments: '--no-build -c Release -o packages -p:BuildNumber=$(buildNumber) -p:IsLocalBuild=False'
+      arguments: '--no-build -c Release -p:PackageOutputPath=$(System.DefaultWorkingDirectory)\packages -p:BuildNumber=$(buildNumber) -p:IsLocalBuild=False'
       projects: |
         **\DotNetWorker.Core.slnf
 
@@ -243,7 +245,8 @@ jobs:
         }
         ./setup-e2e-tests.ps1 -FunctionsRuntimeVersion $env:FUNCTIONSRUNTIMEVERSION `
                               -UseCoreToolsBuildFromIntegrationTests:$useIntegrationTestingCoreTools `
-                              -SkipCosmosDBEmulator
+                              -SkipCosmosDBEmulator `
+                              -SkipBuildOnPack
       displayName: "Setup E2E tests"
       env:
         CORE_TOOLS_URL: $(CORE_TOOLS_URL)

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -118,7 +118,7 @@ if (!$SkipCosmosDBEmulator -and $startedCosmos -eq $true)
     $cosmosStatus = Get-CosmosDbEmulatorStatus
     Write-Host "CosmosDB emulator status: $cosmosStatus"
 
-    $waitSuccess = Wait-CosmosDbEmulator -Status Running -Timeout 60
+    $waitSuccess = Wait-CosmosDbEmulator -Status Running -Timeout 60 -ErrorAction Continue
 
     if ($waitSuccess -ne $true)
     {


### PR DESCRIPTION
- The emulator retry wasn't working because it was exiting upon timeout. I think I've fixed this.
- We have always been generating the incorrect `AssemblyInformationalVersion` string because we've been packing the assemblies from the *test build* rather than from the initial build. These were always built with Release config, but used a different InformationalVersion so we've always had "-local_____" in that string. I'm now specifiying `--no-build` during testing so we don't re-build those assemblies ever. Confirmed that things look right.
- Switched another place to use `PackageOutputPath` in case we get hit with the `-o` error in the near future.