### PR TITLE
Fix EventHubTrigger sample by setting IsBatched=false

### DIFF
--- a/samples/WorkerBindingSamples/EventHubs/EventDataSamples.cs
+++ b/samples/WorkerBindingSamples/EventHubs/EventDataSamples.cs
@@ -53,7 +53,7 @@ namespace SampleApp
         /// </summary>
         [Function(nameof(EventDataWithStringPropertiesFunction))]
         public void EventDataWithStringPropertiesFunction(
-            [EventHubTrigger("queue", Connection = "EventHubConnection")]
+            [EventHubTrigger("queue", Connection = "EventHubConnection", IsBatched = false)]
             EventData @event, string contentType, long offset)
         {
             // The ContentType property and the contentType parameter are the same.

--- a/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
@@ -761,7 +761,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                 b => ValidateTrigger(b, cardinalityMany));
 
             AssertDictionary(extensions, new Dictionary<string, string>(){
-                { "Microsoft.Azure.WebJobs.Extensions.EventHubs", "5.3.0" }
+                { "Microsoft.Azure.WebJobs.Extensions.EventHubs", "5.4.0" }
             });
 
             void ValidateTrigger(ExpandoObject b, bool many)

--- a/test/SdkE2ETests/Contents/WorkerBindingSamplesOutput/functions.metadata
+++ b/test/SdkE2ETests/Contents/WorkerBindingSamplesOutput/functions.metadata
@@ -973,6 +973,72 @@
     ]
   },
   {
+    "name": "EventDataFunctions",
+    "scriptFile": "WorkerBindingSamples.dll",
+    "entryPoint": "SampleApp.EventDataSamples.EventDataFunctions",
+    "language": "dotnet-isolated",
+    "properties": {
+      "IsCodeless": false
+    },
+    "bindings": [
+      {
+        "name": "event",
+        "direction": "In",
+        "type": "eventHubTrigger",
+        "eventHubName": "queue",
+        "connection": "EventHubConnection",
+        "cardinality": "One",
+        "properties": {
+          "supportsDeferredBinding": "True"
+        }
+      }
+    ]
+  },
+  {
+    "name": "EventDataBatchFunction",
+    "scriptFile": "WorkerBindingSamples.dll",
+    "entryPoint": "SampleApp.EventDataSamples.EventDataBatchFunction",
+    "language": "dotnet-isolated",
+    "properties": {
+      "IsCodeless": false
+    },
+    "bindings": [
+      {
+        "name": "events",
+        "direction": "In",
+        "type": "eventHubTrigger",
+        "eventHubName": "queue",
+        "connection": "EventHubConnection",
+        "cardinality": "Many",
+        "properties": {
+          "supportsDeferredBinding": "True"
+        }
+      }
+    ]
+  },
+  {
+    "name": "EventDataWithStringPropertiesFunction",
+    "scriptFile": "WorkerBindingSamples.dll",
+    "entryPoint": "SampleApp.EventDataSamples.EventDataWithStringPropertiesFunction",
+    "language": "dotnet-isolated",
+    "properties": {
+      "IsCodeless": false
+    },
+    "bindings": [
+      {
+        "name": "event",
+        "direction": "In",
+        "type": "eventHubTrigger",
+        "eventHubName": "queue",
+        "connection": "EventHubConnection",
+        "cardinality": "One",
+        "properties": {
+          "supportsDeferredBinding": "True"
+        }
+      }
+    ]
+  },
+  {
     "name": "ServiceBusReceivedMessageFunction",
     "scriptFile": "WorkerBindingSamples.dll",
     "entryPoint": "SampleApp.ServiceBusReceivedMessageBindingSamples.ServiceBusReceivedMessageFunction",

--- a/test/SdkE2ETests/PublishTests.cs
+++ b/test/SdkE2ETests/PublishTests.cs
@@ -123,6 +123,9 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
                     new Extension("CosmosDB",
                         "Microsoft.Azure.WebJobs.Extensions.CosmosDB.CosmosDBWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.CosmosDB, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
                         @"./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll"),
+                    new Extension("EventHubs",
+                        "Microsoft.Azure.WebJobs.EventHubs.EventHubsWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.EventHubs, Version=5.4.0.0, Culture=neutral, PublicKeyToken=014045d636e89289",
+                        @"./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll"),
                     new Extension("Startup",
                         "Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.Startup, Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=551316b6919f366c",
                         @"./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll"),
@@ -145,7 +148,6 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
             // Verify functions.metadata
             TestUtility.ValidateFunctionsMetadata(functionsMetadataPath, "Microsoft.Azure.Functions.SdkE2ETests.Contents.WorkerBindingSamplesOutput.functions.metadata");
         }
-
 
         private class Extension
         {


### PR DESCRIPTION
The sample project does not build as the function `EventDataWithStringPropertiesFunction` is in error:

 `Failed to generate function metadata from WorkerBindingSamples.dll: Failed to generate metadata for function 'EventDataWithStringPropertiesFunction' (method 'System.Void SampleApp.EventDataSamples::EventDataWithStringPropertiesFunction(Azure.Messaging.EventHubs.EventData,System.String,System.Int64)'): Function is configured to process events in batches but parameter type is not iterable. Change parameter named 'event' to be an IEnumerable type or set 'IsBatched' to false on your 'EventHubTrigger' attribute. [/Users/likasem/source/functions/azure-functions-dotnet-worker/samples/WorkerBindingSamples/WorkerBindingSamples.csproj]`

Setting IsBatched = false on that sample to fix this issue.

Also fixing failed tests.