### PR TITLE
Disable blob container path analyzer when an expression is used for the blob path

### DIFF
--- a/docs/analyzer-rules/AZFW0011.md
+++ b/docs/analyzer-rules/AZFW0011.md
@@ -16,11 +16,9 @@ When using the `BlobInputAttribute` with a container path, the target parameter 
 
 Example, if your function uses `BlobInput("<container path>")` and it is binding to a `string`, this rule will be violated.
 
-
 ## How to fix violations
 
 Change the binding type to an iterable type such as `IEnumerable<T>` or provide blob path `container/blob` instead of a container path when using a non-iterable binding type is desired.
-
 
 ### Supported Types
 

--- a/sdk/Sdk.Analyzers/Extensions/TypeSymbolExtensions.cs
+++ b/sdk/Sdk.Analyzers/Extensions/TypeSymbolExtensions.cs
@@ -87,12 +87,12 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
             return IsIEnumerableTType || IsIEnumerableType || isArrayType;
         }
 
-        internal static bool IsOrImplementsOrDerivesFrom(this ITypeSymbol symbol, ITypeSymbol? other)
+        internal static bool IsOrImplementsOrDerivesFrom(this ITypeSymbol symbol, ITypeSymbol other)
         {
             return symbol.IsOrImplements(other) || symbol.IsOrDerivedFrom(other);
         }
 
-        internal static bool IsOrDerivedFrom(this ITypeSymbol symbol, ITypeSymbol? other)
+        internal static bool IsOrDerivedFrom(this ITypeSymbol symbol, ITypeSymbol other)
         {
             if (other is null)
             {
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Analyzers
             return false;
         }
 
-        internal static bool IsOrImplements(this ITypeSymbol symbol, ITypeSymbol? other)
+        internal static bool IsOrImplements(this ITypeSymbol symbol, ITypeSymbol other)
         {
             if (other is null)
             {

--- a/sdk/Sdk.Analyzers/Sdk.Analyzers.csproj
+++ b/sdk/Sdk.Analyzers/Sdk.Analyzers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>2</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <OutputType>Library</OutputType>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>13</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -8,9 +8,9 @@
 
 - <entry>
 
-### Microsoft.Azure.Functions.Worker.Sdk.Analyzers <version>
+### Microsoft.Azure.Functions.Worker.Sdk.Analyzers 1.2.1
 
-- <entry>
+- Disable blob container path analyzer when an expression is used for the blob path
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,9 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk <version>
+### Microsoft.Azure.Functions.Worker.Sdk 1.13.1
 
-- <entry>
+- Update Microsoft.Azure.Functions.Worker.Sdk.Analyzers dependency to 1.2.1
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Analyzers 1.2.1
 

--- a/test/Sdk.Analyzers.Tests/IterableBindingTypeExpectedForBlobContainerPathTests.cs
+++ b/test/Sdk.Analyzers.Tests/IterableBindingTypeExpectedForBlobContainerPathTests.cs
@@ -30,10 +30,10 @@ namespace Sdk.Analyzers.Tests
             var test = new AnalyzerTest
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "5.1.1-preview2"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
 
                 TestCode = testCode
             };
@@ -68,10 +68,10 @@ namespace Sdk.Analyzers.Tests
             var test = new AnalyzerTest
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "5.1.1-preview2"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
 
                 TestCode = testCode
             };
@@ -105,10 +105,10 @@ namespace Sdk.Analyzers.Tests
             var test = new AnalyzerTest
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "5.1.1-preview2"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
 
                 TestCode = testCode
             };
@@ -143,10 +143,10 @@ namespace Sdk.Analyzers.Tests
             var test = new AnalyzerTest
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "5.1.1-preview2"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
 
                 TestCode = testCode
             };
@@ -179,10 +179,10 @@ namespace Sdk.Analyzers.Tests
             var test = new AnalyzerTest
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "5.1.1-preview2"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
 
                 TestCode = testCode
             };
@@ -214,10 +214,10 @@ namespace Sdk.Analyzers.Tests
             var test = new AnalyzerTest
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "5.1.1-preview2"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
 
                 TestCode = testCode
             };
@@ -249,10 +249,10 @@ namespace Sdk.Analyzers.Tests
             var test = new AnalyzerTest
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "5.1.1-preview2"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
 
                 TestCode = testCode
             };
@@ -285,10 +285,46 @@ namespace Sdk.Analyzers.Tests
             var test = new AnalyzerTest
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.15.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "5.1.1-preview2"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+
+                TestCode = testCode
+            };
+
+            // test.ExpectedDiagnostics is an empty collection.
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task BlobInputAttribute_BlobPathExpression_Diagnostics_NotExpected()
+        {
+            string testCode = @"
+                using System;
+                using System.Collections.Generic;
+                using Microsoft.Azure.Functions.Worker;
+                using Azure.Storage.Blobs;
+
+                namespace FunctionApp
+                {
+                    public static class SomeFunction
+                    {
+                        [Function(nameof(SomeFunction))]
+                        public static void Run([BlobInput(""{input}"")] string message)
+                        {
+                        }
+                    }
+                }";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
 
                 TestCode = testCode
             };


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Bug fix: we don't know what the blob path will be when an expression is used, so we should not activate this analyzer when expressions are used in the blob path

resolves #1804

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
