### PR TITLE
Disable cosmos emulator for non-Windows OS

### DIFF
--- a/src/ci.yml
+++ b/src/ci.yml
@@ -43,7 +43,7 @@ jobs:
     buildConfiguration: 'Release'
 
   steps:
-  - pwsh: . "tools/start-emulators.ps1 -NoWait"
+  - pwsh: . "tools/start-emulators.ps1" -NoWait
     displayName: "Start emulators (NoWait)"
 
   - template: ../build/install-dotnet.yml

--- a/src/ci.yml
+++ b/src/ci.yml
@@ -43,8 +43,8 @@ jobs:
     buildConfiguration: 'Release'
 
   steps:
-  - pwsh: . "tools/start-emulators.ps1"
-    displayName: "Start emulators"
+  - pwsh: . "tools/start-emulators.ps1 -NoWait"
+    displayName: "Start emulators (NoWait)"
 
   - template: ../build/install-dotnet.yml
 

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -15,20 +15,27 @@ $DebugPreference = 'Continue'
 Write-Host "Skip CosmosDB Emulator: $SkipCosmosDBEmulator"
 Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 
-if (!$SkipCosmosDBEmulator)
-{
-    Add-MpPreference -ExclusionPath "$env:ProgramFiles\Azure Cosmos DB Emulator"
-    Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-}
-
 $startedCosmos = $false
 $startedStorage = $false
 
 if (!$IsWindows -and !$IsLinux -and !$IsMacOs)
 {
-  # For pre-PS6
-  Write-Host "Could not resolve OS. Assuming Windows."
-  $IsWindows = $true
+    # For pre-PS6
+    Write-Host "Could not resolve OS. Assuming Windows."
+    $IsWindows = $true
+}
+
+if (!$IsWindows)
+{
+    Write-Host "Skipping CosmosDB emulator because it is not supported on non-Windows OS."
+    $SkipCosmosDBEmulator = $true
+}
+
+if (!$SkipCosmosDBEmulator)
+{
+    # Locally, you may need to run PowerShell with administrative privileges
+    Add-MpPreference -ExclusionPath "$env:ProgramFiles\Azure Cosmos DB Emulator"
+    Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
 }
 
 function IsStorageEmulatorRunning()


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1577

- Disable the cosmos emulator if not running on Windows (no non-windows support available)
- Add back the -NoWait on the initial emulator startup in the AzDO CI
