### PR TITLE
Worker Extension project incremental build support

### DIFF
--- a/samples/FunctionApp/FunctionApp.csproj
+++ b/samples/FunctionApp/FunctionApp.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.13.0-preview1-local" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>

--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -31,9 +31,23 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         {
             var extensionsCsprojFilePath = Path.Combine(_outputPath, ExtensionsProjectName);
 
-            RecreateDirectory(_outputPath);
+            string csproj = GetCsProjContent();
 
-            WriteExtensionsCsProj(extensionsCsprojFilePath);
+            // Incremental build support: write the new csproj only if contents have changed.
+            // By keeping one from a previous build around, our restore & build has a chance
+            // to follow incremental build and no-op if nothing needs to be done.
+            if (File.Exists(extensionsCsprojFilePath))
+            {
+                string existing = File.ReadAllText(extensionsCsprojFilePath);
+                if (string.Equals(csproj, existing, StringComparison.Ordinal))
+                {
+                    // Up to date, nothing to do.
+                    return;
+                }
+            }
+
+            RecreateDirectory(_outputPath);
+            File.WriteAllText(extensionsCsprojFilePath, csproj);
         }
 
         private void RecreateDirectory(string directoryPath)
@@ -44,13 +58,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             }
 
             Directory.CreateDirectory(directoryPath);
-        }
-
-        private void WriteExtensionsCsProj(string filePath)
-        {
-            string csprojContent = GetCsProjContent();
-
-            File.WriteAllText(filePath, csprojContent);
         }
 
         internal string GetCsProjContent()

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <MinorProductVersion>12</MinorProductVersion>
+    <MinorProductVersion>13</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
+    <VersionSuffix>-preview1</VersionSuffix>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -62,14 +62,17 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps."/>
     </Target>
 
-    <Target Name="_FunctionsPostBuild" AfterTargets="AfterBuild" DependsOnTargets="_FunctionsPostBuildNetFx;_FunctionsPostBuildNetApp"/>
+    <Target Name="_FunctionsPostBuild" AfterTargets="AfterBuild" DependsOnTargets="_FunctionsGetWorkerExtensionPath;_FunctionsPostBuildNetFx;_FunctionsPostBuildNetApp"/>
+
+    <Target Name="_FunctionsGetWorkerExtensionPath">
+        <PropertyGroup>
+            <_FunctionsWorkerConfigOutputFile>$(TargetDir)\worker.config.json</_FunctionsWorkerConfigOutputFile>
+            <ExtensionsCsProjFilePath Condition="'$(ExtensionsCsProjFilePath)' == ''">$([System.IO.Path]::GetFullPath($(IntermediateOutputPath)WorkExtensions))</ExtensionsCsProjFilePath>
+        </PropertyGroup>
+    </Target>
+
     <!--.NET Framework post build-->
     <Target Name="_FunctionsPostBuildNetFx" Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
-        <PropertyGroup>
-            <OutputFile>$(TargetDir)\worker.config.json</OutputFile>
-            <ExtensionsCsProjFilePath>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ExtensionsCsProjFilePath>
-        </PropertyGroup>
-
         <GenerateFunctionMetadata
           AssemblyPath="$(TargetDir)$(AssemblyName).exe"
           ReferencePaths="@(ReferencePath)"
@@ -84,24 +87,20 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           Condition="!$(FunctionsEnablePlaceholder)"
           SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
           DestinationFolder="$(ExtensionsCsProjFilePath)\buildout"
+          SkipUnchangedFiles="true"
           OverwriteReadOnlyFiles="true" />
 
         <WriteLinesToFile
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', '{WorkerRoot}$(TargetName).exe')
-                                  .Replace('$functionWorker$', '$(TargetName).exe')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-            Overwrite="true" />
+          File="$(_FunctionsWorkerConfigOutputFile)"
+          Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
+                                .Replace('$functionExe$', '{WorkerRoot}$(TargetName).exe')
+                                .Replace('$functionWorker$', '$(TargetName).exe')
+                                .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
+          Overwrite="true" />
     </Target>
 
     <!--.NET/.NET Core post build-->
     <Target Name="_FunctionsPostBuildNetApp" Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">
-        <PropertyGroup>
-            <OutputFile>$(TargetDir)\worker.config.json</OutputFile>
-            <ExtensionsCsProjFilePath>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ExtensionsCsProjFilePath>
-        </PropertyGroup>
-
         <GenerateFunctionMetadata
           AssemblyPath="$(TargetDir)$(AssemblyName).dll"
           ReferencePaths="@(ReferencePath)"
@@ -110,31 +109,33 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
           TargetFrameworkVersion="$(TargetFrameworkVersion)"
           OutputPath="$(TargetDir)"/>
+
         <!-- Do not copy _FunctionsMetadataLoaderExtensionFile when in placeholder mode, as we don't want the FunctionMetadataLoader entry in extensions.json--> 
         <Copy
           Condition="!$(FunctionsEnablePlaceholder)"
           SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
           DestinationFolder="$(ExtensionsCsProjFilePath)\buildout"
+          SkipUnchangedFiles="true"
           OverwriteReadOnlyFiles="true" />
 
         <WriteLinesToFile
-            Condition="$(SelfContained)"
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', '{WorkerRoot}$(TargetName)')
-                                  .Replace('$functionWorker$', '$(TargetName).dll')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-        Overwrite="true" />
+          Condition="$(SelfContained)"
+          File="$(_FunctionsWorkerConfigOutputFile)"
+          Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
+                                .Replace('$functionExe$', '{WorkerRoot}$(TargetName)')
+                                .Replace('$functionWorker$', '$(TargetName).dll')
+                                .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
+          Overwrite="true" />
 
 
         <WriteLinesToFile
-            Condition="!$(SelfContained)"
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', 'dotnet')
-                                  .Replace('$functionWorker$', '$(TargetName).dll')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-        Overwrite="true" />
+          Condition="!$(SelfContained)"
+          File="$(_FunctionsWorkerConfigOutputFile)"
+          Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
+                                .Replace('$functionExe$', 'dotnet')
+                                .Replace('$functionWorker$', '$(TargetName).dll')
+                                .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
+          Overwrite="true" />
 
   </Target>
 
@@ -153,8 +154,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
             <ExtensionRuntimeBinaries Include="$(ExtensionsCsProjFilePath)\buildout\runtimes\**\*.*" />
         </ItemGroup>
 
-        <Copy SourceFiles="@(ExtensionBinaries)" DestinationFolder="$(TargetDir)\.azurefunctions\%(RecursiveDir)" />
-        <Copy SourceFiles="@(ExtensionRuntimeBinaries)" DestinationFolder="$(TargetDir)\.azurefunctions\runtimes\%(RecursiveDir)" />
+        <Copy SourceFiles="@(ExtensionBinaries)" DestinationFolder="$(TargetDir)\.azurefunctions\%(RecursiveDir)" SkipUnchangedFiles="true" />
+        <Copy SourceFiles="@(ExtensionRuntimeBinaries)" DestinationFolder="$(TargetDir)\.azurefunctions\runtimes\%(RecursiveDir)" SkipUnchangedFiles="true" />
     </Target>
 
     <Target Name ="_WorkerExtensionsBuild" AfterTargets="_WorkerExtensionsRestore">


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1740 

This PR attempts to solve frequent pain points with our SDK build steps which cause file locked issues. I believe the issue lies with how we perform an inner-build with the `WorkerExtensions.csproj` to generate collect host extensions. To mitigate this inner-build causing file lock issues, two primary changes have been made:

1. The `WorkerExtension.csproj` is now generate & built in the intermediate output path of the outer-project (typically `obj/{Configuration}/{TargetFramework}`) under the `WorkerExtensions` folder.
2. Incremental build support has been improved
  - Copy tasks now use `SkipUnchanged` to avoid copying files which already exist and are up to date at the target destination
  - Generation of the csproj itself now checks for an existing csproj, and only writes if there are differences.

These changes combined reduces how much happens on re-builds of a functions worker project, which as a result means less file interactions and thus less file locked issues.

### Pull request checklist

TODO

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
