### PR TITLE
Fix HttpTriggers with POCO deserialization not working

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 
 - Logging an error on a function invocation exception. This error will also be logged by the host, but this allows for richer telemetry coming directly from the worker. See #1421 for details on how to disable this log if desired.
 - Add query as property to HttpRequestData (#1408)
+- Enable HttpTriggers with object deserialization and a secondary HttpRequestData parameter (#1454)

--- a/test/DotNetWorkerTests/Converters/JsonPocoConverterTests.cs
+++ b/test/DotNetWorkerTests/Converters/JsonPocoConverterTests.cs
@@ -9,7 +9,6 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core.Serialization;
 using Microsoft.Azure.Functions.Worker.Converters;
-using Microsoft.Azure.Functions.Worker.Tests.OutputBindings;
 using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;

--- a/test/DotNetWorkerTests/GrpcFunctionDefinitionTests.cs
+++ b/test/DotNetWorkerTests/GrpcFunctionDefinitionTests.cs
@@ -118,12 +118,67 @@ namespace Microsoft.Azure.Functions.Worker.Tests
                 });
 
             // InputBindings
-            Assert.Collection(definition.InputBindings,
+            Assert.All(definition.InputBindings,
                 p =>
                 {
                     Assert.Equal(BindingDirection.In, p.Value.Direction);
                     Assert.Equal("HttpTrigger", p.Value.Type);
+                });
+
+            Assert.True(definition.InputBindings.ContainsKey("data"));
+            Assert.True(definition.InputBindings.ContainsKey("req"));
+        }
+        
+        [Fact]
+        public void Creates_InputBindings_WhenHttpRequestDataIsThirdParameter()
+        {
+            using var testVariables = new TestScopedEnvironmentVariable("FUNCTIONS_WORKER_DIRECTORY", ".");
+
+            var bindingInfoProvider = new DefaultOutputBindingsInfoProvider();
+            var methodInfoLocator = new DefaultMethodInfoLocator();
+
+            string fullPathToThisAssembly = GetType().Assembly.Location;
+            var functionLoadRequest = new FunctionLoadRequest
+            {
+                FunctionId = "abc",
+                Metadata = new RpcFunctionMetadata
+                {
+                    EntryPoint = $"Microsoft.Azure.Functions.Worker.Tests.{nameof(GrpcFunctionDefinitionTests)}+{nameof(MyFunctionClass)}.{nameof(MyFunctionClass.ThirdParameterHttpRequestData)}",
+                    ScriptFile = Path.GetFileName(fullPathToThisAssembly),
+                    Name = "myfunction"
+                }
+            };
+
+            functionLoadRequest.Metadata.Bindings.Add("data", new BindingInfo { Type = "HttpTrigger", Direction = Direction.In });
+            functionLoadRequest.Metadata.Bindings.Add("$return", new BindingInfo { Type = "Http", Direction = Direction.Out });
+
+            FunctionDefinition definition = functionLoadRequest.ToFunctionDefinition(methodInfoLocator);
+
+            Assert.Equal(functionLoadRequest.FunctionId, definition.Id);
+            Assert.Equal(functionLoadRequest.Metadata.EntryPoint, definition.EntryPoint);
+            Assert.Equal(functionLoadRequest.Metadata.Name, definition.Name);
+            Assert.Equal(fullPathToThisAssembly, definition.PathToAssembly);
+
+            // Parameters
+            Assert.Collection(definition.Parameters,
+                p =>
+                {
+                    Assert.Equal("data", p.Name);
+                    Assert.Equal(typeof(string), p.Type);
                 },
+                p =>
+                {
+                    Assert.Equal("category", p.Name);
+                    Assert.Equal(typeof(string), p.Type);
+                },
+                p =>
+                {
+                    Assert.Equal("req", p.Name);
+                    Assert.Equal(typeof(HttpRequestData), p.Type);
+                });
+
+            // InputBindings
+            Assert.All(definition.InputBindings,
                 p =>
                 {
                     Assert.Equal(BindingDirection.In, p.Value.Direction);
@@ -142,6 +197,11 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             }
 
             public HttpResponseData SecondParameterHttpRequestData(string data, HttpRequestData req)
+            {
+                return req.CreateResponse();
+            }
+
+            public HttpResponseData ThirdParameterHttpRequestData(string data, string category, HttpRequestData req)
             {
                 return req.CreateResponse();
             }

--- a/test/DotNetWorkerTests/HttpRequestDataExtensionsTests.cs
+++ b/test/DotNetWorkerTests/HttpRequestDataExtensionsTests.cs
@@ -9,7 +9,6 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Azure.Core.Serialization;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.Functions.Worker.Tests.OutputBindings;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Xunit;

--- a/test/DotNetWorkerTests/OutputBindings/OutputBindingsMiddlewareTests.cs
+++ b/test/DotNetWorkerTests/OutputBindings/OutputBindingsMiddlewareTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Security.Claims;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.OutputBindings;
 using Xunit;
@@ -189,36 +187,5 @@ namespace Microsoft.Azure.Functions.Worker.Tests.OutputBindings
         public override HttpHeadersCollection Headers { get; set; }
         public override Stream Body { get; set; }
         public override HttpCookies Cookies { get; }
-    }
-
-    public class TestHttpRequestData : HttpRequestData
-    {
-        public TestHttpRequestData(FunctionContext functionContext, Stream body = null, string method = "GET", string url = null)
-            : base(functionContext)
-        {
-            Body = body ?? new MemoryStream();
-            Headers = new HttpHeadersCollection();
-            Cookies = new List<IHttpCookie>();
-            Url = new Uri(url ?? "https://localhost");
-            Identities = new List<ClaimsIdentity>();
-            Method = method;
-        }
-
-        public override Stream Body { get; }
-
-        public override HttpHeadersCollection Headers { get; }
-
-        public override IReadOnlyCollection<IHttpCookie> Cookies { get; }
-
-        public override Uri Url { get; }
-
-        public override IEnumerable<ClaimsIdentity> Identities { get; }
-
-        public override string Method { get; }
-
-        public override HttpResponseData CreateResponse()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/test/DotNetWorkerTests/TestHttpRequestData.cs
+++ b/test/DotNetWorkerTests/TestHttpRequestData.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Claims;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace Microsoft.Azure.Functions.Worker.Tests
+{
+    public class TestHttpRequestData : HttpRequestData
+    {
+        public TestHttpRequestData(FunctionContext functionContext, Stream body = null, string method = "GET", string url = null)
+            : base(functionContext)
+        {
+            Body = body ?? new MemoryStream();
+            Headers = new HttpHeadersCollection();
+            Cookies = new List<IHttpCookie>();
+            Url = new Uri(url ?? "https://localhost");
+            Identities = new List<ClaimsIdentity>();
+            Method = method;
+        }
+
+        public override Stream Body { get; }
+
+        public override HttpHeadersCollection Headers { get; }
+
+        public override IReadOnlyCollection<IHttpCookie> Cookies { get; }
+
+        public override Uri Url { get; }
+
+        public override IEnumerable<ClaimsIdentity> Identities { get; }
+
+        public override string Method { get; }
+
+        public override HttpResponseData CreateResponse()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
@@ -3,8 +3,6 @@
 
 using System.Net;
 using System.Text.Json;
-using System.Web;
-using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 
@@ -70,6 +68,71 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp
             logger.LogInformation(".NET Worker HTTP trigger function processed a request");
 
             return new MyResponse { Name = "Test" };
+        }
+
+        [Function(nameof(POCOAndHttpRequest))]
+        public static HttpResponseData POCOAndHttpRequest(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] Book book,
+            HttpRequestData req,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(POCOAndHttpRequest));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.WriteString($"Book {book.Title}");
+            return response;
+        }
+
+        [Function(nameof(RequestDataAfterRouteParameters))]
+        public static HttpResponseData RequestDataAfterRouteParameters(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "{region}/{category}/" + nameof(RequestDataAfterRouteParameters))] Book book,
+            string region,
+            string category,
+            HttpRequestData req,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(RequestDataAfterRouteParameters));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.WriteString($"{region} {category} {book.Title}");
+            return response;
+        }
+
+        [Function(nameof(POCOAndHttpRequestWithQueryString))]
+        public static HttpResponseData POCOAndHttpRequestWithQueryString(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] Book book,
+            HttpRequestData req,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(POCOAndHttpRequestWithQueryString));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+
+            var queryName = req.Query["name"];
+
+            if (string.IsNullOrEmpty(queryName))
+            {
+                return req.CreateResponse(HttpStatusCode.BadRequest);
+            }
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.WriteString($"Book {book.Title}");
+            return response;
+        }
+
+        [Function(nameof(VoidHttpTriggerWithPOCO))]
+        public static void VoidHttpTriggerWithPOCO(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] Book book,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(VoidHttpTriggerWithPOCO));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+        }
+
+        public class Book
+        {
+            public string Title { get; set; }
         }
 
         public class MyResponse

--- a/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
@@ -3,6 +3,8 @@
 
 using System.Net;
 using System.Text.Json;
+using System.Threading.Tasks;
+using Azure;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 
@@ -81,6 +83,20 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.WriteString($"Book {book.Title}");
+            return response;
+        }
+
+        [Function(nameof(POCOAndHttpRequestWithReadAsString))]
+        public static async Task<HttpResponseData> POCOAndHttpRequestWithReadAsString(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] Book book,
+            HttpRequestData req,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(POCOAndHttpRequestWithReadAsString));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.WriteString(await req.ReadAsStringAsync());
             return response;
         }
 

--- a/test/E2ETests/E2EApps/E2EApp/Http/FailingHttpFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Http/FailingHttpFunctions.cs
@@ -1,10 +1,9 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 ﻿using System;
-using Microsoft.Azure.Functions.Worker;
+using System.Net;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.Functions.Worker.Pipeline;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Functions.Worker.E2EApp
@@ -19,6 +18,19 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp
             var logger = context.GetLogger(nameof(ExceptionFunction));
             logger.LogInformation(".NET Worker HTTP trigger function processed a request");
             throw new Exception("This should never succeed!");
+        }
+
+        [Function(nameof(CreatingResponseFromDuplicateHttpRequestDataParameter))]
+        public static HttpResponseData CreatingResponseFromDuplicateHttpRequestDataParameter(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] string input,
+            HttpRequestData req,
+            HttpRequestData req2,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(CreatingResponseFromDuplicateHttpRequestDataParameter));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+
+            return req2.CreateResponse(HttpStatusCode.OK);
         }
     }
 }

--- a/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
+++ b/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
@@ -55,7 +55,12 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
                     _funcProcess.StartInfo.ArgumentList.Add("HelloFromQuery");
                     _funcProcess.StartInfo.ArgumentList.Add("HelloFromJsonBody");
                     _funcProcess.StartInfo.ArgumentList.Add("HelloUsingPoco");
+                    _funcProcess.StartInfo.ArgumentList.Add("POCOAndHttpRequest");
+                    _funcProcess.StartInfo.ArgumentList.Add("POCOAndHttpRequestWithQueryString");
+                    _funcProcess.StartInfo.ArgumentList.Add("VoidHttpTriggerWithPOCO");
+                    _funcProcess.StartInfo.ArgumentList.Add("RequestDataAfterRouteParameters");
                     _funcProcess.StartInfo.ArgumentList.Add("ExceptionFunction");
+                    _funcProcess.StartInfo.ArgumentList.Add("CreatingResponseFromDuplicateHttpRequestDataParameter");
                 }
 
                 await CosmosDBHelpers.TryCreateDocumentCollectionsAsync(_logger);

--- a/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
+++ b/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
                     _funcProcess.StartInfo.ArgumentList.Add("HelloUsingPoco");
                     _funcProcess.StartInfo.ArgumentList.Add("POCOAndHttpRequest");
                     _funcProcess.StartInfo.ArgumentList.Add("POCOAndHttpRequestWithQueryString");
+                    _funcProcess.StartInfo.ArgumentList.Add("POCOAndHttpRequestWithReadAsString");
                     _funcProcess.StartInfo.ArgumentList.Add("VoidHttpTriggerWithPOCO");
                     _funcProcess.StartInfo.ArgumentList.Add("RequestDataAfterRouteParameters");
                     _funcProcess.StartInfo.ArgumentList.Add("ExceptionFunction");

--- a/test/E2ETests/E2ETests/Helpers/HttpHelpers.cs
+++ b/test/E2ETests/E2ETests/Helpers/HttpHelpers.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             return await GetResponseMessage(request);
         }
 
-        public static async Task<HttpResponseMessage> InvokeHttpTriggerWithBody(string functionName, string body, HttpStatusCode expectedStatusCode, string mediaType, int expectedCode = 0)
+        public static async Task<HttpResponseMessage> InvokeHttpTriggerWithBody(string functionName, string body, string mediaType, string queryString = "")
         {
-            HttpRequestMessage request = GetTestRequest(functionName);
+            HttpRequestMessage request = GetTestRequest(functionName, queryString);
             request.Content = new StringContent(body);
             request.Content.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(mediaType));

--- a/test/E2ETests/E2ETests/HttpEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/HttpEndToEndTests.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
         [Theory]
         [InlineData("POCOAndHttpRequest", "", "{ \"Title\": \"b\" }", "application/json", HttpStatusCode.OK, "Book b")]
         [InlineData("POCOAndHttpRequest", "", "{ \"Title\": \"b\" }", "application/octet-stream", HttpStatusCode.OK, "Book b")]
+        [InlineData("POCOAndHttpRequestWithReadAsString", "", "{ \"Title\": \"b\" }", "application/json", HttpStatusCode.OK, "{ \"Title\": \"b\" }")]
         [InlineData("VoidHttpTriggerWithPOCO", "", "{ \"Title\": \"b\" }", "application/json", HttpStatusCode.NoContent, "")]
         [InlineData("RequestDataAfterRouteParameters", "eu/books/", "{ \"Title\": \"b\" }", "application/json", HttpStatusCode.OK, "eu books b")]
         [InlineData("CreatingResponseFromDuplicateHttpRequestDataParameter", "", "body", "application/json", HttpStatusCode.InternalServerError, "")]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #164

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information
* Fixes POCO deserialization
* Populates HttpRequestData if it’s a secondary parameter
* Resets the request body stream position to allow `ReadAsStringAsync` and similar methods
* Moved `TestHttpRequestData.cs`
