### PR TITLE
Remove Grpc.Net.ClientFactory for netfx, use Grpc.Core

### DIFF
--- a/extensions/Worker.Extensions.Rpc/README.md
+++ b/extensions/Worker.Extensions.Rpc/README.md
@@ -1,0 +1,51 @@
+# Worker.Extensions.Rpc
+
+This package provides helpers for RPC communication with the functions host.
+
+## Commonly used types
+
+- `FunctionsGrpcOptions`
+- `GrpcHttpClientBuilderExtensions.ConfigureForFunctionsHostGrpc` (>= net6.0 only)
+
+## Example usage
+
+Both examples below you have some gRPC client "`MyGrpcClient`" which has a `CallInvoker` accepting constructor.
+
+### netstandard
+
+When using netstandard2.0, creating a gRPC client that communicates to the host is done via `FunctionsGrpcOptions`.
+
+``` CSharp
+[assembly: WorkerExtensionStartup(typeof(WorkerRpcStartup))]
+public class MyWorkerExtensionStartup : WorkerExtensionStartup
+{
+    public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
+    {
+        applicationBuilder.Services.AddTransient<MyGrpcClient>(sp =>
+        {
+            IOptions<FunctionsGrpcOptions> options = sp.GetRequiredService<IOptions<FunctionsGrpcOptions>>();
+            return new MyGrpcClient(options.CallInvoker);
+        });
+    }
+}
+```
+
+### net6.0
+
+When using net6.0 or newer, creating a gRPC client can be done either the same way as the [netstandard](#netstandard) example, or it can be done via [Grpc.Net.ClientFactory](https://learn.microsoft.com/aspnet/core/grpc/clientfactory). Using the client factory lets you further customize your client.
+
+``` CSharp
+[assembly: WorkerExtensionStartup(typeof(WorkerRpcStartup))]
+public class MyWorkerExtensionStartup : WorkerExtensionStartup
+{
+    public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
+    {
+        applicationBuilder.Services
+            .AddGrpcClient<MyGrpcClient>(options =>
+            {
+                // configure options here as necessary.
+            })
+            .ConfigureForFunctionsHostGrpc();
+    }
+}
+```

--- a/extensions/Worker.Extensions.Rpc/README.md
+++ b/extensions/Worker.Extensions.Rpc/README.md
@@ -1,4 +1,4 @@
-# Worker.Extensions.Rpc
+# Microsoft.Azure.Functions.Worker.Extensions.Rpc
 
 This package provides helpers for RPC communication with the functions host.
 

--- a/extensions/Worker.Extensions.Rpc/release_notes.md
+++ b/extensions/Worker.Extensions.Rpc/release_notes.md
@@ -7,9 +7,9 @@
 ### Microsoft.Azure.Functions.Worker.Extensions.Rpc 1.0.0-preview1
 
 - Add `IHttpClientBuilder.ConfigureForFunctionsHostGrpc` extension method. (#1616)
-    - Used along with `IServiceCollection.AddGrpcClient<TClient>()` to configure for Functions host communication.
-    - **NOTE**: when using Grpc.Net.ClientFactory <= 2.54.0-pre1 use `IServiceCollection.AddGrpcClient<TClient>(_ => { })`
-    - See [grpc/grpc-dotnet/issues/2158](https://github.com/grpc/grpc-dotnet/issues/2158)
-    - Available in `>=net6.0` only.
+  - Used along with `IServiceCollection.AddGrpcClient<TClient>()` to configure for Functions host communication.
+  - **NOTE**: when using Grpc.Net.ClientFactory <= 2.54.0-pre1 use `IServiceCollection.AddGrpcClient<TClient>(_ => { })`
+  - See [grpc/grpc-dotnet/issues/2158](https://github.com/grpc/grpc-dotnet/issues/2158)
+  - Available in `>=net6.0` only.
 - Add `FunctionsGrpcOptions`, which can be used to get a built `CallInvoker` for gRPC communication with the functions host. (#1637)
   - Available in all TFMs.

--- a/extensions/Worker.Extensions.Rpc/release_notes.md
+++ b/extensions/Worker.Extensions.Rpc/release_notes.md
@@ -10,3 +10,6 @@
     - Used along with `IServiceCollection.AddGrpcClient<TClient>()` to configure for Functions host communication.
     - **NOTE**: when using Grpc.Net.ClientFactory <= 2.54.0-pre1 use `IServiceCollection.AddGrpcClient<TClient>(_ => { })`
     - See [grpc/grpc-dotnet/issues/2158](https://github.com/grpc/grpc-dotnet/issues/2158)
+    - Available in `>=net6.0` only.
+- Add `FunctionsGrpcOptions`, which can be used to get a built `CallInvoker` for gRPC communication with the functions host. (#1637)
+  - Available in all TFMs.

--- a/extensions/Worker.Extensions.Rpc/src/ConfigurationExtensions.cs
+++ b/extensions/Worker.Extensions.Rpc/src/ConfigurationExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc
+{
+    internal static class ConfigurationExtensions
+    {
+        /// <summary>
+        /// Gets the functions host gRPC address from <see cref="IConfiguration"/>.
+        /// </summary>
+        /// <param name="configuration">The configuration to get the host URI from.</param>
+        /// <returns>The URI representing the functions host.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// If <paramref name="configuration"/> does not contain the required values.
+        /// </exception>
+        public static Uri GetFunctionsHostGrpcUri(this IConfiguration configuration)
+        {
+            string uriString = $"http://{configuration["HOST"]}:{configuration["PORT"]}";
+            if (!Uri.TryCreate(uriString, UriKind.Absolute, out Uri? grpcUri))
+            {
+                throw new InvalidOperationException($"The gRPC channel URI '{uriString}' could not be parsed.");
+            }
+
+            return grpcUri;
+        }
+    }
+}

--- a/extensions/Worker.Extensions.Rpc/src/FunctionsGrpcOptions.cs
+++ b/extensions/Worker.Extensions.Rpc/src/FunctionsGrpcOptions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Grpc.Core;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc;
+
+/// <summary>
+/// Contains options for the functions gRPC invocation.
+/// </summary>
+public sealed class FunctionsGrpcOptions
+{
+    /// <summary>
+    /// Gets the <see cref="CallInvoker" /> which is configured to call the functions host.
+    /// </summary>
+    public CallInvoker CallInvoker { get; internal set; } = null!;
+}

--- a/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
@@ -1,82 +1,66 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+#if !NETSTANDARD
+
 using System;
 using System.Runtime.CompilerServices;
 using Grpc.Net.ClientFactory;
+using Microsoft.Azure.Functions.Worker.Extensions.Rpc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
-#if !NET6_0_OR_GREATER
-using System.Net.Http;
-using Grpc.Net.Client.Web;
-#endif
-
-namespace Microsoft.Azure.Functions.Worker;
-
-/// <summary>
-/// Extensions for registering RPC services to communication with the functions host.
-/// </summary>
-public static class GrpcHttpClientBuilderExtensions
+namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
-    /// Configures a <see cref="IHttpClientBuilder" /> to communicate with the functions host.
+    /// Extensions for registering RPC services to communication with the functions host.
     /// </summary>
-    /// <param name="builder">The original builder for call chaining.</param>
-    /// <remarks>
-    /// When using Grpc.Net.ClientFactory 2.54.0-pre1 or earlier, use a <see cref="GrpcClientFactoryOptions"/>
-    /// configure accepting overload of <c>AddGrpcClient</c>, such as
-    /// <see cref="GrpcClientServiceExtensions.AddGrpcClient{TClient}(IServiceCollection, Action{GrpcClientFactoryOptions})"/>.
-    /// </remarks>
-    public static IHttpClientBuilder ConfigureForFunctionsHostGrpc(this IHttpClientBuilder builder)
+    public static class GrpcHttpClientBuilderExtensions
     {
-        if (builder is null)
+        /// <summary>
+        /// Configures a <see cref="IHttpClientBuilder" /> to communicate with the functions host.
+        /// </summary>
+        /// <param name="builder">The original builder for call chaining.</param>
+        /// <remarks>
+        /// When using Grpc.Net.ClientFactory 2.54.0-pre1 or earlier, use a <see cref="GrpcClientFactoryOptions"/>
+        /// configure accepting overload of <c>AddGrpcClient</c>, such as
+        /// <see cref="GrpcClientServiceExtensions.AddGrpcClient{TClient}(IServiceCollection, Action{GrpcClientFactoryOptions})"/>.
+        /// </remarks>
+        public static IHttpClientBuilder ConfigureForFunctionsHostGrpc(this IHttpClientBuilder builder)
         {
-            throw new ArgumentNullException(nameof(builder));
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            ValidateGrpcClient(builder);
+            builder.Services.AddOptions<GrpcClientFactoryOptions>(builder.Name)
+                .Configure<IConfiguration>((options, config) => options.Address = config.GetFunctionsHostGrpcUri());
+
+            return builder;
         }
 
-        ValidateGrpcClient(builder);
-        builder.Services.AddOptions<GrpcClientFactoryOptions>(builder.Name)
-            .Configure<IConfiguration>((options, config) =>
-            {
-                // We could add IOptions with explicit host URI on it,
-                // but given it is a single value it is not worth the effort.
-                string uriString = $"http://{config["HOST"]}:{config["PORT"]}";
-                if (!Uri.TryCreate(uriString, UriKind.Absolute, out Uri? grpcUri))
-                {
-                    throw new InvalidOperationException($"The gRPC channel URI '{uriString}' could not be parsed.");
-                }
-
-                options.Address = grpcUri;
-            });
-
-#if !NET6_0_OR_GREATER
-        // For older TFMs, we need to use Grpc.Web instead of HTTP/2
-        builder.ConfigurePrimaryHttpMessageHandler(() => new GrpcWebHandler(new HttpClientHandler()));
-#endif
-
-        return builder;
-    }
-
-    // Validates the IHttpClientBuilder is from a IServiceCollection.AddGrpcClient call, and not some other IHttpClientBuilder.
-    // Code taken from https://github.com/grpc/grpc-dotnet/blob/ff1a07b90c498f259e6d9f4a50cdad7c89ecd3c0/src/Grpc.Net.ClientFactory/GrpcHttpClientBuilderExtensions.cs#L382.
-    private static void ValidateGrpcClient(IHttpClientBuilder builder, [CallerMemberName] string? caller = null)
-    {
-        // Validate the builder is for a gRPC client
-        foreach (var service in builder.Services)
+        // Validates the IHttpClientBuilder is from a IServiceCollection.AddGrpcClient call, and not some other IHttpClientBuilder.
+        // Code taken from https://github.com/grpc/grpc-dotnet/blob/ff1a07b90c498f259e6d9f4a50cdad7c89ecd3c0/src/Grpc.Net.ClientFactory/GrpcHttpClientBuilderExtensions.cs#L382.
+        private static void ValidateGrpcClient(IHttpClientBuilder builder, [CallerMemberName] string? caller = null)
         {
-            if (service.ServiceType == typeof(IConfigureOptions<GrpcClientFactoryOptions>))
+            // Validate the builder is for a gRPC client
+            foreach (var service in builder.Services)
             {
-                // Builder is from AddGrpcClient if options have been configured with the same name
-                var namedOptions = service.ImplementationInstance as ConfigureNamedOptions<GrpcClientFactoryOptions>;
-                if (namedOptions != null && string.Equals(builder.Name, namedOptions.Name, StringComparison.Ordinal))
+                if (service.ServiceType == typeof(IConfigureOptions<GrpcClientFactoryOptions>))
                 {
-                    return;
+                    // Builder is from AddGrpcClient if options have been configured with the same name
+                    if (service.ImplementationInstance is ConfigureNamedOptions<GrpcClientFactoryOptions> namedOptions
+                        && string.Equals(builder.Name, namedOptions.Name, StringComparison.Ordinal))
+                    {
+                        return;
+                    }
                 }
             }
-        }
 
-        throw new InvalidOperationException($"{caller} must be used with a gRPC client.");
+            throw new InvalidOperationException($"{caller} must be used with a gRPC client.");
+        }
     }
 }
+#endif

--- a/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
-    /// Extensions for registering RPC services to communication with the functions host.
+    /// Extensions for registering RPC services to communicate with the functions host.
     /// </summary>
     public static class GrpcHttpClientBuilderExtensions
     {

--- a/extensions/Worker.Extensions.Rpc/src/Worker.Extensions.Rpc.csproj
+++ b/extensions/Worker.Extensions.Rpc/src/Worker.Extensions.Rpc.csproj
@@ -7,7 +7,7 @@
     <Description>Contains types to facilitate RPC communication between a worker extension and the functions host.</Description>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix>-preview1</VersionSuffix>
-    <PackageReadmeFile>../README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <Import Project="..\..\..\build\Extensions.props" />
@@ -24,6 +24,10 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Grpc.Net.Client" Version="2.53.0" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.53.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Worker.Extensions.Rpc/src/Worker.Extensions.Rpc.csproj
+++ b/extensions/Worker.Extensions.Rpc/src/Worker.Extensions.Rpc.csproj
@@ -7,17 +7,22 @@
     <Description>Contains types to facilitate RPC communication between a worker extension and the functions host.</Description>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix>-preview1</VersionSuffix>
+    <PackageReadmeFile>../README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <Import Project="..\..\..\build\Extensions.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\Worker.Extensions.Abstractions\src\Worker.Extensions.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\DotNetWorker.Core\DotNetWorker.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Grpc.Core" Version="2.46.6" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Grpc.Net.Client" Version="2.53.0" />
-    <PackageReference Include="Grpc.Net.Client.Web" Version="2.53.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.53.0" />
   </ItemGroup>
 

--- a/extensions/Worker.Extensions.Rpc/src/WorkerRpcStartup.cs
+++ b/extensions/Worker.Extensions.Rpc/src/WorkerRpcStartup.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Grpc.Core;
+using Microsoft.Azure.Functions.Worker.Core;
+using Microsoft.Azure.Functions.Worker.Extensions.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+#if NETSTANDARD
+using Microsoft.Extensions.Configuration;
+#endif
+
+[assembly: WorkerExtensionStartup(typeof(WorkerRpcStartup))]
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc
+{
+
+    /// <summary>
+    /// Startup code for extensions RPC.
+    /// </summary>
+    public sealed class WorkerRpcStartup : WorkerExtensionStartup
+    {
+        /// <inheritdoc/>
+        public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
+        {
+            if (applicationBuilder is null)
+            {
+                throw new ArgumentNullException(nameof(applicationBuilder));
+            }
+
+            OptionsBuilder<FunctionsGrpcOptions> builder = applicationBuilder.Services
+                .AddOptions<FunctionsGrpcOptions>();
+
+            ConfigureCallInvoker(builder);
+            builder.Validate(options => options.CallInvoker is not null, "gRPC CallInvoker must not be null.");
+        }
+
+        private void ConfigureCallInvoker(OptionsBuilder<FunctionsGrpcOptions> builder)
+        {
+#if NETSTANDARD
+            builder.Configure<IConfiguration>((options, config) =>
+            {
+                Uri address = config.GetFunctionsHostGrpcUri();
+                Channel c = new Channel(address.Host, address.Port, ChannelCredentials.Insecure);
+                options.CallInvoker = c.CreateCallInvoker();
+            });
+
+#else
+            // Instead of building the GrpcChannel/CallInvoker ourselves, we use Grpc.Net.ClientFactory to
+            // construct and configure the CallInvoker for us, then we attach that to our options.
+            builder.Services.AddGrpcClient<CallInvokerExtractor>(_ => { })
+                .ConfigureForFunctionsHostGrpc();
+
+            builder.Configure<CallInvokerExtractor>((options, extractor) =>
+            {
+                options.CallInvoker = extractor.CallInvoker;
+            });
+#endif
+        }
+
+#if !NETSTANDARD
+        // Used as a roundabout way of getting the configured CallInvoker from Grpc.Net.ClientFactory.
+        private class CallInvokerExtractor
+        {
+            public CallInvokerExtractor(CallInvoker callInvoker)
+            {
+                CallInvoker = callInvoker ?? throw new ArgumentNullException(nameof(callInvoker));
+            }
+
+            public CallInvoker CallInvoker { get; }
+        }
+#endif
+    }
+}

--- a/test/Worker.Extensions.Rpc.Tests/GrpcHttpClientBuilderExtensionsTests.cs
+++ b/test/Worker.Extensions.Rpc.Tests/GrpcHttpClientBuilderExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+#if NET6_0_OR_GREATER
+
 using Grpc.Core;
 using Grpc.Net.ClientFactory;
 using Microsoft.Extensions.Configuration;
@@ -8,10 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Options;
 using Xunit;
-
-#if NETFRAMEWORK
-using Grpc.Net.Client.Web;
-#endif
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc.Tests
 {
@@ -75,12 +73,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc.Tests
             GrpcClientFactoryOptions options = monitor.Get(builder.Name);
 
             Assert.Equal(new Uri($"http://localhost:{port}"), options.Address);
-
-#if NETFRAMEWORK
-            Assert.IsType<GrpcWebHandler>(handler);
-#else
             Assert.Null(handler);
-#endif
         }
 
         private class CallInvokerExtractor
@@ -94,3 +87,5 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc.Tests
         }
     }
 }
+
+#endif

--- a/test/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
+++ b/test/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
@@ -12,12 +12,9 @@
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Worker.Extensions.Rpc.Tests/WorkerRpcStartupTests.cs
+++ b/test/Worker.Extensions.Rpc.Tests/WorkerRpcStartupTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc.Tests
+{
+    public class WorkerRpcStartupTests
+    {
+        [Fact]
+        public void Configure_AddsFunctionsGrpcOptions()
+        {
+            int port = 21584; // random enough.
+            ConfigurationBuilder configBuilder = new();
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string>()
+            {
+                ["HOST"] = "localhost",
+                ["PORT"] = port.ToString(),
+            });
+
+            ServiceCollection services = new();
+            services.AddSingleton((IConfiguration)configBuilder.Build());
+            IFunctionsWorkerApplicationBuilder builder = Mock.Of<IFunctionsWorkerApplicationBuilder>(
+                m => m.Services == services);
+
+            WorkerRpcStartup startup = new();
+            startup.Configure(builder);
+
+            IServiceProvider sp = services.BuildServiceProvider();
+            IOptions<FunctionsGrpcOptions> options = sp.GetService<IOptions<FunctionsGrpcOptions>>();
+            Assert.NotNull(options);
+            Assert.NotNull(options.Value);
+            Assert.NotNull(options.Value.CallInvoker);
+        }
+    }
+}


### PR DESCRIPTION

Follow up for #1563. The original changes attempted to use `Grpc.Net.Client.Web` for the netstandard (netfx) scenarios. Unfortunately, this approach has limited support for some gRPC scenarios. This PR abandons that approach and instead uses `Grpc.Core` when `Grpc.Net.ClientFactory` is not fully supported. The downside of this is the experience with netstandard/netfx projects is now not as robust as net6.0. As much as I would like to converge the experiences, it is out of the scope of our project to provide a full gRPC client builder in the netstandard scenarios.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

