### PR TITLE
Adding Schema Regsistry attributes for kafka trigger and ouput

### DIFF
--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Kafka 3.9.0
+### Microsoft.Azure.Functions.Worker.Extensions.Kafka 3.10.0
 
 - Added Schema Registry Attributes for Trigger and Output bindings

--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Kafka <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Kafka 3.9.0
 
-- <entry>
+- Added Schema Registry Attributes for Trigger and Output bindings

--- a/extensions/Worker.Extensions.Kafka/src/KafkaOutputAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaOutputAttribute.cs
@@ -128,5 +128,20 @@ namespace Microsoft.Azure.Functions.Worker
         /// being sent to cluster. Larger value allows more batching results in high throughput.
         /// </summary>
         public int LingerMs { get; set; } = 5;
+
+        /// <summary>
+        /// URL for the Avro Schema Registry
+        /// </summary>
+        public string SchemaRegistryUrl { get; set; }
+
+        /// <summary>
+        /// Username for the Avro Schema Registry
+        /// </summary>
+        public string SchemaRegistryUsername { get; set; }
+
+        /// <summary>
+        /// Password for the Avro Schema Registry
+        /// </summary>
+        public string SchemaRegistryPassword { get; set; }
     }
 }

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
@@ -113,6 +113,21 @@ namespace Microsoft.Azure.Functions.Worker
         public long LagThreshold { get; set; } = 1000;
 
         /// <summary>
+        /// URL for the Avro Schema Registry
+        /// </summary>
+        public string SchemaRegistryUrl { get; set; }
+
+        /// <summary>
+        /// Username for the Avro Schema Registry
+        /// </summary>
+        public string SchemaRegistryUsername { get; set; }
+
+        /// <summary>
+        /// Password for the Avro Schema Registry
+        /// </summary>
+        public string SchemaRegistryPassword { get; set; }
+
+        /// <summary>
         /// Gets or sets the configuration to enable batch processing of events. Default value is "false".
         /// </summary>
         public bool IsBatched

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -5,7 +5,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.9.0</VersionPrefix>
+    <VersionPrefix>3.10.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Kafka extension 3.9.0 has introduced additional attributes for Avro Schema Registry Support. This PR aims at exposing the attributes for out of proc model. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

