### PR TITLE
Update extension variables to not use build number with tags

### DIFF
--- a/build/pipelines/templates/extensions-variables.yml
+++ b/build/pipelines/templates/extensions-variables.yml
@@ -1,7 +1,7 @@
 variables:
-  ${{ if not(contains(variables['Build.SourceBranch'], '/release/' )) }}:
+  ${{ if and( not(contains(variables['Build.SourceBranch'], '/release/')),  not(startsWith(variables['Build.SourceBranch'], 'refs/tags')) ) }}:
     buildNumberTemp: $(Build.BuildNumber)
-  ${{ or(contains(variables['Build.SourceBranch'], '/release/'), startsWith(variables['Build.SourceBranch'], 'refs/tags')) }}:
+  ${{ if or( contains(variables['Build.SourceBranch'], '/release/'), startsWith(variables['Build.SourceBranch'], 'refs/tags') ) }}:
     isReleaseBuildTemp: true
   buildNumber: $[variables.buildNumberTemp]
   isReleaseBuild: $[variables.isReleaseBuildTemp]


### PR DESCRIPTION
Created a test tag to verify this works, here is the pipeline result:

```yml
  buildNumber:
    Parsing expression: <variables.buildNumberTemp>
    Evaluating: variables['buildNumberTemp']
    Expanded: Null
    Result: ''
  isReleaseBuild:
    Parsing expression: <variables.isReleaseBuildTemp>
    Evaluating: variables['isReleaseBuildTemp']
    Result: 'true'
```