### PR TITLE
Sending EnableUserCodeException as a capability of native worker 

### DIFF
--- a/host/src/FunctionsNetHost/Grpc/WorkerCapabilities.cs
+++ b/host/src/FunctionsNetHost/Grpc/WorkerCapabilities.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace FunctionsNetHost.Grpc
+{
+    internal static class WorkerCapabilities
+    {
+        internal const string EnableUserCodeException = "EnableUserCodeException";
+    }
+}

--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>


### PR DESCRIPTION
- Sending `EnableUserCodeException` as a capability of native worker. - this forces host to log it in a way it surfaces user's AI logs.
- Improving the exception message for env reload failure. - host will log it as it is received.
- Version bump to 1.0.2
