### PR TITLE
Update BlobConverter to use attribute for connection value

### DIFF
--- a/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs
@@ -60,6 +60,14 @@ namespace Microsoft.Azure.Functions.Worker
                 }
 
                 BlobBindingData blobData = GetBindingDataContent(modelBindingData);
+
+                // Temp fix for connection value being incorrect from WebJobs
+                context.TryGetBindingAttribute<BlobTriggerAttribute>(out object attribute);
+                if (attribute is BlobTriggerAttribute blobTriggerAttribute)
+                {
+                    blobData.Connection = blobTriggerAttribute.Connection;
+                }
+
                 var result = await ConvertModelBindingDataAsync(context.TargetType, blobData);
 
                 if (result is null)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

1. Getting feedback on the switch to using the attribute directly for the Connection value vs making a fix in the WebJobs SDK.


