### PR TITLE
Add binding attribute to converter context

### DIFF
--- a/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Functions.Worker
             };
         }
 
-        internal virtual async ValueTask<ConversionResult> ConvertFromBindingDataAsync(ConverterContext context, ModelBindingData modelBindingData)
+        private async ValueTask<ConversionResult> ConvertFromBindingDataAsync(ConverterContext context, ModelBindingData modelBindingData)
         {
             if (!IsBlobExtension(modelBindingData))
             {
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Functions.Worker
             return ConversionResult.Unhandled();
         }
 
-        internal virtual async ValueTask<ConversionResult> ConvertFromCollectionBindingDataAsync(ConverterContext context, CollectionModelBindingData collectionModelBindingData)
+        private async ValueTask<ConversionResult> ConvertFromCollectionBindingDataAsync(ConverterContext context, CollectionModelBindingData collectionModelBindingData)
         {
             Type elementType = context.TargetType.IsArray
                 ? context.TargetType.GetElementType()
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Functions.Worker
             }
         }
 
-        internal bool IsBlobExtension(ModelBindingData bindingData)
+        private bool IsBlobExtension(ModelBindingData bindingData)
         {
             if (bindingData?.Source is not Constants.BlobExtensionName)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Functions.Worker
             return true;
         }
 
-        internal Dictionary<string, string> GetBindingDataContent(ModelBindingData bindingData)
+        private Dictionary<string, string> GetBindingDataContent(ModelBindingData bindingData)
         {
             return bindingData?.ContentType switch
             {
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Functions.Worker
             };
         }
 
-        internal virtual async Task<object?> ConvertModelBindingDataAsync(IDictionary<string, string> content, Type targetType, ModelBindingData bindingData)
+        private async Task<object?> ConvertModelBindingDataAsync(IDictionary<string, string> content, Type targetType, ModelBindingData bindingData)
         {
             content.TryGetValue(Constants.Connection, out var connectionName);
             content.TryGetValue(Constants.ContainerName, out var containerName);
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Functions.Worker
             return await ToTargetTypeAsync(targetType, connectionName, containerName, blobName);
         }
 
-        internal virtual async Task<object?> ToTargetTypeAsync(Type targetType, string connectionName, string containerName, string blobName) => targetType switch
+        private async Task<object?> ToTargetTypeAsync(Type targetType, string connectionName, string containerName, string blobName) => targetType switch
         {
             Type _ when targetType == typeof(string) => await GetBlobStringAsync(connectionName, containerName, blobName),
             Type _ when targetType == typeof(Stream) => await GetBlobStreamAsync(connectionName, containerName, blobName),
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Functions.Worker
             _ => await DeserializeToTargetObjectAsync(targetType, connectionName, containerName, blobName)
         };
 
-        internal async Task<object?> DeserializeToTargetObjectAsync(Type targetType, string connectionName, string containerName, string blobName)
+        private async Task<object?> DeserializeToTargetObjectAsync(Type targetType, string connectionName, string containerName, string blobName)
         {
             var content = await GetBlobStreamAsync(connectionName, containerName, blobName);
             return _workerOptions?.Value?.Serializer?.Deserialize(content, targetType, CancellationToken.None);
@@ -198,14 +198,14 @@ namespace Microsoft.Azure.Functions.Worker
             return stream.ToArray();
         }
 
-        internal virtual async Task<Stream> GetBlobStreamAsync(string connectionName, string containerName, string blobName)
+        private async Task<Stream> GetBlobStreamAsync(string connectionName, string containerName, string blobName)
         {
             var client = CreateBlobClient<BlobClient>(connectionName, containerName, blobName);
             var download = await client.DownloadStreamingAsync();
             return download.Value.Content;
         }
 
-        internal virtual BlobContainerClient CreateBlobContainerClient(string connectionName, string containerName)
+        private BlobContainerClient CreateBlobContainerClient(string connectionName, string containerName)
         {
             var blobStorageOptions = _blobOptions.Get(connectionName);
             BlobServiceClient blobServiceClient = blobStorageOptions.CreateClient();
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Functions.Worker
             return container;
         }
 
-        internal virtual T CreateBlobClient<T>(string connectionName, string containerName, string blobName) where T : BlobBaseClient
+        private T CreateBlobClient<T>(string connectionName, string containerName, string blobName) where T : BlobBaseClient
         {
             if (string.IsNullOrEmpty(blobName))
             {

--- a/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Functions.Worker
             };
         }
 
-        private async ValueTask<ConversionResult> ConvertFromBindingDataAsync(ConverterContext context, ModelBindingData modelBindingData)
+        internal virtual async ValueTask<ConversionResult> ConvertFromBindingDataAsync(ConverterContext context, ModelBindingData modelBindingData)
         {
             if (!IsBlobExtension(modelBindingData))
             {
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Functions.Worker
             return ConversionResult.Unhandled();
         }
 
-        private async ValueTask<ConversionResult> ConvertFromCollectionBindingDataAsync(ConverterContext context, CollectionModelBindingData collectionModelBindingData)
+        internal virtual async ValueTask<ConversionResult> ConvertFromCollectionBindingDataAsync(ConverterContext context, CollectionModelBindingData collectionModelBindingData)
         {
             Type elementType = context.TargetType.IsArray
                 ? context.TargetType.GetElementType()
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Functions.Worker
             }
         }
 
-        private bool IsBlobExtension(ModelBindingData bindingData)
+        internal bool IsBlobExtension(ModelBindingData bindingData)
         {
             if (bindingData?.Source is not Constants.BlobExtensionName)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Functions.Worker
             return true;
         }
 
-        private Dictionary<string, string> GetBindingDataContent(ModelBindingData bindingData)
+        internal Dictionary<string, string> GetBindingDataContent(ModelBindingData bindingData)
         {
             return bindingData?.ContentType switch
             {
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Functions.Worker
             };
         }
 
-        private async Task<object?> ConvertModelBindingDataAsync(IDictionary<string, string> content, Type targetType, ModelBindingData bindingData)
+        internal virtual async Task<object?> ConvertModelBindingDataAsync(IDictionary<string, string> content, Type targetType, ModelBindingData bindingData)
         {
             content.TryGetValue(Constants.Connection, out var connectionName);
             content.TryGetValue(Constants.ContainerName, out var containerName);
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Functions.Worker
             return await ToTargetTypeAsync(targetType, connectionName, containerName, blobName);
         }
 
-        private async Task<object?> ToTargetTypeAsync(Type targetType, string connectionName, string containerName, string blobName) => targetType switch
+        internal virtual async Task<object?> ToTargetTypeAsync(Type targetType, string connectionName, string containerName, string blobName) => targetType switch
         {
             Type _ when targetType == typeof(string) => await GetBlobStringAsync(connectionName, containerName, blobName),
             Type _ when targetType == typeof(Stream) => await GetBlobStreamAsync(connectionName, containerName, blobName),
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Functions.Worker
             _ => await DeserializeToTargetObjectAsync(targetType, connectionName, containerName, blobName)
         };
 
-        private async Task<object?> DeserializeToTargetObjectAsync(Type targetType, string connectionName, string containerName, string blobName)
+        internal async Task<object?> DeserializeToTargetObjectAsync(Type targetType, string connectionName, string containerName, string blobName)
         {
             var content = await GetBlobStreamAsync(connectionName, containerName, blobName);
             return _workerOptions?.Value?.Serializer?.Deserialize(content, targetType, CancellationToken.None);
@@ -198,14 +198,14 @@ namespace Microsoft.Azure.Functions.Worker
             return stream.ToArray();
         }
 
-        private async Task<Stream> GetBlobStreamAsync(string connectionName, string containerName, string blobName)
+        internal virtual async Task<Stream> GetBlobStreamAsync(string connectionName, string containerName, string blobName)
         {
             var client = CreateBlobClient<BlobClient>(connectionName, containerName, blobName);
             var download = await client.DownloadStreamingAsync();
             return download.Value.Content;
         }
 
-        private BlobContainerClient CreateBlobContainerClient(string connectionName, string containerName)
+        internal virtual BlobContainerClient CreateBlobContainerClient(string connectionName, string containerName)
         {
             var blobStorageOptions = _blobOptions.Get(connectionName);
             BlobServiceClient blobServiceClient = blobStorageOptions.CreateClient();
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Functions.Worker
             return container;
         }
 
-        private T CreateBlobClient<T>(string connectionName, string containerName, string blobName) where T : BlobBaseClient
+        internal virtual T CreateBlobClient<T>(string connectionName, string containerName, string blobName) where T : BlobBaseClient
         {
             if (string.IsNullOrEmpty(blobName))
             {

--- a/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                     // Return the cached value if BindFunctionInputAsync is called a second time during invocation.
                     return _inputBindingResult!;
                 }
-                
+
                 IFunctionBindingsFeature functionBindings = context.GetBindings();
                 var inputBindingCache = context.InstanceServices.GetService<IBindingCache<ConversionResult>>();
                 var inputConversionFeature = context.Features.Get<IInputConversionFeature>();
@@ -72,25 +72,12 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                     {
                         var properties = new Dictionary<string, object>();
 
-                        // Pass info about specific input converter type defined for this parameter, if present.
-                        if (param.Properties.TryGetValue(PropertyBagKeys.ConverterType, out var converterTypeAssemblyFullName))
-                        {
-                            properties.Add(PropertyBagKeys.ConverterType, converterTypeAssemblyFullName);
-                        }
+                        AddFunctionParameterPropertyIfPresent(properties, param, PropertyBagKeys.ConverterType);
+                        AddFunctionParameterPropertyIfPresent(properties, param, PropertyBagKeys.AllowConverterFallback);
+                        AddFunctionParameterPropertyIfPresent(properties, param, PropertyBagKeys.BindingAttributeSupportedConverters);
+                        AddFunctionParameterPropertyIfPresent(properties, param, PropertyBagKeys.BindingAttribute);
 
-                        // Pass info about the flag to allow fallback to default converters defined for this parameter, if present.
-                        if (param.Properties.TryGetValue(PropertyBagKeys.AllowConverterFallback, out var flag))
-                        {
-                            properties.Add(PropertyBagKeys.AllowConverterFallback, flag);
-                        }
-
-                        // Pass info about input converter types defined for this parameter, if present.
-                        if (param.Properties.TryGetValue(PropertyBagKeys.BindingAttributeSupportedConverters, out var converters))
-                        {
-                            properties.Add(PropertyBagKeys.BindingAttributeSupportedConverters, converters);
-                        }
-
-                        var converterContext = _converterContextFactory.Create(param.Type, source, context, properties.Count() != 0 
+                        var converterContext = _converterContextFactory.Create(param.Type, source, context, properties.Count() != 0
                                              ? properties.ToImmutableDictionary()
                                              : ImmutableDictionary<string, object>.Empty);
 
@@ -126,6 +113,14 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
             finally
             {
                 _semaphoreSlim.Release();
+            }
+        }
+
+        private void AddFunctionParameterPropertyIfPresent(IDictionary<string, object> properties, FunctionParameter param, string key)
+        {
+            if (param.Properties.TryGetValue(key, out object val))
+            {
+                properties.Add(key, val);
             }
         }
 

--- a/src/DotNetWorker.Core/Converters/Converter/ConverterContextExtensions.cs
+++ b/src/DotNetWorker.Core/Converters/Converter/ConverterContextExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.Azure.Functions.Worker.Converters
 {
     /// <summary>
@@ -14,16 +16,7 @@ namespace Microsoft.Azure.Functions.Worker.Converters
         /// <param name="context">The converter context.</param>
         /// <param name="bindingAttribute">When this method returns, contains the binding attribute if found; otherwise, <c>null</c>.</param>
         /// <returns><c>true</c> if the binding attribute is found in the converter context; otherwise, <c>false</c>.</returns>
-        public static bool TryGetBindingAttribute(this ConverterContext context, out object? bindingAttribute)
-        {
-            if (context.Properties.TryGetValue(PropertyBagKeys.BindingAttribute, out object? value))
-            {
-                bindingAttribute = value;
-                return true;
-            }
-
-            bindingAttribute = null;
-            return false;
-        }
+        public static bool TryGetBindingAttribute<T>(this ConverterContext context, out object? bindingAttribute) where T : Attribute
+            => context.Properties.TryGetValue(PropertyBagKeys.BindingAttribute, out bindingAttribute);
     }
 }

--- a/src/DotNetWorker.Core/Converters/Converter/ConverterContextExtensions.cs
+++ b/src/DotNetWorker.Core/Converters/Converter/ConverterContextExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker.Converters
+{
+    /// <summary>
+    /// Provides extension methods to work with an <see cref="ConverterContext"/> instance.
+    /// </summary>
+    public static class ConverterContextExtensions
+    {
+        /// <summary>
+        /// Tries to retrieve the binding attribute from the <see cref="ConverterContext"/>.
+        /// </summary>
+        /// <param name="context">The converter context.</param>
+        /// <param name="bindingAttribute">When this method returns, contains the binding attribute if found; otherwise, <c>null</c>.</param>
+        /// <returns><c>true</c> if the binding attribute is found in the converter context; otherwise, <c>false</c>.</returns>
+        public static bool TryGetBindingAttribute(this ConverterContext context, out object? bindingAttribute)
+        {
+            if (context.Properties.TryGetValue(PropertyBagKeys.BindingAttribute, out object? value))
+            {
+                bindingAttribute = value;
+                return true;
+            }
+
+            bindingAttribute = null;
+            return false;
+        }
+    }
+}

--- a/src/DotNetWorker.Core/Converters/Converter/PropertyBagKeys.cs
+++ b/src/DotNetWorker.Core/Converters/Converter/PropertyBagKeys.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Functions.Worker.Converters
     internal static class PropertyBagKeys
     {
         internal const string ConverterType = "converterType";
+        internal const string BindingAttribute = "bindingAttribute";
         internal const string AllowConverterFallback = "allowConverterFallback";
         internal const string BindingAttributeSupportedConverters = "bindingAttributeSupportedConverters";
     }

--- a/src/DotNetWorker.Grpc/Definition/GrpcFunctionDefinition.cs
+++ b/src/DotNetWorker.Grpc/Definition/GrpcFunctionDefinition.cs
@@ -111,10 +111,11 @@ namespace Microsoft.Azure.Functions.Worker.Definition
             var output = new Dictionary<string, object>();
             bool isInputConverterAttributeAdvertised = false;
 
+            output.Add(PropertyBagKeys.BindingAttribute, bindingAttribute);
+
             // ConverterTypesDictionary will be "object" part of the return value - ImmutableDictionary<string, object>
             // The dictionary has key of type IInputConverter and value as List of Types supported by the converter.
             var converterTypesDictionary = new Dictionary<Type, List<Type>>();
-
 
             Type type = bindingAttribute.GetType();
             var attributes = type.GetCustomAttributes<InputConverterAttribute>();


### PR DESCRIPTION
Adding the binding attribute for a given parameter to the converter context, this enables converters to have all the information they need about the attribute a parameter is using without having to make a roundtrip to WebJobs.