### PR TITLE
Always uses .NET 6 as TFM for extensions csrpoj

### DIFF
--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -64,11 +64,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
                 {
                     targetFramework = Constants.NetCoreApp31;
                 }
-
-                if (_targetFrameworkVersion.Equals(Constants.NetCoreVersion7, StringComparison.OrdinalIgnoreCase))
-                {
-                    targetFramework = Constants.Net70;
-                }
             }
 
             string netSdkVersion = _azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) ? "3.1.2" : "4.2.0";


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1709

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


### Additional information

Azure Functions runtime/host 4 is targeting at .NET 6, see https://github.com/Azure/azure-functions-host/blob/50788a70d720400dd0cbbd34aba0a06f60c941e6/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj#L5 , it doesn't make sense for the extensions project to target at .NET 7, as those extensions run in .NET 6 runtime.
