### PR TITLE
Removing setting the unused env variable(AzureWebJobsScriptRoot)

### DIFF
--- a/host/src/funcgrpc/handlers/funcgrpc_native_handler.cpp
+++ b/host/src/funcgrpc/handlers/funcgrpc_native_handler.cpp
@@ -85,9 +85,6 @@ void AzureFunctionsRpc::NativeHostMessageHandler::HandleMessage(ByteBuffer *rece
 
                         _putenv(envString.c_str());
                     }
-
-                    string scriptRootEnvVar("AzureWebJobsScriptRoot=" + dir);
-                    _putenv(scriptRootEnvVar.c_str());
                 }
 
                 string exePath = funcgrpc::WorkerConfigHandle().GetApplicationExePath(dir);

--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.0-preview6</version>
+    <version>1.0.0-preview7</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>


### PR DESCRIPTION
We recently removed using "AzureWebJobsScriptRoot" env variable in #1330 
Removing the native host code which was setting this env variable as it is not needed anymore.