### PR TITLE
mapping endpoints on worker for ASP.NET proxy integration

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionHttpBinding.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionHttpBinding.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
+{
+    /// <summary>
+    /// Represents an HttpTrigger binding. Internal class for deserializing raw binding info.
+    /// </summary>
+    internal class FunctionHttpBinding
+    {
+        public string Name { get; set; } = default!;
+
+        public string Type { get; set; } = default!;
+
+        public string Route { get; set; } = default!;
+
+        public string[] Methods { get; set; } = default!;
+    }
+}

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMiddleware
+{
+    internal class FunctionsEndpointDataSource : EndpointDataSource
+    {
+        private const string FunctionsApplicationDirectoryKey = "FUNCTIONS_APPLICATION_DIRECTORY";
+        private const string HostJsonFileName = "host.json";
+        private const string DefaultRoutePrefix = "api";
+
+        private readonly IFunctionMetadataProvider _functionMetadataProvider;
+        private readonly object _lock = new();
+
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+
+        private List<Endpoint>? _endpoints;
+
+        public FunctionsEndpointDataSource(IFunctionMetadataProvider functionMetadataProvider)
+        {
+            _functionMetadataProvider = functionMetadataProvider ?? throw new ArgumentNullException(nameof(functionMetadataProvider));
+        }
+
+        public override IReadOnlyList<Endpoint> Endpoints
+        {
+            get
+            {
+                if (_endpoints is null)
+                {
+                    lock (_lock)
+                    {
+                        _endpoints ??= BuildEndpoints();
+                    }
+                }
+
+                return _endpoints;
+            }
+        }
+
+        private List<Endpoint> BuildEndpoints()
+        {
+            List<Endpoint> endpoints = new List<Endpoint>();
+
+            string scriptRoot = Environment.GetEnvironmentVariable(FunctionsApplicationDirectoryKey) ??
+                           throw new InvalidOperationException("Cannot determine script root directory.");
+
+            var metadata = _functionMetadataProvider.GetFunctionMetadataAsync(scriptRoot).GetAwaiter().GetResult();
+
+            string routePrefix = GetRoutePrefixFromHostJson(scriptRoot) ?? DefaultRoutePrefix;
+
+            foreach (var functionMetadata in metadata)
+            {
+                var endpoint = MapHttpFunction(functionMetadata, routePrefix);
+
+                if (endpoint is not null)
+                {
+                    endpoints.Add(endpoint);
+                }
+            }
+
+            return endpoints;
+        }
+
+        public override IChangeToken GetChangeToken() => NullChangeToken.Singleton;
+
+        internal static Endpoint? MapHttpFunction(IFunctionMetadata functionMetadata, string routePrefix)
+        {
+            if (functionMetadata.RawBindings is null)
+            {
+                return null;
+            }
+
+            var functionName = functionMetadata.Name ?? string.Empty;
+
+            int order = 0;
+            foreach (var binding in functionMetadata.RawBindings)
+            {
+                var functionBinding = JsonSerializer.Deserialize<FunctionHttpBinding>(binding, _jsonSerializerOptions);
+
+                if (functionBinding is null)
+                {
+                    continue;
+                }
+
+                if (functionBinding.Type.Equals("httpTrigger", StringComparison.OrdinalIgnoreCase))
+                {
+                    string routeSuffix = functionBinding.Route ?? functionName;
+                    string route = $"{routePrefix}/{routeSuffix}";
+
+                    var pattern = RoutePatternFactory.Parse(route);
+
+                    var endpointBuilder = new RouteEndpointBuilder(FunctionsHttpContextExtensions.InvokeFunctionAsync, pattern, order++)
+                    {
+                        DisplayName = functionName
+                    };
+                    endpointBuilder.Metadata.Add(new HttpMethodMetadata(functionBinding.Methods));
+
+                    // no need to look at other bindings for this function
+                    return endpointBuilder.Build();
+                }
+            }
+
+            return null;
+        }
+
+        private static string? GetRoutePrefixFromHostJson(string scriptRoot)
+        {
+            string hostJsonPath = Path.Combine(scriptRoot, HostJsonFileName);
+
+            if (!File.Exists(hostJsonPath))
+            {
+                return null;
+            }
+
+            string hostJsonString = File.ReadAllText(hostJsonPath);
+            return GetRoutePrefix(hostJsonString);
+        }
+
+        internal static string? GetRoutePrefix(string hostJsonString)
+        {
+            var hostJson = JsonSerializer.Deserialize<HostJsonModel>(hostJsonString, _jsonSerializerOptions);
+            return hostJson?.Extensions?.Http?.RoutePrefix;
+        }
+    }
+}

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsHttpContextExtensions.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsHttpContextExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Http
+{
+    internal static class FunctionsHttpContextExtensions
+    {
+        internal static Task InvokeFunctionAsync(this HttpContext context)
+        {
+            var coordinator = context.RequestServices.GetRequiredService<IHttpCoordinator>();
+            context.Request.Headers.TryGetValue(Constants.CorrelationHeader, out StringValues invocationId);
+            return coordinator.RunFunctionInvocationAsync(invocationId);
+        }
+    }
+}

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/HostJsonModel.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/HostJsonModel.cs
@@ -1,0 +1,20 @@
+﻿namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
+{
+    /// <summary>
+    /// Represents host.json. Internal class for deserializing.
+    /// </summary>
+    internal class HostJsonModel
+    {
+        public HostJsonExtensionModel Extensions { get; set; } = default!;
+    }
+
+    internal class HostJsonExtensionModel
+    {
+        public HostJsonExtensionHttpModel Http { get; set; } = default!;
+    }
+
+    internal class HostJsonExtensionHttpModel
+    {
+        public string RoutePrefix { get; set; } = default!;
+    }
+}

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/InvokeFunctionMiddleware.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/InvokeFunctionMiddleware.cs
@@ -3,23 +3,18 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 {
     internal class InvokeFunctionMiddleware
     {
-        private readonly IHttpCoordinator _coordinator;
-
-        public InvokeFunctionMiddleware(RequestDelegate next, IHttpCoordinator httpCoordinator)
+        public InvokeFunctionMiddleware(RequestDelegate next)
         {
-            _coordinator = httpCoordinator;
         }
 
         public Task Invoke(HttpContext context)
         {
-            context.Request.Headers.TryGetValue(Constants.CorrelationHeader, out StringValues invocationId);
-            return _coordinator.RunFunctionInvocationAsync(invocationId);
+            return context.InvokeFunctionAsync();
         }
     }
 }

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsHostBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsHostBuilderExtensions.cs
@@ -47,6 +47,11 @@ namespace Microsoft.Extensions.Hosting
 
         internal static IHostBuilder ConfigureAspNetCoreIntegration(this IHostBuilder builder)
         {
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<FunctionsEndpointDataSource>();
+            });
+
             builder.ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseUrls(HttpUriProvider.HttpUriString);

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsHostBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsHostBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore;
+using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMiddleware;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting
@@ -13,7 +14,7 @@ namespace Microsoft.Extensions.Hosting
     /// <summary>
     /// Provides extension methods to work with a <see cref="IHostBuilder"/>.
     /// </summary>
-    public static class HostBuilderExtensions
+    public static class FunctionsHostBuilderExtensions
     {
         /// <summary>
         /// Configures the worker to use the ASP.NET Core integration, enabling advanced HTTP features.
@@ -51,9 +52,14 @@ namespace Microsoft.Extensions.Hosting
                 webBuilder.UseUrls(HttpUriProvider.HttpUriString);
                 webBuilder.Configure(b =>
                 {
+                    b.UseRouting();
                     b.UseMiddleware<WorkerRequestServicesMiddleware>();
-                    // TODO: provide a way for customers to configure their middleware pipeline here
-                    b.UseMiddleware<InvokeFunctionMiddleware>();
+                    // TODO: provide a way for customers to configure their middleware pipeline here                   
+                    b.UseEndpoints(endpoints =>
+                    {
+                        var dataSource = endpoints.ServiceProvider.GetRequiredService<FunctionsEndpointDataSource>();
+                        endpoints.DataSources.Add(dataSource);
+                    });
                 });
             });
 

--- a/test/DotNetWorkerTests/AspNetCore/FunctionsEndpointDataSourceTests.cs
+++ b/test/DotNetWorkerTests/AspNetCore/FunctionsEndpointDataSourceTests.cs
@@ -1,0 +1,136 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMiddleware;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests.AspNetCore
+{
+    public class FunctionsEndpointDataSourceTests
+    {
+        [Theory]
+        [InlineData("api")]
+        [InlineData("customRoutePrefix")]
+        public void MapHttpFunction(string routePrefix)
+        {
+            string rawBinding = """
+            {
+                "name": "req",
+                "direction": "In",
+                "Type": "httpTrigger",
+                "authLevel": "Anonymous",
+                "methods": ["get", "post"],
+                "properties": { }
+            }
+            """;
+
+            var metadata = new DefaultFunctionMetadata
+            {
+                Name = "TestFunction",
+                RawBindings = new List<string> { rawBinding },
+            };
+
+            RouteEndpoint endpoint = FunctionsEndpointDataSource.MapHttpFunction(metadata, routePrefix) as RouteEndpoint;
+
+            Assert.Equal("TestFunction", endpoint.DisplayName);
+            Assert.Equal($"{routePrefix}/TestFunction", endpoint.RoutePattern.RawText);
+            var endpointMetadata = endpoint.Metadata.Single() as HttpMethodMetadata;
+            Assert.Equal(new[] { "GET", "POST" }, endpointMetadata.HttpMethods);
+        }
+
+        [Fact]
+        public void MapHttpFunction_CustomRoute()
+        {
+            string rawBinding = """
+            {
+                "name": "req",
+                "direction": "In",
+                "type": "httpTrigger",
+                "route": "customRoute/function",
+                "authLevel": "Anonymous",
+                "methods": ["get", "post"],
+                "properties": { }
+            }
+            """;
+
+            var metadata = new DefaultFunctionMetadata
+            {
+                Name = "TestFunction",
+                RawBindings = new List<string> { rawBinding },
+            };
+
+            RouteEndpoint endpoint = FunctionsEndpointDataSource.MapHttpFunction(metadata, "api") as RouteEndpoint;
+
+            Assert.Equal("TestFunction", endpoint.DisplayName);
+            Assert.Equal($"api/customRoute/function", endpoint.RoutePattern.RawText);
+            var endpointMetadata = endpoint.Metadata.Single() as HttpMethodMetadata;
+            Assert.Equal(new[] { "GET", "POST" }, endpointMetadata.HttpMethods);
+        }
+
+        [Fact]
+        public void MapHttpFunction_CustomRoute_CaseInsensitive()
+        {
+            string rawBinding = """
+            {
+                "name": "req",
+                "direction": "In",
+                "tyPe": "httpTrigger",
+                "rOute": "customRoute/function",
+                "authLevel": "Anonymous",
+                "metHOds": ["get", "post"],
+                "properties": { }
+            }
+            """;
+
+            var metadata = new DefaultFunctionMetadata
+            {
+                Name = "TestFunction",
+                RawBindings = new List<string> { rawBinding },
+            };
+
+            RouteEndpoint endpoint = FunctionsEndpointDataSource.MapHttpFunction(metadata, "api") as RouteEndpoint;
+
+            Assert.Equal("TestFunction", endpoint.DisplayName);
+            Assert.Equal($"api/customRoute/function", endpoint.RoutePattern.RawText);
+            var endpointMetadata = endpoint.Metadata.Single() as HttpMethodMetadata;
+            Assert.Equal(new[] { "GET", "POST" }, endpointMetadata.HttpMethods);
+        }
+
+        [Fact]
+        public void GetRoutePrefix()
+        {
+            string hostJson = """
+            {
+                "version": "2.0",
+                "extensions": {  
+                    "http": {
+                        "routePrefix": "custom"
+                    }
+                }
+            }
+            """;
+
+            string prefix = FunctionsEndpointDataSource.GetRoutePrefix(hostJson);
+            Assert.Equal("custom", prefix);
+        }
+
+        [Fact]
+        public void GetRoutePrefix_CaseInsensitive()
+        {
+            string hostJson = """
+            {
+                "version": "2.0",
+                "ExTEnsions": {  
+                    "hTtp": {
+                        "rOUtepREfix": "custom"
+                    }
+                }
+            }
+            """;
+
+            string prefix = FunctionsEndpointDataSource.GetRoutePrefix(hostJson);
+            Assert.Equal("custom", prefix);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1527 

Previously, endpoints were not available when using the ASP.NET Core integration feature.

This change registers endpoints by combining the host.json "routePrefix" setting with the `HttpTriggerAttribute` Route to provide details on the endpoint that was selected (or uses the defaults).

Now, you can do something like this to access the endpoint selected for the Function.

```csharp
[Function(nameof(HttpProxyTrigger))]
public IActionResult Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequest req)
{
    // Previously, this was null
    RouteEndpoint endpoint = req.HttpContext.GetEndpoint() as RouteEndpoint;

    string displayName = endpoint.DisplayName; // "HttpProxyTrigger"
    string routePattern = endpoint.RoutePattern.RawText; // "api/HttpProxyTrigger"
    IReadOnlyList<string> httpMethods = (endpoint.Metadata.Single() as HttpMethodMetadata)?.HttpMethods; // "GET, POST"
    ...
}
```