### PR TITLE
Add new Extensions.Rpc package with gRPC helpers

### DIFF
--- a/DotNetWorker.sln
+++ b/DotNetWorker.sln
@@ -122,6 +122,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerBindingSamples", "sam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Rpc", "extensions\Worker.Extensions.Rpc\src\Worker.Extensions.Rpc.csproj", "{93B64F12-EBDD-46CE-B4FB-0904701F0032}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extensions", "Extensions", "{AA4D318D-101B-49E7-A4EC-B34165AEDB33}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Rpc.Tests", "test\Worker.Extensions.Rpc.Tests\Worker.Extensions.Rpc.Tests.csproj", "{B13C9E5F-0E4B-413E-90AE-20B84B100364}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -300,6 +304,10 @@ Global
 		{93B64F12-EBDD-46CE-B4FB-0904701F0032}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93B64F12-EBDD-46CE-B4FB-0904701F0032}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93B64F12-EBDD-46CE-B4FB-0904701F0032}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B13C9E5F-0E4B-413E-90AE-20B84B100364}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B13C9E5F-0E4B-413E-90AE-20B84B100364}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B13C9E5F-0E4B-413E-90AE-20B84B100364}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B13C9E5F-0E4B-413E-90AE-20B84B100364}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -352,6 +360,8 @@ Global
 		{277D77B9-8915-41E3-8763-0B66328ADDDA} = {A7B4FF1E-3DF7-4F28-9333-D0961CDDF702}
 		{901DA3C3-3ABA-4859-89D3-63343ED2A0AC} = {9D6603BD-7EA2-4D11-A69C-0D9E01317FD6}
 		{93B64F12-EBDD-46CE-B4FB-0904701F0032} = {A7B4FF1E-3DF7-4F28-9333-D0961CDDF702}
+		{AA4D318D-101B-49E7-A4EC-B34165AEDB33} = {FD7243E4-BF18-43F8-8744-BA1D17ACF378}
+		{B13C9E5F-0E4B-413E-90AE-20B84B100364} = {AA4D318D-101B-49E7-A4EC-B34165AEDB33}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {497D2ED4-A13E-4BCA-8D29-F30CA7D0EA4A}

--- a/DotNetWorker.sln
+++ b/DotNetWorker.sln
@@ -117,7 +117,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Tables", "extensions\Worker.Extensions.Tables\src\Worker.Extensions.Tables.csproj", "{004DEF24-7EBB-499D-BD1C-E940AC4E122D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Shared", "extensions\Worker.Extensions.Shared\Worker.Extensions.Shared.csproj", "{277D77B9-8915-41E3-8763-0B66328ADDDA}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerBindingSamples", "samples\WorkerBindingSamples\WorkerBindingSamples.csproj", "{901DA3C3-3ABA-4859-89D3-63343ED2A0AC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Rpc", "extensions\Worker.Extensions.Rpc\src\Worker.Extensions.Rpc.csproj", "{93B64F12-EBDD-46CE-B4FB-0904701F0032}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -293,6 +296,10 @@ Global
 		{901DA3C3-3ABA-4859-89D3-63343ED2A0AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{901DA3C3-3ABA-4859-89D3-63343ED2A0AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{901DA3C3-3ABA-4859-89D3-63343ED2A0AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93B64F12-EBDD-46CE-B4FB-0904701F0032}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93B64F12-EBDD-46CE-B4FB-0904701F0032}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93B64F12-EBDD-46CE-B4FB-0904701F0032}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93B64F12-EBDD-46CE-B4FB-0904701F0032}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -344,6 +351,7 @@ Global
 		{004DEF24-7EBB-499D-BD1C-E940AC4E122D} = {A7B4FF1E-3DF7-4F28-9333-D0961CDDF702}
 		{277D77B9-8915-41E3-8763-0B66328ADDDA} = {A7B4FF1E-3DF7-4F28-9333-D0961CDDF702}
 		{901DA3C3-3ABA-4859-89D3-63343ED2A0AC} = {9D6603BD-7EA2-4D11-A69C-0D9E01317FD6}
+		{93B64F12-EBDD-46CE-B4FB-0904701F0032} = {A7B4FF1E-3DF7-4F28-9333-D0961CDDF702}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {497D2ED4-A13E-4BCA-8D29-F30CA7D0EA4A}

--- a/build/Extensions.props
+++ b/build/Extensions.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)' == '' AND '$(TargetFrameworks)' == ''">netstandard2.0</TargetFramework>
     <VersionSuffix Condition="$(VersionSuffix) == ''"></VersionSuffix>
     <GenerateDocumentationFile Condition="$(GenerateDocumentationFile) == ''">true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/extensions/Worker.Extensions.Rpc/ci.yml
+++ b/extensions/Worker.Extensions.Rpc/ci.yml
@@ -1,0 +1,24 @@
+trigger:
+  branches:
+    include:
+    - main
+    - release/*
+    - feature/*
+  paths:
+    include:
+    - extensions/Worker.Extensions.Rpc/
+
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+    - feature/*
+  paths:
+    include:
+    - extensions/Worker.Extensions.Rpc/
+
+extends:
+  template: ../../build/pipelines/templates/extensions-ci.yml
+  parameters:
+    ExtensionDirectory: extensions/Worker.Extensions.Rpc

--- a/extensions/Worker.Extensions.Rpc/release_notes.md
+++ b/extensions/Worker.Extensions.Rpc/release_notes.md
@@ -1,0 +1,12 @@
+## What's Changed
+
+<!-- Please add your release notes in the following format:
+- My change description (#PR/#issue)
+-->
+
+### Microsoft.Azure.Functions.Worker.Extensions.Rpc 1.0.0-preview1
+
+- Add `IHttpClientBuilder.ConfigureForFunctionsHostGrpc` extension method. (#1616)
+    - Used along with `IServiceCollection.AddGrpcClient<TClient>()` to configure for Functions host communication.
+    - **NOTE**: when using Grpc.Net.ClientFactory <= 2.54.0-pre1 use `IServiceCollection.AddGrpcClient<TClient>(_ => { })`
+    - See [grpc/grpc-dotnet/issues/2158](https://github.com/grpc/grpc-dotnet/issues/2158)

--- a/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Grpc.Net.ClientFactory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+#if !NET6_0_OR_GREATER
+using System.Net.Http;
+using Grpc.Net.Client.Web;
+#endif
+
+namespace Microsoft.Azure.Functions.Worker;
+
+/// <summary>
+/// Extensions for registering RPC services to communication with the functions host.
+/// </summary>
+public static class GrpcHttpClientBuilderExtensions
+{
+    /// <summary>
+    /// Configures a <see cref="IHttpClientBuilder" /> to communicate with the functions host.
+    /// </summary>
+    /// <param name="builder">The original builder for call chaining.</param>
+    public static IHttpClientBuilder ConfigureForFunctionsHostGrpc(this IHttpClientBuilder builder)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        ValidateGrpcClient(builder);
+        builder.Services.AddOptions<GrpcClientFactoryOptions>(builder.Name)
+            .Configure<IConfiguration>((options, config) =>
+            {
+                // We could add IOptions with explicit host URI on it,
+                // but given it is a single value it is not worth the effort.
+                string uriString = $"http://{config["HOST"]}:{config["PORT"]}";
+                if (!Uri.TryCreate(uriString, UriKind.Absolute, out Uri? grpcUri))
+                {
+                    throw new InvalidOperationException($"The gRPC channel URI '{uriString}' could not be parsed.");
+                }
+
+                options.Address = grpcUri;
+            });
+
+#if !NET6_0_OR_GREATER
+        // For older TFMs, we need to use Grpc.Web instead of HTTP/2
+        builder.ConfigurePrimaryHttpMessageHandler(() => new GrpcWebHandler(new HttpClientHandler()));
+#endif
+
+        return builder;
+    }
+
+    // Validates the IHttpClientBuilder is from a IServiceCollection.AddGrpcClient call, and not some other IHttpClientBuilder.
+    // Code taken from https://github.com/grpc/grpc-dotnet/blob/ff1a07b90c498f259e6d9f4a50cdad7c89ecd3c0/src/Grpc.Net.ClientFactory/GrpcHttpClientBuilderExtensions.cs#L382.
+    private static void ValidateGrpcClient(IHttpClientBuilder builder, [CallerMemberName] string? caller = null)
+    {
+        // Validate the builder is for a gRPC client
+        foreach (var service in builder.Services)
+        {
+            if (service.ServiceType == typeof(IConfigureOptions<GrpcClientFactoryOptions>))
+            {
+                // Builder is from AddGrpcClient if options have been configured with the same name
+                var namedOptions = service.ImplementationInstance as ConfigureNamedOptions<GrpcClientFactoryOptions>;
+                if (namedOptions != null && string.Equals(builder.Name, namedOptions.Name, StringComparison.Ordinal))
+                {
+                    return;
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"{caller} must be used with a gRPC client.");
+    }
+}

--- a/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
@@ -24,6 +24,11 @@ public static class GrpcHttpClientBuilderExtensions
     /// Configures a <see cref="IHttpClientBuilder" /> to communicate with the functions host.
     /// </summary>
     /// <param name="builder">The original builder for call chaining.</param>
+    /// <remarks>
+    /// When using Grpc.Net.ClientFactory 2.54.0-pre1 or earlier, use a <see cref="GrpcClientFactoryOptions"/>
+    /// configure accepting overload of <c>AddGrpcClient</c>, such as
+    /// <see cref="GrpcClientServiceExtensions.AddGrpcClient{TClient}(IServiceCollection, Action{GrpcClientFactoryOptions})"/>.
+    /// </remarks>
     public static IHttpClientBuilder ConfigureForFunctionsHostGrpc(this IHttpClientBuilder builder)
     {
         if (builder is null)

--- a/extensions/Worker.Extensions.Rpc/src/Worker.Extensions.Rpc.csproj
+++ b/extensions/Worker.Extensions.Rpc/src/Worker.Extensions.Rpc.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Rpc</AssemblyName>
+    <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Rpc</RootNamespace>
+    <Description>Contains types to facilitate RPC communication between a worker extension and the functions host.</Description>
+    <VersionPrefix>1.0.0</VersionPrefix>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\build\Extensions.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Worker.Extensions.Abstractions\src\Worker.Extensions.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.Net.Client" Version="2.53.0" />
+    <PackageReference Include="Grpc.Net.Client.Web" Version="2.53.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.53.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/Worker.Extensions.Rpc.Tests/GrpcHttpClientBuilderExtensionsTests.cs
+++ b/test/Worker.Extensions.Rpc.Tests/GrpcHttpClientBuilderExtensionsTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Grpc.Core;
+using Grpc.Net.ClientFactory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+#if NETFRAMEWORK
+using Grpc.Net.Client.Web;
+#endif
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc.Tests
+{
+    public class GrpcHttpClientBuilderExtensionsTests
+    {
+        [Fact]
+        public void ConfigureForFunctionsHostGrpc_Configure_SetsUri()
+            => ConfigureForFunctionsHostGrpc(s => s.AddGrpcClient<CallInvokerExtractor>(_ => { }));
+
+        [Fact]
+        public void ConfigureForFunctionsHostGrpc_SetsUri()
+        {
+            // https://github.com/grpc/grpc-dotnet/issues/2158
+            // NOTE: when this test starts failing, it means the above issue was fixed.
+            // We should update this test and documentation to reflect as such.
+            InvalidOperationException exception = null;
+            try
+            {
+                ConfigureForFunctionsHostGrpc(s => s.AddGrpcClient<CallInvokerExtractor>());
+            }
+            catch (InvalidOperationException ex)
+            {
+                exception = ex;
+            }
+
+            Assert.NotNull(exception);
+        }
+
+        private void ConfigureForFunctionsHostGrpc(Func<IServiceCollection, IHttpClientBuilder> configure)
+        {
+            int port = 21584; // random enough.
+            ConfigurationBuilder configBuilder = new();
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string>()
+            {
+                ["HOST"] = "localhost",
+                ["PORT"] = port.ToString(),
+            });
+
+            ServiceCollection services = new();
+            services.AddSingleton((IConfiguration)configBuilder.Build());
+            IHttpClientBuilder builder = configure(services);
+            builder.ConfigureForFunctionsHostGrpc();
+
+            // Capture the configured primary message handler.
+            HttpMessageHandler handler = null;
+            builder.Services.Configure(builder.Name, delegate (HttpClientFactoryOptions options)
+            {
+                options.HttpMessageHandlerBuilderActions.Add(b =>
+                {
+                    handler = b.PrimaryHandler;
+                });
+            });
+
+            IServiceProvider sp = services.BuildServiceProvider();
+            CallInvokerExtractor extractor = sp.GetService<CallInvokerExtractor>();
+
+            Assert.NotNull(extractor);
+            Assert.NotNull(extractor.CallInvoker);
+
+            IOptionsMonitor<GrpcClientFactoryOptions> monitor = sp.GetService<IOptionsMonitor<GrpcClientFactoryOptions>>();
+            GrpcClientFactoryOptions options = monitor.Get(builder.Name);
+
+            Assert.Equal(new Uri($"http://localhost:{port}"), options.Address);
+
+#if NETFRAMEWORK
+            Assert.IsType<GrpcWebHandler>(handler);
+#else
+            Assert.Null(handler);
+#endif
+        }
+
+        private class CallInvokerExtractor
+        {
+            public CallInvokerExtractor(CallInvoker callInvoker)
+            {
+                CallInvoker = callInvoker;
+            }
+
+            public CallInvoker CallInvoker { get; }
+        }
+    }
+}

--- a/test/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
+++ b/test/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net48</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>true</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Rpc</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.Rpc\src\Worker.Extensions.Rpc.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1563

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR -- TODO
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md` -- TODO
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) -- TODO

<!-- Optional: delete if not applicable  -->
### Additional information

This PR introduces a new package `Microsoft.Azure.Functions.Worker.Extensions.Rpc`. The aim of this package is to expose a simple API for other worker extensions to configuring RPC clients for communication with the functions host. To start, this package introduces a single extension API that integrates with `Grpc.Net.ClientFactory` - configuring the gRPC client for communication with the functions host.

Example:

``` CSharp
IFunctionsWorkerApplicationBuilder builder;

builder.Services.AddGrpcClient<MyGrpcClient>(_ => { }) // See notes
    .ConfigureForFunctionsHostGrpc(); // extension method added by this PR.
``` 

#### Notes
Due to a bug in the `Grpc.Net.ClientFactory` library, customers should call `builder.Services.AddGrpcClient<MyGrpcClient>(_ => { }) ` and **NOT** `builder.Services.AddGrpcClient<MyGrpcClient>()` See https://github.com/grpc/grpc-dotnet/issues/2158

