### PR TITLE
adding ConfigureFunctionsWebApplication to register AspNetCore services

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -2,3 +2,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR/#issue)
 -->
+Breaking changes:
+- `UseAspNetCoreIntegration()` and `ConfgigureAspNetCoreIntegration()` are now obsolete. Use `ConfigureFunctionsWebApplication()` to configure services for AspNetCore integration. Details can be found in PR #1601.

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/HostBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/HostBuilderExtensions.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,14 +15,36 @@ namespace Microsoft.Extensions.Hosting
     /// </summary>
     public static class HostBuilderExtensions
     {
-
-        // TODO: This should be modified to extend IFunctionsWorkerApplicationBuilder.
         /// <summary>
         /// Configures the worker to use the ASP.NET Core integration, enabling advanced HTTP features.
         /// </summary>
         /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
         /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
-        public static IHostBuilder ConfigureAspNetCoreIntegration(this IHostBuilder builder)
+        public static IHostBuilder ConfigureWebFunctionsWorker(this IHostBuilder builder)
+        {
+            return builder.ConfigureWebFunctionsWorker(_ => { });
+        }
+
+        /// <summary>
+        /// Configures the worker to use the ASP.NET Core integration, enabling advanced HTTP features.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
+        /// <param name="configureWorker">The worker configure callback.</param>
+        /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
+        public static IHostBuilder ConfigureWebFunctionsWorker(this IHostBuilder builder, Action<IFunctionsWorkerApplicationBuilder> configureWorker)
+        {
+            builder.ConfigureFunctionsWorkerDefaults(workerAppBuilder =>
+            {
+                workerAppBuilder.UseAspNetCoreIntegration();
+                configureWorker?.Invoke(workerAppBuilder);
+            });
+
+            builder.ConfigureAspNetCoreIntegration();
+
+            return builder;
+        }
+
+        internal static IHostBuilder ConfigureAspNetCoreIntegration(this IHostBuilder builder)
         {
             builder.ConfigureWebHostDefaults(webBuilder =>
             {

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/HostBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/HostBuilderExtensions.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
         /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
-        public static IHostBuilder ConfigureWebFunctionsWorker(this IHostBuilder builder)
+        public static IHostBuilder ConfigureFunctionsWebApplication(this IHostBuilder builder)
         {
-            return builder.ConfigureWebFunctionsWorker(_ => { });
+            return builder.ConfigureFunctionsWebApplication(_ => { });
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
         /// <param name="configureWorker">The worker configure callback.</param>
         /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
-        public static IHostBuilder ConfigureWebFunctionsWorker(this IHostBuilder builder, Action<IFunctionsWorkerApplicationBuilder> configureWorker)
+        public static IHostBuilder ConfigureFunctionsWebApplication(this IHostBuilder builder, Action<IFunctionsWorkerApplicationBuilder> configureWorker)
         {
             builder.ConfigureFunctionsWorkerDefaults(workerAppBuilder =>
             {

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
@@ -15,7 +15,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\DotNetWorker.Core\DotNetWorker.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\DotNetWorker\DotNetWorker.csproj" />
     <ProjectReference Include="..\..\Worker.Extensions.Abstractions\src\Worker.Extensions.Abstractions.csproj" />
   </ItemGroup>
 

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/WorkerBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/WorkerBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Functions.Worker
     /// <summary>
     /// Provides extension methods to work with a <see cref="IFunctionsWorkerApplicationBuilder"/>.
     /// </summary>
-    public static class WorkerBuilderExtensions
+    internal static class WorkerBuilderExtensions
     {
         /// <summary>
         /// Adds the services needed to integrate with AspNetCore


### PR DESCRIPTION
Fixes #1597

Adds a wrapper that combines the two calls you used to have to make into a single call. This changes how we register all of the services for the worker and for ASP.NET.

A call to `ConfigureFunctionsWebApplication()` replaces the two wire-up calls made in the earlier preview. It also replaces the call to `ConfigureFunctionsWorkerDefaults()`.

### Previously:
Two calls: one on the `IFunctionsWorkerApplicationBuilder` and one on the `HostBuilder`
```csharp
var host = new HostBuilder()
    .ConfigureFunctionsWorkerDefaults(builder =>
    {
        builder.UseAspNetCoreIntegration();
    })
    .ConfigureAspNetCoreIntegration()
    .Build()
```

### Now 
A single method on the `HostBuilder` with similar callbacks available
```csharp
var host = new HostBuilder()
    .ConfigureFunctionsWebApplication()
    .Build();
```