### PR TITLE
Add Cosmos emulator brute force script & reenabling tests

### DIFF
--- a/src/ci.yml
+++ b/src/ci.yml
@@ -43,8 +43,8 @@ jobs:
     buildConfiguration: 'Release'
 
   steps:
-  - pwsh: . "tools/start-emulators.ps1" -NoWait
-    displayName: "Start emulators (-NoWait)"
+  - pwsh: . "tools/start-emulators.ps1"
+    displayName: "Start emulators"
 
   - template: ../build/install-dotnet.yml
 

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -47,7 +47,7 @@ jobs:
     displayName: "Start emulators (-NoWait)"
 
   - template: ../build/install-dotnet.yml
-  
+
   - task: DotNetCoreCLI@2
     displayName: 'Build projects'
     inputs:
@@ -63,8 +63,7 @@ jobs:
       }
       ./setup-e2e-tests.ps1 -FunctionsRuntimeVersion $env:FUNCTIONSRUNTIMEVERSION `
                             -UseCoreToolsBuildFromIntegrationTests:$useIntegrationTestingCoreTools `
-                            -SkipBuildOnPack `
-                            -SkipCosmosDBEmulator
+                            -SkipBuildOnPack
     displayName: "Setup E2E tests"
 
   - task: DotNetCoreCLI@2

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -43,7 +43,7 @@ jobs:
     buildConfiguration: 'Release'
 
   steps:
-  - pwsh: . "tools/start-emulators.ps1" -NoWait -SkipCosmosDBEmulator
+  - pwsh: . "tools/start-emulators.ps1" -NoWait
     displayName: "Start emulators (-NoWait)"
 
   - template: ../build/install-dotnet.yml

--- a/test/E2ETests/E2ETests/CosmosDBEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/CosmosDBEndToEndTests.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             _disposeLog = _fixture.TestLogs.UseTestLogger(testOutput);
         }
 
-        [Fact(Skip = "Need to debug why Cosmos emulator does not always start.")]
+        [Fact]
         public async Task CosmosDBTriggerAndOutput_Succeeds()
         {
             string expectedDocId = Guid.NewGuid().ToString();
             try
             {
-                //Trigger            
+                //Trigger
                 await CosmosDBHelpers.CreateDocument(expectedDocId);
 
                 //Read

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -17,6 +17,7 @@ Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 
 if (!$SkipCosmosDBEmulator)
 {
+    Add-MpPreference -ExclusionPath "$env:ProgramFiles\Azure Cosmos DB Emulator"
     Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
 }
 
@@ -54,23 +55,54 @@ if (!$SkipCosmosDBEmulator)
 {
     Write-Host ""
     Write-Host "---Starting CosmosDB emulator---"
-    $cosmosStatus = Get-CosmosDbEmulatorStatus
-    Write-Host "CosmosDB emulator status: $cosmosStatus"
+    # $cosmosStatus = Get-CosmosDbEmulatorStatus
+    # Write-Host "CosmosDB emulator status: $cosmosStatus"
 
-    if ($cosmosStatus -eq "StartPending")
-    {        
-        $startedCosmos = $true
+
+    for ($j=0; $j -lt 3; $j++) {
+        Write-Host "Attempt $j"
+        Start-Process "$env:ProgramFiles\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/NoExplorer /NoUI /DisableRateLimiting /PartitionCount=50 /Consistency=Strong /EnablePreview /EnableSqlComputeEndpoint" -Verb RunAs
+
+        for ($i=0; $i -lt 5; $i++) {
+            $status = Get-CosmosDbEmulatorStatus
+            Write-Host "Cosmos DB Emulator Status: $status"
+
+            if ($status -ne "Running") {
+                sleep 30;
+            }
+            else {
+                break;
+            }
+        }
+
+        if ($status -ne "Running") {
+            Write-Host "Shutting down and restarting"
+            Start-Process "$env:ProgramFiles\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/Shutdown" -Verb RunAs
+            sleep 30;
+        }
+        else {
+            break;
+        }
     }
-    elseif ($cosmosStatus -ne "Running")
-    {
-        Write-Host "CosmosDB emulator is not running. Starting emulator."
-        Start-CosmosDbEmulator -NoWait -NoUI
-        $startedCosmos = $true
+
+    if ($status -ne "Running") {
+        Write-Error "Emulator failed to start"
     }
-    else
-    {    
-        Write-Host "CosmosDB emulator is already running."
-    }
+
+    # if ($cosmosStatus -eq "StartPending")
+    # {
+    #     $startedCosmos = $true
+    # }
+    # elseif ($cosmosStatus -ne "Running")
+    # {
+    #     Write-Host "CosmosDB emulator is not running. Starting emulator."
+    #     Start-CosmosDbEmulator -NoWait -NoUI
+    #     $startedCosmos = $true
+    # }
+    # else
+    # {
+    #     Write-Host "CosmosDB emulator is already running."
+    # }
 }
 
 if (!$SkipStorageEmulator)
@@ -112,25 +144,25 @@ if ($NoWait -eq $true)
     exit 0
 }
 
-if (!$SkipCosmosDBEmulator -and $startedCosmos -eq $true)
-{
-    Write-Host "---Waiting for CosmosDB emulator to be running---"
-    $cosmosStatus = Get-CosmosDbEmulatorStatus
-    Write-Host "CosmosDB emulator status: $cosmosStatus"
+# if (!$SkipCosmosDBEmulator -and $startedCosmos -eq $true)
+# {
+#     Write-Host "---Waiting for CosmosDB emulator to be running---"
+#     $cosmosStatus = Get-CosmosDbEmulatorStatus
+#     Write-Host "CosmosDB emulator status: $cosmosStatus"
 
-    $waitSuccess = Wait-CosmosDbEmulator -Status Running -Timeout 60 -ErrorAction Continue
+#     $waitSuccess = Wait-CosmosDbEmulator -Status Running -Timeout 60 -ErrorAction Continue
 
-    if ($waitSuccess -ne $true)
-    {
-        Write-Host "CosmosDB emulator not yet running after waiting 60 seconds. Restarting."
-        Stop-CosmosDbEmulator
-        Write-Host "Restarting CosmosDB emulator"
-        Start-CosmosDbEmulator -NoUI
-    }
+#     if ($waitSuccess -ne $true)
+#     {
+#         Write-Host "CosmosDB emulator not yet running after waiting 60 seconds. Restarting."
+#         Stop-CosmosDbEmulator
+#         Write-Host "Restarting CosmosDB emulator"
+#         Start-CosmosDbEmulator -NoUI
+#     }
 
-    Write-Host "------"
-    Write-Host
-}
+#     Write-Host "------"
+#     Write-Host
+# }
 
 if (!$SkipStorageEmulator -and $startedStorage -eq $true)
 {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1567

We still don't have an update from the team that manages the cosmos emulator; for now, we're going to copy what the CosmosDB PG is doing and clone their brute force [script](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/templates/emulator-setup.yml).

I've run the pipeline a couple times now and the cosmos emulator has come up every time; and cosmos tests are successful:

![Screenshot 2023-05-26 at 12 43 48 PM](https://github.com/Azure/azure-functions-dotnet-worker/assets/2198905/957673c9-8e38-44e0-ad08-58bfe94d7bd1)
