### PR TITLE
fixing race on grpc client start

### DIFF
--- a/src/DotNetWorker.Grpc/GrpcWorker.cs
+++ b/src/DotNetWorker.Grpc/GrpcWorker.cs
@@ -67,9 +67,10 @@ namespace Microsoft.Azure.Functions.Worker
             _invocationHandler = new InvocationHandler(_application, _invocationFeaturesFactory, _serializer, _outputBindingsInfoProvider, _inputConversionFeatureProvider, logger);
         }
 
-        public async Task StartAsync(CancellationToken token)
+        public Task StartAsync(CancellationToken token)
         {
-            _workerClient = await _workerClientFactory.StartClientAsync(this, token);
+            _workerClient = _workerClientFactory.CreateClient(this);
+            return _workerClient.StartAsync(token);
         }
 
         public Task StopAsync(CancellationToken token) => Task.CompletedTask;

--- a/src/DotNetWorker.Grpc/IWorkerClient.cs
+++ b/src/DotNetWorker.Grpc/IWorkerClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Grpc.Messages;
 
@@ -8,6 +9,8 @@ namespace Microsoft.Azure.Functions.Worker.Grpc
 {
     internal interface IWorkerClient
     {
+        Task StartAsync(CancellationToken cancellationToken);
+
         ValueTask SendMessageAsync(StreamingMessage message);
     }
 }

--- a/src/DotNetWorker.Grpc/IWorkerClientFactory.cs
+++ b/src/DotNetWorker.Grpc/IWorkerClientFactory.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Microsoft.Azure.Functions.Worker.Grpc
 {
     internal interface IWorkerClientFactory
     {
-        Task<IWorkerClient> StartClientAsync(IMessageProcessor messageProcessor, CancellationToken token);
+        IWorkerClient CreateClient(IMessageProcessor messageProcessor);
     }
 }

--- a/src/DotNetWorker.Grpc/NativeHostIntegration/NativeWorkerClient.cs
+++ b/src/DotNetWorker.Grpc/NativeHostIntegration/NativeWorkerClient.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Text.Json;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Google.Protobuf;
 using Microsoft.Azure.Functions.Worker.Grpc.Messages;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Microsoft.Azure.Functions.Worker.Grpc.NativeHostIntegration
 {
@@ -28,6 +26,12 @@ namespace Microsoft.Azure.Functions.Worker.Grpc.NativeHostIntegration
             _outputChannelReader = outputChannel.Channel.Reader;
             _outputChannelWriter = outputChannel.Channel.Writer;
             _application = new NativeSafeHandle(nativeHostData.pNativeApplication);
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Start();
+            return Task.CompletedTask;
         }
 
         public unsafe void Start()

--- a/src/DotNetWorker.Grpc/NativeHostIntegration/NativeWorkerClientFactory.cs
+++ b/src/DotNetWorker.Grpc/NativeHostIntegration/NativeWorkerClientFactory.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Microsoft.Azure.Functions.Worker.Grpc.NativeHostIntegration
 {
     internal class NativeWorkerClientFactory : IWorkerClientFactory
@@ -16,14 +12,10 @@ namespace Microsoft.Azure.Functions.Worker.Grpc.NativeHostIntegration
             _hostChannel = hostChannel;
         }
 
-        public Task<IWorkerClient> StartClientAsync(IMessageProcessor messageProcessor, CancellationToken token)
+        public IWorkerClient CreateClient(IMessageProcessor messageProcessor)
         {
             var nativeHostData = NativeMethods.GetNativeHostData();
-
-            var client = new NativeWorkerClient(messageProcessor, _hostChannel, nativeHostData);
-            client.Start();
-
-            return Task.FromResult<IWorkerClient>(client);
+            return new NativeWorkerClient(messageProcessor, _hostChannel, nativeHostData);
         }
     }
 }


### PR DESCRIPTION
There's a possibility that `_workerClient` is null during initialization.

```
public async Task StartAsync(CancellationToken token)
{
    _workerClient = await _workerClientFactory.StartClientAsync(this, token);
}
```
Inside that call we send the `StartStream()` and start listening... so we can start to get messages sent to us before `StartClientAsync()` has returned -- leaving `_workeClient` null.

Change is to make this two distinct calls... one to create the client and another to start it so that it can never be null.