### PR TITLE
HttpTrigger POCO E2E Tests

### DIFF
--- a/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
@@ -3,8 +3,8 @@
 
 using System.Net;
 using System.Text.Json;
-using System.Web;
-using Microsoft.Azure.Functions.Worker;
+using System.Threading.Tasks;
+using Azure;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 
@@ -70,6 +70,59 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp
             logger.LogInformation(".NET Worker HTTP trigger function processed a request");
 
             return new MyResponse { Name = "Test" };
+        }
+
+        [Function(nameof(HelloWithNoResponse))]
+        public static Task HelloWithNoResponse(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)][FromBody] HttpRequestData req,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(HelloWithNoResponse));
+            logger.LogInformation($".NET Worker HTTP trigger function processed a request");
+
+            return Task.CompletedTask;
+        }
+
+        [Function(nameof(PocoFromBody))]
+        public static HttpResponseData PocoFromBody(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequestData req,
+            [FromBody] CallerName caller,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(PocoFromBody));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.WriteString($"Greetings {caller.Name}");
+            return response;
+        }
+
+        [Function(nameof(PocoBeforeRouteParameters))]
+        public static Task PocoBeforeRouteParameters(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "{region}/{category}/" + nameof(PocoBeforeRouteParameters))] [FromBody] CallerName caller,
+            string region,
+            string category,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(PocoBeforeRouteParameters));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+            return Task.CompletedTask;
+        }
+
+        [Function(nameof(PocoAfterRouteParameters))]
+        public static HttpResponseData PocoAfterRouteParameters(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "{region}/{category}/" + nameof(PocoAfterRouteParameters))] HttpRequestData req,
+            string region,
+            string category,
+            [FromBody] CallerName caller,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(PocoAfterRouteParameters));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.WriteString($"{region} {category} {caller.Name}");
+            return response;
         }
 
         public class MyResponse

--- a/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Azure;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 

--- a/test/E2ETests/E2EApps/E2EApp/Http/FailingHttpFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Http/FailingHttpFunctions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 ﻿using System;
@@ -6,6 +6,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Pipeline;
 using Microsoft.Extensions.Logging;
+using static Microsoft.Azure.Functions.Worker.E2EApp.BasicHttpFunctions;
 
 namespace Microsoft.Azure.Functions.Worker.E2EApp
 {
@@ -17,6 +18,16 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp
             FunctionContext context)
         {
             var logger = context.GetLogger(nameof(ExceptionFunction));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+            throw new Exception("This should never succeed!");
+        }        
+        
+        [Function(nameof(PocoWithoutBindingSource))]
+        public static HttpResponseData PocoWithoutBindingSource(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] CallerName caller,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(PocoWithoutBindingSource));
             logger.LogInformation(".NET Worker HTTP trigger function processed a request");
             throw new Exception("This should never succeed!");
         }

--- a/test/E2ETests/E2EApps/E2EApp/Http/FailingHttpFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Http/FailingHttpFunctions.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 ﻿using System;
-using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.Functions.Worker.Pipeline;
 using Microsoft.Extensions.Logging;
 using static Microsoft.Azure.Functions.Worker.E2EApp.BasicHttpFunctions;
 

--- a/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
+++ b/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
                     _funcProcess.StartInfo.ArgumentList.Add("PocoBeforeRouteParameters");
                     _funcProcess.StartInfo.ArgumentList.Add("PocoAfterRouteParameters");
                     _funcProcess.StartInfo.ArgumentList.Add("ExceptionFunction");
+                    _funcProcess.StartInfo.ArgumentList.Add("PocoWithoutBindingSource");
                 }
 
                 await CosmosDBHelpers.TryCreateDocumentCollectionsAsync(_logger);

--- a/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
+++ b/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
@@ -55,6 +55,10 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
                     _funcProcess.StartInfo.ArgumentList.Add("HelloFromQuery");
                     _funcProcess.StartInfo.ArgumentList.Add("HelloFromJsonBody");
                     _funcProcess.StartInfo.ArgumentList.Add("HelloUsingPoco");
+                    _funcProcess.StartInfo.ArgumentList.Add("HelloWithNoResponse");
+                    _funcProcess.StartInfo.ArgumentList.Add("PocoFromBody");
+                    _funcProcess.StartInfo.ArgumentList.Add("PocoBeforeRouteParameters");
+                    _funcProcess.StartInfo.ArgumentList.Add("PocoAfterRouteParameters");
                     _funcProcess.StartInfo.ArgumentList.Add("ExceptionFunction");
                 }
 

--- a/test/E2ETests/E2ETests/HttpEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/HttpEndToEndTests.cs
@@ -69,6 +69,17 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             Assert.Equal(expectedBody, responseBody);
         }
 
+
+        [Fact]
+        public async Task HttpTriggerTests_PocoWithoutBindingSource()
+        {
+            const HttpStatusCode expectedStatusCode = HttpStatusCode.InternalServerError;
+
+            HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("PocoWithoutBindingSource", "{ \"Name\": \"John\" }", expectedStatusCode, "application/json");
+
+            Assert.Equal(expectedStatusCode, response.StatusCode);
+        }
+
         [Fact]
         public async Task HttpTriggerTestsPocoResult()
         {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Adds the E2E tests mentioned in #1454. 

Note that it also has a missing binding source test and an extra test that's out of scope, `HelloWithNoResponse`. And I skipped removing the unused parameters in `InvokeHttpTriggerWithBody` this time.

@fabiocav 
