### PR TITLE
Forwarding env reload request to worker(customer app payload) after it is loaded

### DIFF
--- a/host/src/funcgrpc/handlers/funcgrpc_native_handler.cpp
+++ b/host/src/funcgrpc/handlers/funcgrpc_native_handler.cpp
@@ -93,7 +93,7 @@ void AzureFunctionsRpc::NativeHostMessageHandler::HandleMessage(ByteBuffer *rece
                     application_->ExecuteApplication(exePath);
                 }
 
-                FUNC_LOG_INFO("Going to wait for worker payload to load.");
+                FUNC_LOG_INFO("Waiting for worker initialization.");
                 std::unique_lock lk(application_->mtx_workerLoaded);
                 application_->cv_workerLoaded.wait(lk, [this] { return application_->hasWorkerLoaded; });
                 FUNC_LOG_INFO("Worker payload loaded. Forwarding env reload request to worker.");

--- a/host/src/funcgrpc/handlers/funcgrpc_native_handler.cpp
+++ b/host/src/funcgrpc/handlers/funcgrpc_native_handler.cpp
@@ -93,15 +93,12 @@ void AzureFunctionsRpc::NativeHostMessageHandler::HandleMessage(ByteBuffer *rece
                     application_->ExecuteApplication(exePath);
                 }
 
-                StreamingMessage streamingMsg;
-                streamingMsg.mutable_function_environment_reload_response()->mutable_result()->set_status(
-                    AzureFunctionsRpcMessages::StatusResult::Success);
+                FUNC_LOG_INFO("Going to wait for worker payload to load.");
+                std::unique_lock lk(application_->mtx_workerLoaded);
+                application_->cv_workerLoaded.wait(lk, [this] { return application_->hasWorkerLoaded; });
+                FUNC_LOG_INFO("Worker payload loaded. Forwarding env reload request to worker.");
 
-                auto uPtrBb = funcgrpc::SerializeToByteBuffer(&streamingMsg);
-                auto byteBuffer = uPtrBb.get();
-
-                FUNC_LOG_DEBUG("Pushing response to outbound channel.contentCase: {}", streamingMsg.content_case());
-                funcgrpc::MessageChannel::GetInstance().GetOutboundChannel().push(*byteBuffer);
+                funcgrpc::MessageChannel::GetInstance().GetInboundChannel().push(*receivedMessageBb);
                 specializationRequestReceived = true;
             }
             catch (const std::exception &ex)

--- a/host/src/funcgrpc/nativehostapplication.cpp
+++ b/host/src/funcgrpc/nativehostapplication.cpp
@@ -73,6 +73,13 @@ void NativeHostApplication::SetCallbackHandles(_In_ PFN_REQUEST_HANDLER request_
     handle = grpcHandle;
 
     ReleaseMutex(initMutex_);
+
+    {
+        std::lock_guard lk(mtx_workerLoaded);
+        hasWorkerLoaded = true;
+    }
+
+    cv_workerLoaded.notify_one();
 }
 
 bool NativeHostApplication::load_hostfxr()

--- a/host/src/funcgrpc/nativehostapplication.h
+++ b/host/src/funcgrpc/nativehostapplication.h
@@ -42,6 +42,12 @@ class NativeHostApplication
         return s_Application;
     }
 
+    // Indicates whether the worker payload(managed code) loaded.
+    bool hasWorkerLoaded = false;
+
+    std::condition_variable cv_workerLoaded;
+
+    std::mutex mtx_workerLoaded;
   private:
     static NativeHostApplication *s_Application;
 

--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.0-preview7</version>
+    <version>1.0.0-preview8</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>


### PR DESCRIPTION
Forwarding env reload request to worker(customer app payload) after it is loaded.

We call [NativeMethods.RegisterCallbacks ](https://github.com/Azure/azure-functions-dotnet-worker/blob/2b78e7b03503f499ae71507b2a842d1848b86fb2/src/DotNetWorker.Grpc/NativeHostIntegration/NativeWorkerClient.cs#L36)when we start the Native worker client. 

On the native side, this invokes [SetCallbackHandles](https://github.com/Azure/azure-functions-dotnet-worker/blob/2b78e7b03503f499ae71507b2a842d1848b86fb2/host/src/funcgrpc/nativehostapplication.cpp#L70). This gets called only once. I am using the call to this method as a signal that worker app (customer payload) was loaded successfully and is ready to take any other streaming messages.  

Once #1425 is also merged, env reload request will be properly handled by the worker even in placeholder/specialiazation use case. Currently we are sending a dummy response (with status = "success") from native host.
