### PR TITLE
Add retries to generate function metadata on IOException

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,5 @@
 - Minor documentation updates (no functional changes)
 ### Microsoft.Azure.Functions.Worker.Grpc 1.10.1
 - Fixed an issue causing throughput degradation and for synchronous functions, blocked the execution pipeline. (#1516)
+### Microsoft.Azure.Functions.Worker.Sdk
+- Added retries on `IOException` when writing `function.metadata` file as part of `GenerateFunctionMetadata` msbuild task. This is to allow builds to continue (with warnings) when another process has the file momentarily locked. If the file continues to be locked the task (and build) will fail after 10 retries with a 1 second delay each.

--- a/sdk/Sdk/FunctionMetadataJsonWriter.cs
+++ b/sdk/Sdk/FunctionMetadataJsonWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -10,39 +10,33 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
 {
     internal static class FunctionMetadataJsonWriter
     {
-        private static readonly JsonSerializerOptions _serializerOptions = CreateSerializerOptions();
-        private const string _fileName = "functions.metadata";
+        private const string FileName = "functions.metadata";
+        private static readonly JsonSerializerOptions s_serializerOptions = CreateSerializerOptions();
 
         private static JsonSerializerOptions CreateSerializerOptions()
         {
             var namingPolicy = new FunctionsJsonNamingPolicy();
-
-            var options = new JsonSerializerOptions
+            return new JsonSerializerOptions
             {
                 WriteIndented = true,
                 IgnoreNullValues = true,
                 PropertyNameCaseInsensitive = true,
                 IgnoreReadOnlyProperties = true,
                 DictionaryKeyPolicy = namingPolicy,
-                PropertyNamingPolicy = namingPolicy
+                PropertyNamingPolicy = namingPolicy,
+                Converters =
+                {
+                    new JsonStringEnumConverter(),
+                }
             };
-
-            options.Converters.Add(new JsonStringEnumConverter());
-
-            return options;
         }
 
         public static void WriteMetadata(IEnumerable<SdkFunctionMetadata> functions, string metadataFileDirectory)
         {
-            string metadataFile = Path.Combine(metadataFileDirectory, _fileName);
-
-            using (var fs = new FileStream(metadataFile, FileMode.Create, FileAccess.Write))
-            {
-                using (var writer = new Utf8JsonWriter(fs, new JsonWriterOptions { Indented = true }))
-                {
-                    JsonSerializer.Serialize(writer, functions, _serializerOptions);
-                }
-            }
+            string metadataFile = Path.Combine(metadataFileDirectory, FileName);
+            using var fs = new FileStream(metadataFile, FileMode.Create, FileAccess.Write);
+            using var writer = new Utf8JsonWriter(fs, new JsonWriterOptions { Indented = true });
+            JsonSerializer.Serialize(writer, functions, s_serializerOptions);
         }
     }
 }

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <MinorProductVersion>10</MinorProductVersion>
+    <MinorProductVersion>11</MinorProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

addresses part of #1513

This PR simply adds retries when trying to write to `function.metadata` as part of a function apps build. Typically, this file would not be locked, but if a function app is built twice in quick succession, this file may be locked by something like antivirus. This is a low-risk change to try and let the build succeed in scenarios where it might fail.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
