### PR TITLE
Bumping minor version of Kafka,Timer and EH. Removing preview suffix of SDK package

### DIFF
--- a/extensions/Worker.Extensions.Abstractions/src/Worker.Extensions.Abstractions.csproj
+++ b/extensions/Worker.Extensions.Abstractions/src/Worker.Extensions.Abstractions.csproj
@@ -6,8 +6,8 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Abstractions</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Abstractions</RootNamespace>
     <Description>Abstractions for Azure Functions .NET Worker</Description>
-    <MinorProductVersion>2</MinorProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
+    <MinorProductVersion>1</MinorProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
   </PropertyGroup>
 
   <Import Project="..\..\..\build\Common.props" />

--- a/extensions/Worker.Extensions.EventHubs/src/Worker.Extensions.EventHubs.csproj
+++ b/extensions/Worker.Extensions.EventHubs/src/Worker.Extensions.EventHubs.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Event Hubs extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.1.0</VersionPrefix>
+    <VersionPrefix>5.2.0</VersionPrefix>
 
   </PropertyGroup>
 

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -5,7 +5,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Timer/src/Worker.Extensions.Timer.csproj
+++ b/extensions/Worker.Extensions.Timer/src/Worker.Extensions.Timer.csproj
@@ -6,7 +6,7 @@
     <Description>Timer extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.2.0</VersionPrefix>
   </PropertyGroup>
 
   <Import Project="..\..\..\build\Extensions.props" />

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <MinorProductVersion>9</MinorProductVersion>
-    <VersionSuffix>-preview2</VersionSuffix>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>


### PR DESCRIPTION
Bumping minor version of 3 extension packages so that they can take advantage of RetryAttributes.
- Kafka 3.7.0 -> 3.8.0
- Event hubs 5.1.0 -> 5.2.0
- Timer 4.1.0 -> 4.2.0

Removing "preview" suffix from SDK package. The attributes used for SDK binding behavior was already removed from main. so the customer's won't be able to get SDK binding related changes.
- 1.9.0-preview2 - > 1.9.0
------------------------------------------------------------------------------------------------------------------------
We added support for retry attributes on isolated [in August 2022](https://github.com/Azure/azure-functions-dotnet-worker/pull/977). Looks like we did not publish a (non preview) version of  [Microsoft.Azure.Functions.Worker.Extensions.Abstractions package](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Abstractions/1.1.0) to reflect this change. So customers have no way to take advantage of this feature yet if they were to create a new EventHub trigger.

We released a preview version of Microsoft.Azure.Functions.Worker.Extensions.Abstractions package recently (1.2.0 preview) for the SDK binding support. I had offline chat with @fabiocav and we decided to release this as a patch version change on top of 1.1.X version.

History:
https://github.com/Azure/azure-functions-dotnet-worker/commits/main/extensions/Worker.Extensions.Abstractions