### PR TITLE
cleaning up build warnings

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -22,6 +22,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true"</ContinuousIntegrationBuild>
     <Deterministic>true</Deterministic>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -9,6 +9,9 @@
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+
+    <!-- disable warnings about non-nullable properties in attributes -->
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\..\build\Extensions.props" />

--- a/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Functions.SdkTests
             var functions = generator.GenerateFunctionMetadata(typeDef);
             var extensions = generator.Extensions;
 
-            Assert.Equal(1, functions.Count());
+            Assert.Single(functions);
 
             var blobToBlob = functions.Single(p => p.Name == "BlobToBlobFunction");
 


### PR DESCRIPTION
We've got lots of warnings in CI -- cleaning them up:
- net5.0 being eol -- but we aren't moving our target forward just yet
- kafka extension not validating non-nullable properties (i disabled nullable on that project) @jainharsh98 / @shrohilla 
- one small xunit test warning

[Previous build: 46 warnings](https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=116659&view=results)
Now: 0