### PR TITLE
Fixing tests to reflect changes from #1629

### DIFF
--- a/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/FunctionMetadataGeneratorTests.cs
@@ -169,8 +169,8 @@ namespace Microsoft.Azure.Functions.SdkTests
 
             AssertDictionary(extensions, new Dictionary<string, string>
             {
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0" },
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.1.0-beta.1" },
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.1.2" },
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.1.2" },
             });
 
             void ValidateQueueTrigger(ExpandoObject b)
@@ -292,8 +292,8 @@ namespace Microsoft.Azure.Functions.SdkTests
 
             AssertDictionary(extensions, new Dictionary<string, string>
             {
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0" },
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.1.0-beta.1" },
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.1.2" },
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "5.1.2" },
             });
 
             void ValidateQueueTrigger(ExpandoObject b)
@@ -358,7 +358,7 @@ namespace Microsoft.Azure.Functions.SdkTests
 
             AssertDictionary(extensions, new Dictionary<string, string>
             {
-                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.0.0" }
+                { "Microsoft.Azure.WebJobs.Extensions.Storage.Queues", "5.1.2" }
             });
 
             void ValidateHttpTrigger(ExpandoObject b)
@@ -494,7 +494,7 @@ namespace Microsoft.Azure.Functions.SdkTests
                 b => ValidateTrigger(b, cardinalityMany));
 
             AssertDictionary(extensions, new Dictionary<string, string>(){
-                { "Microsoft.Azure.WebJobs.Extensions.EventHubs", "5.3.0" }
+                { "Microsoft.Azure.WebJobs.Extensions.EventHubs", "5.4.0" }
             });
 
             void ValidateTrigger(ExpandoObject b, bool many)

--- a/test/SdkE2ETests/PublishTests.cs
+++ b/test/SdkE2ETests/PublishTests.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
             // Make sure files are in /.azurefunctions
             string azureFunctionsDir = Path.Combine(outputDir, ".azurefunctions");
             Assert.True(Directory.Exists(azureFunctionsDir));
-            var files = Directory.EnumerateFiles(azureFunctionsDir);
 
             // Verify files are present
             string metadataLoaderPath = Path.Combine(azureFunctionsDir, "Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll");
@@ -65,10 +64,10 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
                         "Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.Startup, Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=551316b6919f366c",
                         @"./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll"),
                     new Extension("AzureStorageBlobs",
-                        "Microsoft.Azure.WebJobs.Extensions.Storage.AzureStorageBlobsWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.Storage.Blobs, Version=5.1.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8",
+                        "Microsoft.Azure.WebJobs.Extensions.Storage.AzureStorageBlobsWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.Storage.Blobs, Version=5.1.2.0, Culture=neutral, PublicKeyToken=92742159e12e44c8",
                         @"./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll"),
                     new Extension("AzureStorageQueues",
-                        "Microsoft.Azure.WebJobs.Extensions.Storage.AzureStorageQueuesWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.Storage.Queues, Version=5.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8",
+                        "Microsoft.Azure.WebJobs.Extensions.Storage.AzureStorageQueuesWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.Storage.Queues, Version=5.1.2.0, Culture=neutral, PublicKeyToken=92742159e12e44c8",
                         @"./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll")
                 }
             });

--- a/test/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
+++ b/test/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net48</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <ImplicitUsings>true</ImplicitUsings>


### PR DESCRIPTION
Fixing tests to reflect changes from #1629. Currently tests are f[ailing with main branch](https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=136616&view=results).