### PR TITLE
Update worker versions and release notes

### DIFF
--- a/extensions/Worker.Extensions.Abstractions/release_notes.md
+++ b/extensions/Worker.Extensions.Abstractions/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Abstractions <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Abstractions 1.3.0
 
-- <event>
+- Add SupportsDeferredBinding attribute

--- a/extensions/Worker.Extensions.Abstractions/src/Worker.Extensions.Abstractions.csproj
+++ b/extensions/Worker.Extensions.Abstractions/src/Worker.Extensions.Abstractions.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Abstractions</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Abstractions</RootNamespace>
     <Description>Abstractions for Azure Functions .NET Worker</Description>
-    <MinorProductVersion>2</MinorProductVersion>
+    <MinorProductVersion>3</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
   </PropertyGroup>
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,7 @@
 ### Microsoft.Azure.Functions.Worker (metapackage) <version>
 
 - Update protobuf to v1.9.0-protofile, which includes gRPC messages for retry-options in worker-indexing scenarios. (#1545)
+- Add support for deferred binding (#1676)
 
 ### Microsoft.Azure.Functions.Worker.Core <version>
 
@@ -16,8 +17,3 @@
 ### Microsoft.Azure.Functions.Worker.Grpc <version>
 
 - Add handling for retry options in worker-indexing grpc communication path (#1548)
-
-### Microsoft.Azure.Functions.Worker.Sdk
-
-- Added retries on `IOException` when writing `function.metadata` file as part of `GenerateFunctionMetadata` msbuild task. This is to allow builds to continue (with warnings) when another process has the file momentarily locked. If the file continues to be locked the task (and build) will fail after 10 retries with a 1 second delay each. (#1532)
-- Implementation for deferred binding feature (#1676)

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -7,6 +7,8 @@
 ### Microsoft.Azure.Functions.Worker.Sdk <version> (meta package)
 
 - Update extension build project to reference Microsoft.NET.Sdk.Functions 4.2.0
+- Added retries on `IOException` when writing `function.metadata` file as part of `GenerateFunctionMetadata` msbuild task. This is to allow builds to continue (with warnings) when another process has the file momentarily locked. If the file continues to be locked the task (and build) will fail after 10 retries with a 1 second delay each. (#1532)
+- Add support for deferred binding (#1676)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Analyzers <version> (delete if not updated)
 

--- a/src/DotNetWorker.Core/DotNetWorker.Core.csproj
+++ b/src/DotNetWorker.Core/DotNetWorker.Core.csproj
@@ -8,8 +8,8 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Core</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>12</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
+    <MinorProductVersion>13</MinorProductVersion>
+    <PatchProductVersion>0</PatchProductVersion>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
+++ b/src/DotNetWorker.Grpc/DotNetWorker.Grpc.csproj
@@ -8,8 +8,8 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Grpc</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Grpc</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>10</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
+    <MinorProductVersion>11</MinorProductVersion>
+    <PatchProductVersion>0</PatchProductVersion>
     <VersionSuffix></VersionSuffix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -8,8 +8,8 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>14</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
+    <MinorProductVersion>15</MinorProductVersion>
+    <PatchProductVersion>0</PatchProductVersion>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
Updating version numbers to catch up with what has been released publicly e.g. the latest worker release is 1.15.0-preview1 right now