### PR TITLE
Change default buffer size for stream reader

### DIFF
--- a/src/DotNetWorker.Core/Http/HttpRequestDataExtensions.cs
+++ b/src/DotNetWorker.Core/Http/HttpRequestDataExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Functions.Worker.Http
                 return null;
             }
 
-            using (var reader = new StreamReader(request.Body, bufferSize: -1, detectEncodingFromByteOrderMarks: true, encoding: encoding, leaveOpen: true))
+            using (var reader = new StreamReader(request.Body, bufferSize: 1024, detectEncodingFromByteOrderMarks: true, encoding: encoding, leaveOpen: true))
             {
                 return await reader.ReadToEndAsync();
             }
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Functions.Worker.Http
                 return null;
             }
 
-            using (var reader = new StreamReader(request.Body, bufferSize: -1, detectEncodingFromByteOrderMarks: true, encoding: encoding, leaveOpen: true))
+            using (var reader = new StreamReader(request.Body, bufferSize: 1024, detectEncodingFromByteOrderMarks: true, encoding: encoding, leaveOpen: true))
             {
                 return reader.ReadToEnd();
             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
The buffer size for the stream reader was initially set to -1, but this causes issues in .NET framework 4.8 as it expects a positive number. Looking at [the source code](https://referencesource.microsoft.com/#q=.NET%20Framework%205) for .NET framework  4.8, the default value is set to be 1024 if legacy isn't enabled. I also see in the documentation [here](https://learn.microsoft.com/en-us/dotnet/api/system.io.streamreader.-ctor?view=net-8.0) that the default is set to be 1024 for later .NET versions.

resolves [#issue_for_this_pr](https://github.com/Azure/azure-functions-dotnet-worker/issues/1439)

### Pull request checklist

* [x ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x ] I have added all required tests (Unit tests, E2E tests) (not needed since this is a bug fix)

