### PR TITLE
[Source Gen] Fixing incorrect entrypoint property value in metadata when namespace is different than assembly name

### DIFF
--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator.Parser.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.;
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -54,12 +53,14 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                         continue;
                     }
 
-                    var functionClass = (ClassDeclarationSyntax) method.Parent!;
-                    var functionClassName = functionClass.Identifier.ValueText;
+                    var methodSymbol = model.GetDeclaredSymbol(method)!;
+                    var fullyQualifiedClassName = methodSymbol.ContainingSymbol.ToDisplayString();
+                    var entryPoint = $"{fullyQualifiedClassName}.{method.Identifier.ValueText}";
+
                     var newFunction = new GeneratorFunctionMetadata
                     {
                         Name = functionName,
-                        EntryPoint = assemblyName + "." + functionClassName + "." + method.Identifier.ValueText,
+                        EntryPoint = entryPoint,
                         Language = "dotnet-isolated",
                         ScriptFile = scriptFile
                     };

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using Microsoft.Azure.Functions.Worker.Sdk.Generators;
@@ -15,7 +12,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
     {
         public class EventHubsBindingsTests
         {
-            private Assembly[] referencedExtensionAssemblies;
+            private readonly Assembly[] _referencedExtensionAssemblies;
             private readonly string _usingStringsForInput;
 
             public EventHubsBindingsTests()
@@ -28,7 +25,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 var hostingAbExtension = Assembly.LoadFrom("Microsoft.Extensions.Hosting.Abstractions.dll");
                 var diAbExtension = Assembly.LoadFrom("Microsoft.Extensions.DependencyInjection.Abstractions.dll");
 
-                referencedExtensionAssemblies = new[]
+                _referencedExtensionAssemblies = new[]
                 {
                     abstractionsExtension,
                     httpExtension,
@@ -110,7 +107,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                                 {
                                     Language = "dotnet-isolated",
                                     Name = "{{functionName}}",
-                                    EntryPoint = "TestProject.EventHubsInput.{{functionName}}",
+                                    EntryPoint = "FunctionApp.EventHubsInput.{{functionName}}",
                                     RawBindings = Function0RawBindings,
                                     ScriptFile = "TestProject.dll"
                                 };
@@ -139,7 +136,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                     """);
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCodeBuilder.ToString(),
                     expectedGeneratedFileName,
                     expectedOutputBuilder.ToString());
@@ -234,7 +231,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "{{functionName}}",
-                                EntryPoint = "TestProject.EventHubsInput.{{functionName}}",
+                                EntryPoint = "FunctionApp.EventHubsInput.{{functionName}}",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -263,7 +260,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """);
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCodeBuilder.ToString(),
                     expectedGeneratedFileName,
                     expectedOutputBuilder.ToString());
@@ -321,7 +318,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "EnumerableBinaryInputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.EnumerableBinaryInputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.EnumerableBinaryInputFunction",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -350,7 +347,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -459,7 +456,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "EnumerableStringClassInputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.EnumerableStringClassInputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.EnumerableStringClassInputFunction",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -471,7 +468,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "EnumerableNestedStringClassInputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.EnumerableNestedStringClassInputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.EnumerableNestedStringClassInputFunction",
                                 RawBindings = Function1RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -483,7 +480,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "EnumerableNestedStringGenericClassInputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.EnumerableNestedStringGenericClassInputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.EnumerableNestedStringGenericClassInputFunction",
                                 RawBindings = Function2RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -495,7 +492,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "EnumerableNestedStringGenericClass2InputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.EnumerableNestedStringGenericClass2InputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.EnumerableNestedStringGenericClass2InputFunction",
                                 RawBindings = Function3RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -524,7 +521,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -607,7 +604,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "EnumerableBinaryClassInputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.EnumerableBinaryClassInputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.EnumerableBinaryClassInputFunction",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -619,7 +616,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "EnumerableNestedBinaryClassInputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.EnumerableNestedBinaryClassInputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.EnumerableNestedBinaryClassInputFunction",
                                 RawBindings = Function1RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -648,7 +645,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -718,7 +715,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "EnumerablePocoInputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.EnumerablePocoInputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.EnumerablePocoInputFunction",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -730,7 +727,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "ListPocoInputFunction",
-                                EntryPoint = "TestProject.EventHubsInput.ListPocoInputFunction",
+                                EntryPoint = "FunctionApp.EventHubsInput.ListPocoInputFunction",
                                 RawBindings = Function1RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -759,7 +756,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -794,7 +791,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 string? expectedOutput = null;
 
                 await TestHelpers.RunTestAsync<ExtensionStartupRunnerGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
     {
         public class IntegratedTriggersAndBindingsTests
         {
-            private Assembly[] referencedExtensionAssemblies;
+            private readonly Assembly[] _referencedExtensionAssemblies;
 
             public IntegratedTriggersAndBindingsTests()
             {
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 var hostingAbExtension = Assembly.LoadFrom("Microsoft.Extensions.Hosting.Abstractions.dll");
                 var diAbExtension = Assembly.LoadFrom("Microsoft.Extensions.DependencyInjection.Abstractions.dll");
 
-                referencedExtensionAssemblies = new[]
+                _referencedExtensionAssemblies = new[]
                 {
                     abstractionsExtension,
                     httpExtension,
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "HttpTriggerWithMultipleOutputBindings",
-                                EntryPoint = "TestProject.HttpTriggerWithMultipleOutputBindings.Run",
+                                EntryPoint = "FunctionApp.HttpTriggerWithMultipleOutputBindings.Run",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "HttpTriggerWithBlobInput",
-                                EntryPoint = "TestProject.HttpTriggerWithBlobInput.Run",
+                                EntryPoint = "FunctionApp.HttpTriggerWithBlobInput.Run",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "Products",
-                                EntryPoint = "TestProject.HttpTriggerWithBlobInput.Run",
+                                EntryPoint = "FunctionApp.HttpTriggerWithBlobInput.Run",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -408,7 +408,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "TimerFunction",
-                                EntryPoint = "TestProject.Timer.RunTimer",
+                                EntryPoint = "FunctionApp.Timer.RunTimer",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -494,7 +494,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "FunctionName",
-                                EntryPoint = "TestProject.BasicHttp.Http",
+                                EntryPoint = "FunctionApp.BasicHttp.Http",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -523,7 +523,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -560,7 +560,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 string? expectedOutput = null;
 
                 await TestHelpers.RunTestAsync<ExtensionStartupRunnerGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Reflection;
-using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Sdk.Generators;
 using Xunit;
 
@@ -13,7 +11,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
     {
         public class StorageBindingTests
         {
-            private Assembly[] referencedExtensionAssemblies;
+            private readonly Assembly[] _referencedExtensionAssemblies;
 
             public StorageBindingTests()
             {
@@ -28,7 +26,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 var diAbExtension = Assembly.LoadFrom("Microsoft.Extensions.DependencyInjection.Abstractions.dll");
                 var blobExtension = Assembly.LoadFrom("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs.dll");
 
-                referencedExtensionAssemblies = new[]
+                _referencedExtensionAssemblies = new[]
                 {
                     abstractionsExtension,
                     blobExtension,
@@ -94,7 +92,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "QueueTriggerFunction",
-                                EntryPoint = "TestProject.QueueTriggerAndOutput.QueueTriggerAndOutputFunction",
+                                EntryPoint = "FunctionApp.QueueTriggerAndOutput.QueueTriggerAndOutputFunction",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -123,7 +121,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);
@@ -199,7 +197,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "QueueToBlobFunction",
-                                EntryPoint = "TestProject.QueueTriggerAndOutput.QueueToBlob",
+                                EntryPoint = "FunctionApp.QueueTriggerAndOutput.QueueToBlob",
                                 RawBindings = Function0RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -212,7 +210,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "BlobToQueueFunction",
-                                EntryPoint = "TestProject.QueueTriggerAndOutput.BlobToQueue",
+                                EntryPoint = "FunctionApp.QueueTriggerAndOutput.BlobToQueue",
                                 RawBindings = Function1RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -225,7 +223,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             {
                                 Language = "dotnet-isolated",
                                 Name = "BlobsToQueueFunction",
-                                EntryPoint = "TestProject.QueueTriggerAndOutput.BlobsToQueue",
+                                EntryPoint = "FunctionApp.QueueTriggerAndOutput.BlobsToQueue",
                                 RawBindings = Function2RawBindings,
                                 ScriptFile = "TestProject.dll"
                             };
@@ -254,7 +252,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 """;
 
                 await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                    referencedExtensionAssemblies,
+                    _referencedExtensionAssemblies,
                     inputCode,
                     expectedGeneratedFileName,
                     expectedOutput);


### PR DESCRIPTION
Fixes #1299 

- Fixed the source gen so that it will use the correct fully qualified name of the parent class when building the EntryPoint property value in metadata. Previously we were using the assembly name to build the namespace part of this value.
- Fixed tests to reflect this.
- Added a new test for nested types scenario.