### PR TITLE
Including "canUsePlaceholder" property in worker.config

### DIFF
--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>15</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/Sdk/worker.config.json
+++ b/sdk/Sdk/worker.config.json
@@ -5,6 +5,6 @@
     "defaultExecutablePath": "$functionExe$",
     "defaultWorkerPath": "$functionWorker$",
     "workerIndexing": "$enableWorkerIndexing$",
-    "isSpecializable": true
+    "canUsePlaceholder": true
   }
 }

--- a/sdk/Sdk/worker.config.json
+++ b/sdk/Sdk/worker.config.json
@@ -4,6 +4,7 @@
     "extensions": [ ".dll" ],
     "defaultExecutablePath": "$functionExe$",
     "defaultWorkerPath": "$functionWorker$",
-    "workerIndexing": "$enableWorkerIndexing$"
+    "workerIndexing": "$enableWorkerIndexing$",
+    "isSpecializable": true
   }
 }

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Worker.Sdk 1.15.1 (meta package)
 
-- Include `isSpecializable` property in worker.config.json (#1956)
+- Include `canUsePlaceholder` property in worker.config.json (#1956)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Analyzers <version> (delete if not updated)
 

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,9 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk <version> (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk 1.15.1 (meta package)
 
-- <entry>
+- Include `isSpecializable` property in worker.config.json (#1956)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Analyzers <version> (delete if not updated)
 


### PR DESCRIPTION
Part of #1951 fix

Including `canUsePlaceholder` property in worker.config. This property will be used by native placeholder to determine whether the function app payload uses a new version of worker package or not. 

We will be publishing a new version with this change and update our docs suggesting customers to use this version as the minimum version to get placeholder support.

Native placeholder changes to read this property is in #1955 

### Pull request checklist

* [x] My changes **do not** require documentation changes - I will work with @mattchenderson to update the docs once our changes are out and validated.
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
