### PR TITLE
Generate correct value for defaultWorkerPath in worker.config when AOT publishing is enabled

### DIFF
--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>16</MinorProductVersion>
-    <PatchProductVersion>2</PatchProductVersion>
+    <PatchProductVersion>3</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -65,6 +65,16 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps."/>
     </Target>
 
+    <PropertyGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
+        <_FunctionsWorkerExecutableFileName >$(TargetName).exe</_FunctionsWorkerExecutableFileName>
+    </PropertyGroup>
+  
+    <PropertyGroup Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">
+        <_FunctionsNativeExecutableExtension Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win')))">.exe</_FunctionsNativeExecutableExtension>
+        <_FunctionsWorkerExecutableFileName Condition="'$(PublishAot)' != 'true'">$(TargetName).dll</_FunctionsWorkerExecutableFileName>
+        <_FunctionsWorkerExecutableFileName Condition="'$(PublishAot)' == 'true'">$(TargetName)$(_FunctionsNativeExecutableExtension)</_FunctionsWorkerExecutableFileName>
+    </PropertyGroup>
+
     <Target Name="_FunctionsPostBuild" AfterTargets="AfterBuild" DependsOnTargets="_FunctionsPostBuildNetFx;_FunctionsPostBuildNetApp"/>
     <!--.NET Framework post build-->
     <Target Name="_FunctionsPostBuildNetFx" Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
@@ -93,7 +103,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
             File="$(OutputFile)"
             Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
                                   .Replace('$functionExe$', '{WorkerRoot}$(TargetName).exe')
-                                  .Replace('$functionWorker$', '$(TargetName).exe')
+                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
                                   .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
             Overwrite="true" />
     </Target>
@@ -125,7 +135,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
             File="$(OutputFile)"
             Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
                                   .Replace('$functionExe$', '{WorkerRoot}$(TargetName)')
-                                  .Replace('$functionWorker$', '$(TargetName).dll')
+                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
                                   .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
         Overwrite="true" />
 
@@ -135,7 +145,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
             File="$(OutputFile)"
             Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
                                   .Replace('$functionExe$', 'dotnet')
-                                  .Replace('$functionWorker$', '$(TargetName).dll')
+                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
                                   .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
         Overwrite="true" />
 
@@ -311,7 +321,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
             File="$(OutputFile)"
             Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
                                   .Replace('$functionExe$', '{WorkerRoot}$(TargetName).exe')
-                                  .Replace('$functionWorker$', '$(TargetName).exe')
+                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
                                   .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
             Overwrite="true" />
     </Target>
@@ -343,7 +353,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
             File="$(OutputFile)"
             Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
                                   .Replace('$functionExe$', '{WorkerRoot}$(TargetName)')
-                                  .Replace('$functionWorker$', '$(TargetName).dll')
+                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
                                   .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
         Overwrite="true" />
 
@@ -352,7 +362,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
             File="$(OutputFile)"
             Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
                                   .Replace('$functionExe$', 'dotnet')
-                                  .Replace('$functionWorker$', '$(TargetName).dll')
+                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
                                   .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
         Overwrite="true" />
 

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -66,7 +66,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </Target>
 
     <PropertyGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
-        <_FunctionsWorkerExecutableFileName >$(TargetName).exe</_FunctionsWorkerExecutableFileName>
+        <_FunctionsWorkerExecutableFileName >$(TargetName)$(TargetExt)</_FunctionsWorkerExecutableFileName>
     </PropertyGroup>
   
     <PropertyGroup Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,10 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.16.2 (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk 1.16.3 (meta package)
 
-- Update Microsoft.Azure.Functions.Worker.Sdk.Generators dependency to 1.1.4
-
-### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.1.4
-
-- Adding support for locating functions within nested types and nested namespaces from referenced assemblies (#2054)
+- Update worker.config generation to accurate worker executable name (#1053)


### PR DESCRIPTION
resolves #1053

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
