### PR TITLE
Remove incorrect log during cancellation success flow

### DIFF
--- a/src/DotNetWorker.Grpc/Handlers/InvocationHandler.cs
+++ b/src/DotNetWorker.Grpc/Handlers/InvocationHandler.cs
@@ -145,7 +145,6 @@ namespace Microsoft.Azure.Functions.Worker.Handlers
                 try
                 {
                     cancellationTokenSource?.Cancel();
-                    _logger.LogWarning("Unable to cancel invocation {invocationId}.", invocationId);
                     return true;
                 }
                 catch (ObjectDisposedException)
@@ -154,7 +153,7 @@ namespace Microsoft.Azure.Functions.Worker.Handlers
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Unable to cancel invocation {invocationId}.", invocationId);
+                    _logger.LogWarning(ex, "Unable to cancel invocation '{invocationId}'.", invocationId);
                     throw;
                 }
             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Bug: we should not be logging "unable to cancel" during a successful cancellation flow

resolves #1753

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
