### PR TITLE
[Analyzer] Warning for extension constrained types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
 Azure.Functions.Cli
+azurite
 
 # For local nuget packages
 [Ll]ocal/

--- a/docs/analyzer-rules/AZFW0010.md
+++ b/docs/analyzer-rules/AZFW0010.md
@@ -1,0 +1,24 @@
+# AZFW0010: Invalid binding type
+
+| | Value |
+|-|-|
+| **Rule ID** |AZFW00010|
+| **Category** |[Usage]|
+| **Severity** |Warning|
+
+## Cause
+
+This rule is triggered when a function is binding to a type that is not supported
+by the binding attribute being used.
+
+## Rule description
+
+Some bindings advertise the types that they support. If a binding advertises supported types
+and does not support falling back to built-in converters, then this rule will will be flagged.
+
+For example if you're binding to a `QueueTrigger` and the only supported type is `string` and
+your function is binding to a `bool`, then you will see this warning.
+
+## How to fix violations
+
+Change the binding type to a type that is supported by the binding your function is using.

--- a/docs/analyzer-rules/AZFW0010.md
+++ b/docs/analyzer-rules/AZFW0010.md
@@ -22,3 +22,21 @@ your function is binding to a `bool`, then you will see this warning.
 ## How to fix violations
 
 Change the binding type to a type that is supported by the binding your function is using.
+
+### Supported Types
+
+You can refer to the [public documentation](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob?tabs=in-process%2Cextensionv5%2Cextensionv3&pivots=programming-language-csharp) to see which types are supported.
+
+| Binding | Supported Types |
+| ------- | --------------- |
+| BlobTrigger | POCO, String, Stream, Byte[], BlobClient*, BlobContainerClient |
+| BlobInput | POCO, IEnumerable*<POCO>, String,  IEnumberable<String>, Stream, IEnumberable<Stream>, Byte[], BlobClient, IEnumerable<BlobClient>, BlobContainerClient |
+| CosmosDBTrigger | POCO, IEnumerable<POCO> |
+| CosmosDBInput | POCO, IEnumerable<POCO>, CosmosClient, Database, Container |
+| EventGridTrigger | String, IEnumerable<String>, CloudEvent, IEnumerable<CloudEvent>, EventGridEvent, IEnumerable<EventGridEvent> |
+| EventHubTrigger | POCO, POCO[], String, String[] |
+| QueueTrigger | POCO, String, BinaryData, QueueMessage |
+| ServiceBusTrigger | String, String[], ServiceBusReceivedMessage, ServiceBusReceivedMessage[] |
+| TableInput | POCO, IEnumerable<POCO>, TableEntity, IEnumerable<TableEntity>, TableClient |
+
+> \* Where `BlobClient` is supported AppendBlobClient, BaseBlobClient, BlockBlobClient and PageBlobClient are also supported

--- a/sdk/Sdk.Analyzers/AsyncVoidAnalyzer.cs
+++ b/sdk/Sdk.Analyzers/AsyncVoidAnalyzer.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class AsyncVoidAnalyzer : DiagnosticAnalyzer
-    {    
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.AsyncVoidReturnType);
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.AsyncVoidReturnType);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
             if (symbol.IsAsync && symbol.ReturnsVoid)
             {
                 // This symbol is a method symbol and will have only one item in Locations property.
-                var location = symbol.Locations[0]; 
+                var location = symbol.Locations[0];
                 var diagnostic = Diagnostic.Create(DiagnosticDescriptors.AsyncVoidReturnType, location);
                 symbolAnalysisContext.ReportDiagnostic(diagnostic);
             }

--- a/sdk/Sdk.Analyzers/AsyncVoidCodeFixProvider.cs
+++ b/sdk/Sdk.Analyzers/AsyncVoidCodeFixProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
         {
             Diagnostic diagnostic = context.Diagnostics.First();
             context.RegisterCodeFix(new VoidToTaskCodeAction(context.Document, diagnostic), diagnostic);
-            
+
             return Task.CompletedTask;
         }
 

--- a/sdk/Sdk.Analyzers/BindingTypeNotSupported.cs
+++ b/sdk/Sdk.Analyzers/BindingTypeNotSupported.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class BindingTypeNotSupported : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(DiagnosticDescriptors.BindingTypeNotSupported); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+            context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+        }
+
+        private static void AnalyzeMethod(SymbolAnalysisContext context)
+        {
+            var method = (IMethodSymbol)context.Symbol;
+
+            if (!method.IsFunction(context))
+            {
+                return;
+            }
+
+            var methodParameters = method.Parameters;
+
+            if (method.Parameters.Length == 0)
+            {
+                return;
+            }
+
+            foreach (var parameter in methodParameters)
+            {
+                AnalyzeParameter(context, parameter);
+            }
+        }
+
+        private static void AnalyzeParameter(SymbolAnalysisContext context, IParameterSymbol parameter)
+        {
+            foreach (var attribute in parameter.GetAttributes())
+            {
+                var attributeType = attribute?.AttributeClass;
+                if (!attributeType.IsInputOrTriggerBinding())
+                {
+                    continue;
+                }
+
+                var inputConverterAttributes = GetInputConverterAttributes(context, attributeType);
+                if (inputConverterAttributes.Count == 0)
+                {
+                    continue;
+                }
+
+                var allowConverterFallbackParameterValue = GetAllowConverterFallbackParameterValue(context, attributeType);
+                if (allowConverterFallbackParameterValue is bool allowFallback && allowFallback)
+                {
+                    // If allowConverterFallback is true, we don't need to check for supported types
+                    // because we don't know all of the types that are supported via the fallback
+                    continue;
+                }
+
+                var supportedTypes = GetSupportedTypes(context, inputConverterAttributes);
+                if (supportedTypes.Count <= 0 || supportedTypes.Contains(parameter.Type))
+                {
+                    continue;
+                }
+
+                ReportDiagnostic(context, parameter, attributeType);
+            }
+        }
+
+        private static List<AttributeData> GetInputConverterAttributes(SymbolAnalysisContext context, ITypeSymbol attributeType)
+        {
+            var inputConverterAttributeType = context.Compilation.GetTypeByMetadataName(Constants.Types.InputConverterAttribute);
+            return attributeType.GetAttributes()
+                .Where(attr => attr.AttributeClass.Equals(inputConverterAttributeType))
+                .ToList();
+        }
+
+        private static object GetAllowConverterFallbackParameterValue(SymbolAnalysisContext context, ITypeSymbol attributeType)
+        {
+            var allowConverterFallbackAttributeType = context.Compilation.GetTypeByMetadataName(Constants.Types.AllowConverterFallbackAttribute);
+            var allowConverterFallbackAttribute = attributeType.GetAttributes().FirstOrDefault(attr => attr.AttributeClass.Equals(allowConverterFallbackAttributeType));
+            return allowConverterFallbackAttribute.ConstructorArguments.FirstOrDefault().Value;
+        }
+
+        private static List<object> GetSupportedTypes(SymbolAnalysisContext context, List<AttributeData> inputConverterAttributes)
+        {
+            var supportedTypes = new List<object>();
+
+            foreach (var inputConverterAttribute in inputConverterAttributes)
+            {
+                var converterName = inputConverterAttribute.ConstructorArguments.FirstOrDefault().Value.ToString();
+                var converter = context.Compilation.GetTypeByMetadataName(converterName);
+
+                var converterAttributes = converter.GetAttributes();
+
+                var converterHasSupportedTypeAttribute = converterAttributes.Any(a => a.AttributeClass.Name == Constants.Names.SupportedConverterTypeAttribute);
+                if (!converterHasSupportedTypeAttribute)
+                {
+                    // If a converter does not have the `SupportedConverterTypeAttribute`, we don't need to check for supported types
+                    continue;
+                }
+
+                supportedTypes.AddRange(converterAttributes
+                    .Where(a => a.AttributeClass.Name == Constants.Names.SupportedConverterTypeAttribute)
+                    .SelectMany(a => a.ConstructorArguments.Select(arg => arg.Value))
+                    .ToList());
+            }
+
+            return supportedTypes;
+        }
+
+        private static void ReportDiagnostic(SymbolAnalysisContext context, IParameterSymbol parameter, ITypeSymbol attributeType)
+        {
+            var diagnostic = Diagnostic.Create(
+                DiagnosticDescriptors.BindingTypeNotSupported,
+                parameter.Locations.First(),
+                parameter.Type.Name,
+                attributeType.Name);
+
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/sdk/Sdk.Analyzers/BindingTypeNotSupported.cs
+++ b/sdk/Sdk.Analyzers/BindingTypeNotSupported.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class BindingTypeNotSupported : DiagnosticAnalyzer
     {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(DiagnosticDescriptors.BindingTypeNotSupported); } }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.BindingTypeNotSupported);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
 
             var methodParameters = method.Parameters;
 
-            if (method.Parameters.Length == 0)
+            if (method.Parameters.Length <= 0)
             {
                 return;
             }
@@ -54,7 +55,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
                 }
 
                 var inputConverterAttributes = GetInputConverterAttributes(context, attributeType);
-                if (inputConverterAttributes.Count == 0)
+                if (inputConverterAttributes.Count <= 0)
                 {
                     continue;
                 }
@@ -81,14 +82,14 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
         {
             var inputConverterAttributeType = context.Compilation.GetTypeByMetadataName(Constants.Types.InputConverterAttribute);
             return attributeType.GetAttributes()
-                .Where(attr => attr.AttributeClass.Equals(inputConverterAttributeType))
+                .Where(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, inputConverterAttributeType))
                 .ToList();
         }
 
         private static object GetAllowConverterFallbackParameterValue(SymbolAnalysisContext context, ITypeSymbol attributeType)
         {
             var allowConverterFallbackAttributeType = context.Compilation.GetTypeByMetadataName(Constants.Types.AllowConverterFallbackAttribute);
-            var allowConverterFallbackAttribute = attributeType.GetAttributes().FirstOrDefault(attr => attr.AttributeClass.Equals(allowConverterFallbackAttributeType));
+            var allowConverterFallbackAttribute = attributeType.GetAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, allowConverterFallbackAttributeType));
             return allowConverterFallbackAttribute.ConstructorArguments.FirstOrDefault().Value;
         }
 
@@ -103,7 +104,8 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
 
                 var converterAttributes = converter.GetAttributes();
 
-                var converterHasSupportedTypeAttribute = converterAttributes.Any(a => a.AttributeClass.Name == Constants.Names.SupportedConverterTypeAttribute);
+                var supportedConverterTypeAttributeType = context.Compilation.GetTypeByMetadataName(Constants.Types.SupportedConverterTypeAttribute);
+                var converterHasSupportedTypeAttribute = converterAttributes.Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, supportedConverterTypeAttributeType));
                 if (!converterHasSupportedTypeAttribute)
                 {
                     // If a converter does not have the `SupportedConverterTypeAttribute`, we don't need to check for supported types
@@ -111,7 +113,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
                 }
 
                 supportedTypes.AddRange(converterAttributes
-                    .Where(a => a.AttributeClass.Name == Constants.Names.SupportedConverterTypeAttribute)
+                    .Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, supportedConverterTypeAttributeType))
                     .SelectMany(a => a.ConstructorArguments.Select(arg => arg.Value))
                     .ToList());
             }

--- a/sdk/Sdk.Analyzers/Constants.cs
+++ b/sdk/Sdk.Analyzers/Constants.cs
@@ -12,9 +12,16 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
             public const string SupportsDeferredBindingAttribute = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.SupportsDeferredBindingAttribute";
             public const string InputBindingAttribute = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.InputBindingAttribute";
             public const string TriggerBindingAttribute = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.TriggerBindingAttribute";
+            public const string InputConverterAttribute = "Microsoft.Azure.Functions.Worker.Converters.InputConverterAttribute";
+            public const string AllowConverterFallbackAttribute = "Microsoft.Azure.Functions.Worker.Converters.AllowConverterFallbackAttribute";
 
             // System types
             internal const string TaskType = "System.Threading.Tasks.Task";
+        }
+
+        internal static class Names
+        {
+            public const string SupportedConverterTypeAttribute = "SupportedConverterTypeAttribute";
         }
 
         internal static class DiagnosticsCategories

--- a/sdk/Sdk.Analyzers/Constants.cs
+++ b/sdk/Sdk.Analyzers/Constants.cs
@@ -14,14 +14,10 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
             public const string TriggerBindingAttribute = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.TriggerBindingAttribute";
             public const string InputConverterAttribute = "Microsoft.Azure.Functions.Worker.Converters.InputConverterAttribute";
             public const string AllowConverterFallbackAttribute = "Microsoft.Azure.Functions.Worker.Converters.AllowConverterFallbackAttribute";
+            public const string SupportedConverterTypeAttribute = "Microsoft.Azure.Functions.Worker.Converters.SupportedConverterTypeAttribute";
 
             // System types
             internal const string TaskType = "System.Threading.Tasks.Task";
-        }
-
-        internal static class Names
-        {
-            public const string SupportedConverterTypeAttribute = "SupportedConverterTypeAttribute";
         }
 
         internal static class DiagnosticsCategories

--- a/sdk/Sdk.Analyzers/DeferredBindingAttributeNotSupported.cs
+++ b/sdk/Sdk.Analyzers/DeferredBindingAttributeNotSupported.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class DeferredBindingAttributeNotSupported : DiagnosticAnalyzer
     {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(DiagnosticDescriptors.DeferredBindingAttributeNotSupported); } }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.DeferredBindingAttributeNotSupported);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/sdk/Sdk.Analyzers/DeferredBindingAttributeNotSupported.cs
+++ b/sdk/Sdk.Analyzers/DeferredBindingAttributeNotSupported.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -33,26 +32,13 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
 
             foreach (var attribute in attributes)
             {
-                if (attribute.IsSupportsDeferredBindingAttribute() && !IsInputOrTriggerBinding(symbol))
+                if (attribute.IsSupportsDeferredBindingAttribute() && !symbol.IsInputOrTriggerBinding())
                 {
                     var location = Location.Create(attribute.ApplicationSyntaxReference.SyntaxTree, attribute.ApplicationSyntaxReference.Span);
                     var diagnostic = Diagnostic.Create(DiagnosticDescriptors.DeferredBindingAttributeNotSupported, location, attribute.AttributeClass.Name);
                     symbolAnalysisContext.ReportDiagnostic(diagnostic);
                 }
             }
-        }
-
-        private static bool IsInputOrTriggerBinding(INamedTypeSymbol symbol)
-        {
-            var baseType = symbol.BaseType?.ToDisplayString();
-
-            if (string.Equals(baseType,Constants.Types.InputBindingAttribute, StringComparison.Ordinal)
-                || string.Equals(baseType,Constants.Types.TriggerBindingAttribute, StringComparison.Ordinal))
-            {
-                return true;
-            }
-
-            return false;
         }
     }
 }

--- a/sdk/Sdk.Analyzers/DiagnosticDescriptors.cs
+++ b/sdk/Sdk.Analyzers/DiagnosticDescriptors.cs
@@ -25,5 +25,8 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
             = Create(id: "AZFW0009", title: "Invalid class attribute", messageFormat: "The attribute '{0}' can only be used on trigger and input binding attributes.",
                 category: Constants.DiagnosticsCategories.Usage, severity: DiagnosticSeverity.Error);
 
+        public static DiagnosticDescriptor BindingTypeNotSupported{ get; }
+            = Create(id: "AZFW0010", title: "Invalid binding type", messageFormat: "The binding type '{0}' is not supported by '{1}'.",
+                category: Constants.DiagnosticsCategories.Usage, severity: DiagnosticSeverity.Warning);
     }
 }

--- a/sdk/Sdk.Analyzers/Extensions/NamedSymbolExtensions.cs
+++ b/sdk/Sdk.Analyzers/Extensions/NamedSymbolExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
+{
+    internal static class NamedSymbolExtensions
+    {
+        internal static bool IsInputOrTriggerBinding(this INamedTypeSymbol symbol)
+        {
+            var baseType = symbol.BaseType?.ToDisplayString();
+
+            if (string.Equals(baseType,Constants.Types.InputBindingAttribute, StringComparison.Ordinal)
+                || string.Equals(baseType,Constants.Types.TriggerBindingAttribute, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/sdk/Sdk.Analyzers/Extensions/TypeSymbolExtensions.cs
+++ b/sdk/Sdk.Analyzers/Extensions/TypeSymbolExtensions.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers

--- a/sdk/Sdk.Analyzers/WebJobsAttributesNotSupported.cs
+++ b/sdk/Sdk.Analyzers/WebJobsAttributesNotSupported.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class WebJobsAttributesNotSupported : DiagnosticAnalyzer
     {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(DiagnosticDescriptors.WebJobsAttributesAreNotSupported); } }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.WebJobsAttributesAreNotSupported);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -8,9 +8,9 @@
 
 - <entry>
 
-### Microsoft.Azure.Functions.Worker.Sdk.Analyzers <version> (delete if not updated)
+### Microsoft.Azure.Functions.Worker.Sdk.Analyzers <version>
 
-- <entry>
+- Added an analyzer that will show a warning for types not supported by a binding attribute (#1505)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version> (delete if not updated)
 

--- a/test/FunctionMetadataGeneratorTests/SdkTests.csproj
+++ b/test/FunctionMetadataGeneratorTests/SdkTests.csproj
@@ -9,13 +9,13 @@
     <!--Investigate script abstractions codeanalysis dependencies and remove this-->
     <NoWarn>$(NoWarn);NU1608;NU1701</NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.3" />
-    <PackageReference Include="Moq" Version="4.18.2" />    
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Sdk.Analyzers.Tests/BindingTypeNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/BindingTypeNotSupportedTests.cs
@@ -1,0 +1,336 @@
+﻿using Xunit;
+using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.BindingTypeNotSupported, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.BindingTypeNotSupported>;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using System.Collections.Immutable;
+
+namespace Sdk.Analyzers.Tests
+{
+    public class BindingTypeNotSupportedTests
+    {
+
+        [Fact]
+        public async Task TestAttribute_ValidBindingType_DiagnosticsNotExpected()
+        {
+            string testCode = @"
+                using System;
+                using Microsoft.Azure.Functions.Worker;
+                using Microsoft.Azure.Functions.Worker.Core;
+                using Microsoft.Azure.Functions.Worker.Converters;
+                using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+
+                namespace Microsoft.Azure.Functions.Worker
+                {
+                    [AllowConverterFallback(false)]
+                    [InputConverter(typeof(TestConverter))]
+                    public class TestTriggerAttribute : TriggerBindingAttribute
+                    {
+                    }
+
+                    [SupportsDeferredBinding]
+                    [SupportedConverterType(typeof(string))]
+                    [SupportedConverterType(typeof(bool))]
+                    public class TestConverter
+                    {
+                    }
+                }
+
+                namespace FunctionApp
+                {
+                    public class SomeFunction
+                    {
+                        [Function(nameof(SomeFunction))]
+                        public void Run([TestTrigger()] string message)
+                        {
+                        }
+                    }
+                }";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                                        new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"))),
+                TestCode = testCode
+            };
+
+            // test.ExpectedDiagnostics is an empty collection.
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestAttribute_ValidBindingType_WithoutDeferredBinding_DiagnosticsNotExpected()
+        {
+            string testCode = @"
+                using System;
+                using Microsoft.Azure.Functions.Worker;
+                using Microsoft.Azure.Functions.Worker.Core;
+                using Microsoft.Azure.Functions.Worker.Converters;
+                using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+
+                namespace Microsoft.Azure.Functions.Worker
+                {
+                    [AllowConverterFallback(false)]
+                    [InputConverter(typeof(TestConverter))]
+                    public class TestTriggerAttribute : TriggerBindingAttribute
+                    {
+                    }
+
+                    [SupportedConverterType(typeof(string))]
+                    [SupportedConverterType(typeof(bool))]
+                    public class TestConverter
+                    {
+                    }
+                }
+
+                namespace FunctionApp
+                {
+                    public class SomeFunction
+                    {
+                        [Function(nameof(SomeFunction))]
+                        public void Run([TestTrigger()] string message)
+                        {
+                        }
+                    }
+                }";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                                        new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"))),
+                TestCode = testCode
+            };
+
+            // test.ExpectedDiagnostics is an empty collection.
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestAttribute_InvalidBindingType_DiagnosticsExpected()
+        {
+            string testCode = @"
+                using System;
+                using Microsoft.Azure.Functions.Worker;
+                using Microsoft.Azure.Functions.Worker.Core;
+                using Microsoft.Azure.Functions.Worker.Converters;
+                using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+
+                namespace Microsoft.Azure.Functions.Worker
+                {
+                    [AllowConverterFallback(false)]
+                    [InputConverter(typeof(TestConverter))]
+                    public class TestTriggerAttribute : TriggerBindingAttribute
+                    {
+                    }
+
+                    [SupportsDeferredBinding]
+                    [SupportedConverterType(typeof(string))]
+                    [SupportedConverterType(typeof(bool))]
+                    public class TestConverter
+                    {
+                    }
+                }
+
+                namespace FunctionApp
+                {
+                    public class SomeFunction
+                    {
+                        [Function(nameof(SomeFunction))]
+                        public void Run([TestTrigger()] BinaryData message)
+                        {
+                        }
+                    }
+                }";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                                        new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"))),
+                TestCode = testCode
+            };
+
+            test.ExpectedDiagnostics.Add(Verify.Diagnostic().WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(29, 68, 29, 75).WithArguments("BinaryData", "TestTriggerAttribute"));
+
+            await test.RunAsync();
+        }
+
+        /*  The following tests use real binding attributes from extensions.
+            We don't currently have a real binding that has SupportedConverterType
+            and has AllowConverterFallback set to false. */
+
+        [Theory]
+        [InlineData("ToDoItem")]
+        [InlineData("CosmosClient")]
+        [InlineData("Container")]
+        [InlineData("BinaryData")]
+        public async Task CosmosDBInputAttribute_DiagnosticsNotExpected(string supportedType)
+        {
+            string testCode = $@"
+                using System;
+                using System.Net;
+                using Microsoft.Azure.Cosmos;
+                using Microsoft.Azure.Functions.Worker;
+                using Microsoft.Azure.Functions.Worker.Http;
+
+                namespace FunctionApp
+                {{
+                    public static class SomeFunction
+                    {{
+                        [Function(nameof(SomeFunction))]
+                        public static void Run([HttpTrigger(AuthorizationLevel.Anonymous, ""get"")] HttpRequestData req,
+                        [CosmosDBInput(""a"", ""b"")] {supportedType} client)
+                        {{
+                        }}
+                    }}
+
+                    public class ToDoItem
+                    {{
+                        public string Id {{ get; set; }}
+                        public string Description {{ get; set; }}
+                        public bool IsComplete {{ get; set; }}
+                    }}
+                }}";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(
+                                        ImmutableArray.Create(
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Http", "3.0.13"),
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.CosmosDB", "4.2.0-preview2")
+                                        )),
+                TestCode = testCode
+            };
+
+            // test.ExpectedDiagnostics is an empty collection.
+
+            await test.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("string")]
+        [InlineData("ToDoItem")]
+        [InlineData("ServiceBusReceivedMessage")]
+        public async Task ServiceBusTriggerAttribute_ValidSingleBindingType_DiagnosticsNotExpected(string supportedType)
+        {
+            string testCode = $@"
+                using System;
+                using Azure.Messaging.ServiceBus;
+                using Microsoft.Azure.Functions.Worker;
+
+                namespace FunctionApp
+                {{
+                    public static class SomeFunction
+                    {{
+                        [Function(nameof(SomeFunction))]
+                        public static void Run([ServiceBusTrigger(""queue"")] {supportedType} message)
+                        {{
+                        }}
+                    }}
+
+                    public class ToDoItem
+                    {{
+                        public string Id {{ get; set; }}
+                        public string Description {{ get; set; }}
+                        public bool IsComplete {{ get; set; }}
+                    }}
+                }}";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(
+                                        ImmutableArray.Create(
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.ServiceBus", "5.10.0-preview2")
+                                        )),
+                TestCode = testCode
+            };
+
+            // test.ExpectedDiagnostics is an empty collection.
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ServiceBusTriggerAttribute_ValidCollectionBindingType_DiagnosticsNotExpected()
+        {
+            string testCode = @"
+                using System;
+                using Azure.Messaging.ServiceBus;
+                using Microsoft.Azure.Functions.Worker;
+
+                namespace FunctionApp
+                {
+                    public static class SomeFunction
+                    {
+                        [Function(nameof(SomeFunction))]
+                        public static void Run([ServiceBusTrigger(""queue"", IsBatched = true)] ServiceBusReceivedMessage[] messages)
+                        {
+                        }
+                    }
+                }";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(
+                                        ImmutableArray.Create(
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.ServiceBus", "5.10.0-preview2")
+                                        )),
+                TestCode = testCode
+            };
+
+            // test.ExpectedDiagnostics is an empty collection.
+
+            await test.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("string")]
+        [InlineData("ToDoItem")]
+        [InlineData("QueueMessage")]
+        [InlineData("BinaryData")]
+        public async Task QueueTriggerAttribute_ValidBindingTypes_DiagnosticsNotExpected(string supportedType)
+        {
+            string testCode = $@"
+                using System;
+                using Azure.Storage.Queues.Models;
+                using Microsoft.Azure.Functions.Worker;
+
+                namespace FunctionApp
+                {{
+                    public static class SomeFunction
+                    {{
+                        [Function(nameof(SomeFunction))]
+                        public static void Run([QueueTrigger(""input-queue"")] {supportedType} message)
+                        {{
+                        }}
+                    }}
+
+                    public class ToDoItem
+                    {{
+                        public string Id {{ get; set; }}
+                        public string Description {{ get; set; }}
+                        public bool IsComplete {{ get; set; }}
+                    }}
+                }}";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(
+                                        ImmutableArray.Create(
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues", "5.1.0-dev638205624203226170-local")
+                                        )),
+                TestCode = testCode
+            };
+
+            // test.ExpectedDiagnostics is an empty collection.
+
+            await test.RunAsync();
+        }
+    }
+}

--- a/test/Sdk.Analyzers.Tests/BindingTypeNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/BindingTypeNotSupportedTests.cs
@@ -289,23 +289,23 @@ namespace Sdk.Analyzers.Tests
         }
 
         [Theory]
-        [InlineData("string")]
-        [InlineData("ToDoItem")]
-        [InlineData("QueueMessage")]
-        [InlineData("BinaryData")]
-        public async Task QueueTriggerAttribute_ValidBindingTypes_DiagnosticsNotExpected(string supportedType)
+        [InlineData("TableClient")]
+        [InlineData("TableEntity")]
+        public async Task TableInputAttribute_ValidBindingTypes_DiagnosticsNotExpected(string supportedType)
         {
             string testCode = $@"
                 using System;
-                using Azure.Storage.Queues.Models;
+                using Azure.Data.Tables;
                 using Microsoft.Azure.Functions.Worker;
+                using Microsoft.Azure.Functions.Worker.Http;
 
                 namespace FunctionApp
                 {{
                     public static class SomeFunction
                     {{
                         [Function(nameof(SomeFunction))]
-                        public static void Run([QueueTrigger(""input-queue"")] {supportedType} message)
+                        public static void Run([HttpTrigger(AuthorizationLevel.Anonymous, ""get"")] HttpRequestData req,
+                        [TableInput(""input"")] {supportedType} message)
                         {{
                         }}
                     }}
@@ -323,7 +323,8 @@ namespace Sdk.Analyzers.Tests
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(
                                         ImmutableArray.Create(
                                             new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                                            new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues", "5.1.0-dev638205624203226170-local")
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Http", "3.0.13"),
+                                            new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Tables", "1.2.0-preview1")
                                         )),
                 TestCode = testCode
             };


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1144

An analyzer that gives a warning if a function is binding to a type that is not supported by the binding being used. This rule only applies if 

a) the converter on the attribute is using the supported converter types attribute to advertise supported types and
b) the binding being used does not allow fallback to built-in converters

Outside of the above scenario, this analyzer does not come into play

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
