### PR TITLE
Reading AzureWebJobsScriptRoot env variable instead of FUNCTIONS_WORKER_DIRECTORY to get script root

### DIFF
--- a/src/DotNetWorker.Grpc/Definition/GrpcFunctionDefinition.cs
+++ b/src/DotNetWorker.Grpc/Definition/GrpcFunctionDefinition.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Azure.Functions.Worker.Definition
             Name = loadRequest.Metadata.Name;
             Id = loadRequest.FunctionId;
 
-            string? scriptRoot = Environment.GetEnvironmentVariable("FUNCTIONS_WORKER_DIRECTORY");
+            string? scriptRoot = Environment.GetEnvironmentVariable("AzureWebJobsScriptRoot");
             if (string.IsNullOrWhiteSpace(scriptRoot))
             {
-                throw new InvalidOperationException("The 'FUNCTIONS_WORKER_DIRECTORY' environment variable value is not defined. This is a required environment variable that is automatically set by the Azure Functions runtime.");
+                throw new InvalidOperationException("The 'AzureWebJobsScriptRoot' environment variable value is not defined. This is a required environment variable that is automatically set by the Azure Functions runtime.");
             }
 
             if (string.IsNullOrWhiteSpace(loadRequest.Metadata.ScriptFile))

--- a/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
+++ b/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>Microsoft.Azure.Functions.Worker.Grpc</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <MinorProductVersion>8</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
     <VersionSuffix>-preview1</VersionSuffix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/test/DotNetWorkerTests/GrpcFunctionDefinitionTests.cs
+++ b/test/DotNetWorkerTests/GrpcFunctionDefinitionTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         [Fact]
         public void Creates()
         {
-            using var testVariables = new TestScopedEnvironmentVariable("FUNCTIONS_WORKER_DIRECTORY", ".");
+            using var testVariables = new TestScopedEnvironmentVariable("AzureWebJobsScriptRoot", ".");
 
             var bindingInfoProvider = new DefaultOutputBindingsInfoProvider();
             var methodInfoLocator = new DefaultMethodInfoLocator();

--- a/test/DotNetWorkerTests/GrpcWorkerTests.cs
+++ b/test/DotNetWorkerTests/GrpcWorkerTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         [Fact]
         public void LoadFunction_ReturnsSuccess()
         {
-            using var testVariables = new TestScopedEnvironmentVariable("FUNCTIONS_WORKER_DIRECTORY", "test");
+            using var testVariables = new TestScopedEnvironmentVariable("AzureWebJobsScriptRoot", "test");
 
             FunctionLoadRequest request = CreateFunctionLoadRequest();
 
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         [Fact]
         public void LoadFunction_Throws_ReturnsFailure()
         {
-            using var testVariables = new TestScopedEnvironmentVariable("FUNCTIONS_WORKER_DIRECTORY", "test");
+            using var testVariables = new TestScopedEnvironmentVariable("AzureWebJobsScriptRoot", "test");
 
             _mockApplication
                 .Setup(m => m.LoadFunction(It.IsAny<FunctionDefinition>()))
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         [Fact]
         public void MethodInfoLocator_Throws_ReturnsFailure()
         {
-            using var testVariables = new TestScopedEnvironmentVariable("FUNCTIONS_WORKER_DIRECTORY", "test");
+            using var testVariables = new TestScopedEnvironmentVariable("AzureWebJobsScriptRoot", "test");
 
             _mockMethodInfoLocator
                 .Setup(m => m.GetMethod(It.IsAny<string>(), It.IsAny<string>()))


### PR DESCRIPTION
Reverted PR #1330. There was merge conflict on the csproj file of dotnet worker. Kept the version of DotnetWorker package as what is in latest main(1.13.0-preview1).

In #1330 we made the change to read from `FUNCTIONS_WORKER_DIRECTORY` instead of `AzureWebJobsScriptRoot` to get the script root of the isolated process binary. This causes placeholder specialization use case to fail. In placeholder use case, the env variable `FUNCTIONS_WORKER_DIRECTORY` has the path to the worker location for the language worker (where we will have the `workerconfig.json` and our native placeholder process. Ex: "WebJobs.Script.WebHost\bin\Debug\net6.0\workers\dotnet-isolated")

For a normal use case (non placeholder), I observed both env variables has the same value , the path to the customer payload binaries. 

![image](https://user-images.githubusercontent.com/144469/222488761-656756e8-f6c1-4b23-8129-f4c5cce46fad.png)

