### PR TITLE
do not wait for coordinator if not HttpTrigger

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 {
     internal class FunctionsHttpProxyingMiddleware : IFunctionsWorkerMiddleware
     {
+        private const string HttpTrigger = "httpTrigger";
+
         private readonly IHttpCoordinator _coordinator;
         private readonly ConcurrentDictionary<string, bool> _isHttpTrigger = new();
 
@@ -59,7 +61,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
         private static bool IsHttpTriggerFunction(FunctionContext funcContext)
         {
             return funcContext.FunctionDefinition.InputBindings
-                .Any(p => p.Value.Type.Equals("httpTrigger", System.StringComparison.OrdinalIgnoreCase));
+                .Any(p => p.Value.Type.Equals(HttpTrigger, System.StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,6 +15,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
     internal class FunctionsHttpProxyingMiddleware : IFunctionsWorkerMiddleware
     {
         private readonly IHttpCoordinator _coordinator;
+        private readonly ConcurrentDictionary<string, bool> _isHttpTrigger = new();
 
         public FunctionsHttpProxyingMiddleware(IHttpCoordinator httpCoordinator)
         {
@@ -21,9 +24,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 
         public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
         {
+            // Only use the coordinator for HttpTriggers
+            if (!_isHttpTrigger.GetOrAdd(context.FunctionId, static (_, c) => IsHttpTriggerFunction(c), context))
+            {
+                await next(context);
+                return;
+            }
+
             var invocationId = context.InvocationId;
 
-            // this call will block until the ASP.NET middleware pipleline has signaled that it's ready to run the function
+            // this call will block until the ASP.NET middleware pipeline has signaled that it's ready to run the function
             var httpContext = await _coordinator.SetFunctionContextAsync(invocationId, context);
 
             AddHttpContextToFunctionContext(context, httpContext);
@@ -44,6 +54,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
         private static void AddHttpContextToFunctionContext(FunctionContext funcContext, HttpContext httpContext)
         {
             funcContext.Items.Add(Constants.HttpContextKey, httpContext);
+        }
+
+        private static bool IsHttpTriggerFunction(FunctionContext funcContext)
+        {
+            return funcContext.FunctionDefinition.InputBindings
+                .Any(p => p.Value.Type.Equals("httpTrigger", System.StringComparison.OrdinalIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
resolves #1584 

When using the ASP.NET integration, we wait for the HttpRequest to come in that matches the Function being executed. But this should only happen for Http triggers. Otherwise, you get a deadlock waiting for an Http request that doesn't exist.