### PR TITLE
Attribute-based middleware

### DIFF
--- a/src/DotNetWorker.Core/Context/FunctionContextMetadataExtensions.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContextMetadataExtensions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// <see cref="FunctionContext"/> extension methods for metadata.
+    /// </summary>
+    internal static class FunctionContextMetadataExtensions
+    {
+        /// <summary>
+        /// Gets the <see cref="MethodInfo"/> of the function entry point.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static MethodInfo? GetMethodInfo(this FunctionContext context)
+        {
+            // note:
+            //  - Use caching strategy for MethodInfo if you want to speed up.
+            //  - Not cached at this time because of limited use.
+
+            var assembly = findAssembly(context.FunctionDefinition.PathToAssembly.AsSpan());
+            if (assembly is null)
+                return null;
+
+            var entryPoint = context.FunctionDefinition.EntryPoint;
+            return findMethod(assembly, entryPoint.AsSpan());
+
+
+            #region Local Functions
+            static Assembly? findAssembly(ReadOnlySpan<char> path)
+            {
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    var location = assembly.Location.AsSpan();
+                    if (location.Equals(path, StringComparison.Ordinal))
+                        return assembly;
+                }
+                return null;
+            }
+
+
+            static MethodInfo? findMethod(Assembly assembly, ReadOnlySpan<char> entryPoint)
+            {
+                var index = entryPoint.LastIndexOf('.');
+                var typeName = entryPoint.Slice(0, index).ToString();
+                var methodName = entryPoint.Slice(index + 1).ToString();
+                var type = assembly.GetType(typeName);
+                const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance;
+                return type?.GetMethod(methodName, flags);
+            }
+            #endregion
+        }
+    }
+}

--- a/src/DotNetWorker.Core/Pipeline/FunctionMiddlewareAttribute.cs
+++ b/src/DotNetWorker.Core/Pipeline/FunctionMiddlewareAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.Functions.Worker.Middleware
+{
+    /// <summary>
+    /// Represents IFunctionsWorkerMiddleware that operates on an attribute-based.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public sealed class FunctionMiddlewareAttribute<T> : Attribute
+        where T : class, IFunctionsWorkerMiddleware
+    { }
+}


### PR DESCRIPTION
# Issue describing the changes in this PR

This PR allows for the provision of Middleware that can be applied at the function level based on attributes. Currently, control is possible through the use of the `.UseWhen<TMiddleware>()` method, but because it is very primitive, SDK users suffer from implementation pains. This PR resolves that issue.

# Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


# How to use

## Step.1 : Creates custom middleware

```cs
internal sealed class CustomMiddleware : IFunctionsWorkerMiddleware
{
    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
    {
        // do something
        await next(context);
    }
}
```

## Step.2 : Registers middleware into DI containers
```cs
new HostBuilder()
    .ConfigureFunctionsWorkerDefaults(static (context, builder) =>
    {
        builder.UseWhenAttribute<CustomMiddleware>();
    })
    .Build()
    .Run();
```

## Step.3 : Annotate `FunctionMiddlewareAttribute<T>`
```cs
internal sealed class FooTimer
{
    [FunctionMiddleware<CustomMiddleware>]  // anotate if you want to use
    [Function("FooTimer")]
    public async Task EntryPoint(
        [TimerTrigger("%AzureWebJobs.FooTimer.Cron%")] TimerInfo timer,
        FunctionContext context)
    {
        // do something
    }
}
```


# Limitation

This feature uses [Generic Attributes](https://github.com/dotnet/csharplang/issues/124). Therefore, it cannot be applied unless C# 11 or later. It is possible to implement this feature without using generic attributes, but it would lose the ability to constrain to the `IFunctionsWorkerMiddleware` type. I have leaned towards adding the constraint in this trade-off, but I would like to hear the opinions of everyone on the SDK team.


# Typical scenario

Sometimes, we may want to set up middleware on a function-by-function basis. For example, you might want to add API key authentication only to certain functions for HttpTrigger. In such cases, it would be cumbersome to check for the API key at the entry point of each HttpTrigger, so you'd probably want to streamline this process with middleware. To achieve this, currently, the only solution is to use the `.UseWhen<TMiddleware>()` method as follows.

```cs
// Program.cs
new HostBuilder()
    .ConfigureFunctionsWorkerDefaults(static (context, builder) =>
    {
        builder.UseWhen<ApiKeyAuthMiddleware>(static context =>
        {
            return context.FunctionDefinition.Name is "Http_DoSomething";
        });
    });
```
```cs
// SampleFunctions.cs
internal sealed class SampleFunctions
{
    [Function("Http_DoSomething")]
    public async Task EntryPoint(
        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "something")] HttpRequestData request,
        FunctionContext context)
    {
        // do something
    }
}
```

This implementation has the following pain points:

- You need to write the implementation for applying the middleware and the functions to be applied in different files.
- You need to compare the names of the target functions as `string`.
    - Although the pain can be alleviated by defining the function names as constants, in my experience, few developers can safely implement changes to function names.
- As the number of middleware and trigger to be applied increases, the predicate delegate becomes bloated and maintainability decreases.

Therefore, I believe that an attribute-based declarative approach, like the one in this PR, can solve the problems mentioned above. The method of `ActionFilterAttribute` in ASP.NET Core MVC has a long history, so I guess there are many developers who are familiar with it.


# Implementation approach

In this PR implementation, I'm scanning the assembly to get the custom attribute `FunctionMiddlewareAttribute<T>` applied to the entry point. As far as I know, there is no other way to get the custom attribute applied to the entry point via `FunctionContext`, which is the callback argument for `.UseWhen<TMiddleware>()`. If a way to get the custom attribute from the `FunctionContext` is provided, it would probably make the implementation simpler.