### PR TITLE
Update Event Hubs version to 5.3.0

### DIFF
--- a/extensions/Worker.Extensions.EventHubs/release_notes.md
+++ b/extensions/Worker.Extensions.EventHubs/release_notes.md
@@ -2,3 +2,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
+
+- Update Microsoft.Azure.WebJobs.Extensions.EventHubs to v5.3.0

--- a/extensions/Worker.Extensions.EventHubs/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.EventHubs/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.EventHubs", "5.1.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.EventHubs", "5.3.0")]

--- a/extensions/Worker.Extensions.EventHubs/src/Worker.Extensions.EventHubs.csproj
+++ b/extensions/Worker.Extensions.EventHubs/src/Worker.Extensions.EventHubs.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Event Hubs extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.2.0</VersionPrefix>
+    <VersionPrefix>5.3.0</VersionPrefix>
 
   </PropertyGroup>
 


### PR DESCRIPTION
Skipping 5.2.0 so that we can stay in sync with WebJobs