### PR TITLE
Update worker extensions to catch up with WebJobs ext versions

### DIFF
--- a/extensions/Worker.Extensions.EventHubs/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.EventHubs/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.EventHubs", "5.3.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.EventHubs", "5.4.0")]

--- a/extensions/Worker.Extensions.EventHubs/src/Worker.Extensions.EventHubs.csproj
+++ b/extensions/Worker.Extensions.EventHubs/src/Worker.Extensions.EventHubs.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Event Hubs extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.3.0</VersionPrefix>
+    <VersionPrefix>5.4.0</VersionPrefix>
 
   </PropertyGroup>
 

--- a/extensions/Worker.Extensions.ServiceBus/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.ServiceBus/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 ﻿using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.ServiceBus", "5.10.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.ServiceBus", "5.11.0")]

--- a/extensions/Worker.Extensions.ServiceBus/src/Worker.Extensions.ServiceBus.csproj
+++ b/extensions/Worker.Extensions.ServiceBus/src/Worker.Extensions.ServiceBus.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Service Bus extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.10.0</VersionPrefix>
+    <VersionPrefix>5.11.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.SignalRService/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.SignalRService/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 ﻿using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.SignalRService", "1.8.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.SignalRService", "1.10.0")]

--- a/extensions/Worker.Extensions.SignalRService/src/Worker.Extensions.SignalRService.csproj
+++ b/extensions/Worker.Extensions.SignalRService/src/Worker.Extensions.SignalRService.csproj
@@ -6,7 +6,7 @@
     <Description>Azure SignalR Service extensions for .NET isolated functions</Description>
     <Nullable>annotations</Nullable>
     <!--Version information-->
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.10.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Storage.Blobs/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.1.0-beta.1")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.1.2")]

--- a/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
@@ -6,8 +6,7 @@
     <Description>Azure Blob Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.1.0</VersionPrefix>
-    <VersionSuffix>-preview1</VersionSuffix>
+    <VersionPrefix>5.1.2</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Storage.Queues/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Storage.Queues/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 ﻿using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.1.2")]

--- a/extensions/Worker.Extensions.Storage.Queues/src/Worker.Extensions.Storage.Queues.csproj
+++ b/extensions/Worker.Extensions.Storage.Queues/src/Worker.Extensions.Storage.Queues.csproj
@@ -4,9 +4,9 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues</RootNamespace>
     <Description>Azure Queue Storage extensions for .NET isolated functions</Description>
-    
+
     <!--Version information-->
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.1.2</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
+++ b/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
@@ -6,8 +6,7 @@
     <Description>Azure Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.1.0</VersionPrefix>
-    <VersionSuffix>-preview1</VersionSuffix>
+    <VersionPrefix>5.1.2</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Tables/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Tables/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 ﻿using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Tables", "1.0.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.Tables", "1.1.0")]

--- a/extensions/Worker.Extensions.Tables/src/Worker.Extensions.Tables.csproj
+++ b/extensions/Worker.Extensions.Tables/src/Worker.Extensions.Tables.csproj
@@ -4,9 +4,9 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Tables</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Tables</RootNamespace>
     <Description>Azure Table Storage extensions for .NET isolated functions</Description>
-    
+
     <!--Version information-->
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
 
   </PropertyGroup>
 


### PR DESCRIPTION
I noticed for some extensions we are pretty behind on version releases so I'd like to get all of these releases out; it would be nice if we can avoid being 2-3 versions behind WebJobs in future.

#### Extensions that are behind

These extensions are several versions behind; for now I'm pushing them all to latest but question for the team:

1. Do we want to go back and release every version we missed?
A: We don't need to release versions we've missed, just catch up to latest. If folks request a specific version we can do that later

- Blobs: 5.1.2
  - Worker: 5.0.1 (3 versions behind)
- Queues: 5.1.2
  - Worker: 5.0.0 (4 versions behind)
- SignalR: 1.10.0
  - Worker: 1.7.0 (3 versions behind)
- ServiceBus: 5.11.0
  - Worker: 5.10.0 (skipped 5.8 and 5.9)

##### Only one version off so not too bad

- EventHubs: 5.4.0
  - Worker: 5.3.0
- Tables: 1.1.0
  - Worker: 1.0.0

#### Extensions that are up to date

- Sql: up to date
- Cosmos - up to date
- EventGrid - up to date
- RabbitMQ - up to date
- Kafka - up to date
- SendGrid - up to date