### PR TITLE
Updating FunctionsNetHost to handle the new "functions-" prefix cmdline args.

### DIFF
--- a/host/src/FunctionsNetHost/Grpc/GrpcClient.cs
+++ b/host/src/FunctionsNetHost/Grpc/GrpcClient.cs
@@ -33,7 +33,7 @@ namespace FunctionsNetHost.Grpc
 
         internal async Task InitAsync()
         {
-            var endpoint = $"http://{_grpcWorkerStartupOptions.Host}:{_grpcWorkerStartupOptions.Port}";
+            var endpoint = _grpcWorkerStartupOptions.ServerUri.AbsoluteUri;
             Logger.LogTrace($"Grpc service endpoint:{endpoint}");
 
             var functionRpcClient = CreateFunctionRpcClient(endpoint);

--- a/host/src/FunctionsNetHost/Grpc/GrpcWorkerStartupOptions.cs
+++ b/host/src/FunctionsNetHost/Grpc/GrpcWorkerStartupOptions.cs
@@ -5,9 +5,7 @@ namespace FunctionsNetHost.Grpc
 {
     internal sealed class GrpcWorkerStartupOptions
     {
-        public string? Host { get; set; }
-
-        public int Port { get; set; }
+        public Uri ServerUri { get; set; }
 
         public string? WorkerId { get; set; }
 

--- a/host/src/FunctionsNetHost/global.json
+++ b/host/src/FunctionsNetHost/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.6.23330.14",
+    "version": "8.0.100-rc.1.23455.8",
     "allowPrerelease": true,
     "rollForward": "latestMinor"
   }


### PR DESCRIPTION
Updating FunctionsNetHost to handle the new "functions-" prefix cmdline args.

Part of #1900  

Also bumped up the global JSON .net version to rc1.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
