### PR TITLE
Update blob and cosmos to use IOptionsMonitor

### DIFF
--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB <version>
+### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.4.1
 
-- <entry>
+- [Bug] Update CosmosOptions from using IOptionsSnapshot to IOptionsMonitor to avoid DI scoping issues

--- a/extensions/Worker.Extensions.CosmosDB/src/CosmosDBConverter.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/CosmosDBConverter.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Azure.Functions.Worker
     [SupportsDeferredBinding]
     internal class CosmosDBConverter : IInputConverter
     {
-        private readonly IOptionsSnapshot<CosmosDBBindingOptions> _cosmosOptions;
+        private readonly IOptionsMonitor<CosmosDBBindingOptions> _cosmosOptions;
         private readonly ILogger<CosmosDBConverter> _logger;
 
-        public CosmosDBConverter(IOptionsSnapshot<CosmosDBBindingOptions> cosmosOptions, ILogger<CosmosDBConverter> logger)
+        public CosmosDBConverter(IOptionsMonitor<CosmosDBBindingOptions> cosmosOptions, ILogger<CosmosDBConverter> logger)
         {
             _cosmosOptions = cosmosOptions ?? throw new ArgumentNullException(nameof(cosmosOptions));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
+++ b/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Cosmos DB extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.4.0</VersionPrefix>
+    <VersionPrefix>4.4.1</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Azure.Functions.Worker
     internal class BlobStorageConverter : IInputConverter
     {
         private readonly IOptions<WorkerOptions> _workerOptions;
-        private readonly IOptionsSnapshot<BlobStorageBindingOptions> _blobOptions;
+        private readonly IOptionsMonitor<BlobStorageBindingOptions> _blobOptions;
         private readonly ILogger<BlobStorageConverter> _logger;
         private readonly Regex BlobIsFileRegex = new Regex(@"\.[^.\/]+$");
 
-        public BlobStorageConverter(IOptions<WorkerOptions> workerOptions, IOptionsSnapshot<BlobStorageBindingOptions> blobOptions, ILogger<BlobStorageConverter> logger)
+        public BlobStorageConverter(IOptions<WorkerOptions> workerOptions, IOptionsMonitor<BlobStorageBindingOptions> blobOptions, ILogger<BlobStorageConverter> logger)
         {
             _workerOptions = workerOptions ?? throw new ArgumentNullException(nameof(workerOptions));
             _blobOptions = blobOptions ?? throw new ArgumentNullException(nameof(blobOptions));

--- a/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Blob Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>6.0.1</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.Storage/release_notes.md
+++ b/extensions/Worker.Extensions.Storage/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage 6.0.1
 
-- Updated Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs to 6.0.1
+- Updated Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs dependency to 6.0.1
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs 6.0.1
 

--- a/extensions/Worker.Extensions.Storage/release_notes.md
+++ b/extensions/Worker.Extensions.Storage/release_notes.md
@@ -4,14 +4,15 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Storage <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Storage 6.0.1
 
-- <entry>
+- Updated Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs to 6.0.1
 
-### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs 6.0.1
 
-- <entry>
+- [Bug] Update BlobOptions from using IOptionsSnapshot to IOptionsMonitor to avoid DI scoping issues
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues <version>
 
 - <entry>
+

--- a/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
+++ b/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>6.0.1</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/test/Worker.Extensions.Tests/Blob/BlobClientTests.cs
+++ b/test/Worker.Extensions.Tests/Blob/BlobClientTests.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Blob
             var mockBlobOptions = new Mock<BlobStorageBindingOptions>();
             mockBlobOptions.Object.Client = _mockBlobServiceClient.Object;
 
-            var mockBlobOptionsSnapshot = new Mock<IOptionsSnapshot<BlobStorageBindingOptions>>();
-            mockBlobOptionsSnapshot
+            var mockBlobOptionsMonitor = new Mock<IOptionsMonitor<BlobStorageBindingOptions>>();
+            mockBlobOptionsMonitor
                 .Setup(m => m.Get(It.IsAny<string>()))
                 .Returns(mockBlobOptions.Object);
 
-            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsSnapshot.Object, logger);
+            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsMonitor.Object, logger);
         }
 
         [Fact]

--- a/test/Worker.Extensions.Tests/Blob/BlobContainerClientTests.cs
+++ b/test/Worker.Extensions.Tests/Blob/BlobContainerClientTests.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Blob
             var mockBlobOptions = new Mock<BlobStorageBindingOptions>();
             mockBlobOptions.Object.Client = _mockBlobServiceClient.Object;
 
-            var mockBlobOptionsSnapshot = new Mock<IOptionsSnapshot<BlobStorageBindingOptions>>();
-            mockBlobOptionsSnapshot
+            var mockBlobOptionsMonitor = new Mock<IOptionsMonitor<BlobStorageBindingOptions>>();
+            mockBlobOptionsMonitor
                 .Setup(m => m.Get(It.IsAny<string>()))
                 .Returns(mockBlobOptions.Object);
 
-            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsSnapshot.Object, logger);
+            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsMonitor.Object, logger);
         }
 
         [Fact]

--- a/test/Worker.Extensions.Tests/Blob/BlobStorageConverterCoreTests.cs
+++ b/test/Worker.Extensions.Tests/Blob/BlobStorageConverterCoreTests.cs
@@ -32,12 +32,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Blob
             var mockBlobOptions = new Mock<BlobStorageBindingOptions>();
             mockBlobOptions.Object.Client = _mockBlobServiceClient.Object;
 
-            var mockBlobOptionsSnapshot = new Mock<IOptionsSnapshot<BlobStorageBindingOptions>>();
-            mockBlobOptionsSnapshot
+            var mockBlobOptionsMonitor = new Mock<IOptionsMonitor<BlobStorageBindingOptions>>();
+            mockBlobOptionsMonitor
                 .Setup(m => m.Get(It.IsAny<string>()))
                 .Returns(mockBlobOptions.Object);
 
-            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsSnapshot.Object, logger);
+            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsMonitor.Object, logger);
         }
 
         [Fact]

--- a/test/Worker.Extensions.Tests/Blob/ByteArrayTests.cs
+++ b/test/Worker.Extensions.Tests/Blob/ByteArrayTests.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Blob
             var mockBlobOptions = new Mock<BlobStorageBindingOptions>();
             mockBlobOptions.Object.Client = _mockBlobServiceClient.Object;
 
-            var mockBlobOptionsSnapshot = new Mock<IOptionsSnapshot<BlobStorageBindingOptions>>();
-            mockBlobOptionsSnapshot
+            var mockBlobOptionsMonitor = new Mock<IOptionsMonitor<BlobStorageBindingOptions>>();
+            mockBlobOptionsMonitor
                 .Setup(m => m.Get(It.IsAny<string>()))
                 .Returns(mockBlobOptions.Object);
 
-            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsSnapshot.Object, logger);
+            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsMonitor.Object, logger);
         }
 
         [Fact]

--- a/test/Worker.Extensions.Tests/Blob/POCOTests.cs
+++ b/test/Worker.Extensions.Tests/Blob/POCOTests.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Blob
             var mockBlobOptions = new Mock<BlobStorageBindingOptions>();
             mockBlobOptions.Object.Client = _mockBlobServiceClient.Object;
 
-            var mockBlobOptionsSnapshot = new Mock<IOptionsSnapshot<BlobStorageBindingOptions>>();
-            mockBlobOptionsSnapshot
+            var mockBlobOptionsMonitor = new Mock<IOptionsMonitor<BlobStorageBindingOptions>>();
+            mockBlobOptionsMonitor
                 .Setup(m => m.Get(It.IsAny<string>()))
                 .Returns(mockBlobOptions.Object);
 
-            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsSnapshot.Object, logger);
+            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsMonitor.Object, logger);
         }
 
         [Fact]

--- a/test/Worker.Extensions.Tests/Blob/StreamTests.cs
+++ b/test/Worker.Extensions.Tests/Blob/StreamTests.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Blob
             var mockBlobOptions = new Mock<BlobStorageBindingOptions>();
             mockBlobOptions.Object.Client = _mockBlobServiceClient.Object;
 
-            var mockBlobOptionsSnapshot = new Mock<IOptionsSnapshot<BlobStorageBindingOptions>>();
-            mockBlobOptionsSnapshot
+            var mockBlobOptionsMonitor = new Mock<IOptionsMonitor<BlobStorageBindingOptions>>();
+            mockBlobOptionsMonitor
                 .Setup(m => m.Get(It.IsAny<string>()))
                 .Returns(mockBlobOptions.Object);
 
-            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsSnapshot.Object, logger);
+            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsMonitor.Object, logger);
         }
 
         [Fact]

--- a/test/Worker.Extensions.Tests/Blob/StringTests.cs
+++ b/test/Worker.Extensions.Tests/Blob/StringTests.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Blob
             var mockBlobOptions = new Mock<BlobStorageBindingOptions>();
             mockBlobOptions.Object.Client = _mockBlobServiceClient.Object;
 
-            var mockBlobOptionsSnapshot = new Mock<IOptionsSnapshot<BlobStorageBindingOptions>>();
-            mockBlobOptionsSnapshot
+            var mockBlobOptionsMonitor = new Mock<IOptionsMonitor<BlobStorageBindingOptions>>();
+            mockBlobOptionsMonitor
                 .Setup(m => m.Get(It.IsAny<string>()))
                 .Returns(mockBlobOptions.Object);
 
-            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsSnapshot.Object, logger);
+            _blobStorageConverter = new BlobStorageConverter(workerOptions, mockBlobOptionsMonitor.Object, logger);
         }
 
         [Fact]

--- a/test/Worker.Extensions.Tests/Cosmos/CosmosDBConverterTests.cs
+++ b/test/Worker.Extensions.Tests/Cosmos/CosmosDBConverterTests.cs
@@ -34,12 +34,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Cosmos
                 .Setup(m => m.GetClient(It.IsAny<string>()))
                 .Returns(_mockCosmosClient.Object);
 
-            var mockCosmosOptionsSnapshot = new Mock<IOptionsSnapshot<CosmosDBBindingOptions>>();
-            mockCosmosOptionsSnapshot
+            var mockCosmosOptionsMonitor = new Mock<IOptionsMonitor<CosmosDBBindingOptions>>();
+            mockCosmosOptionsMonitor
                 .Setup(m => m.Get(It.IsAny<string>()))
                 .Returns(mockCosmosOptions.Object);
 
-            _cosmosDBConverter = new CosmosDBConverter(mockCosmosOptionsSnapshot.Object, logger);
+            _cosmosDBConverter = new CosmosDBConverter(mockCosmosOptionsMonitor.Object, logger);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1786

'IOptionsSnapshot' is registered as a scoped service and should only be resolved in a scoped container. We are currently resolving these options in a root container (via `DefaultInputConverterProvider`) which is leading to the problem described in the linked GH issue.

- Update CosmosOptions from using IOptionsSnapshot to IOptionsMonitor to avoid DI scoping issues
- Update BlobOptions from using IOptionsSnapshot to IOptionsMonitor to avoid DI scoping issues

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
