### PR TITLE
Close hostfxr handle, skip creating unnecessary parameters

### DIFF
--- a/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
+++ b/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
@@ -45,12 +45,7 @@ namespace FunctionsNetHost
 
             unsafe
             {
-                var parameters = new HostFxr.hostfxr_initialize_parameters
-                {
-                    size = sizeof(HostFxr.hostfxr_initialize_parameters)
-                };
-
-                var error = HostFxr.Initialize(1, new[] { assemblyPath }, ref parameters, out _hostContextHandle);
+                var error = HostFxr.Initialize(1, new[] { assemblyPath }, IntPtr.Zero, out _hostContextHandle);
 
                 if (_hostContextHandle == IntPtr.Zero)
                 {
@@ -95,8 +90,8 @@ namespace FunctionsNetHost
 
                 if (_hostContextHandle != IntPtr.Zero)
                 {
-                    NativeLibrary.Free(_hostContextHandle);
-                    Logger.LogTrace($"Freed hostcontext handle");
+                    HostFxr.Close(_hostContextHandle);
+                    Logger.LogTrace($"Closed hostcontext handle");
                     _hostContextHandle = IntPtr.Zero;
                 }
 

--- a/host/src/FunctionsNetHost/AppLoader/HostFxr.cs
+++ b/host/src/FunctionsNetHost/AppLoader/HostFxr.cs
@@ -14,37 +14,33 @@ namespace FunctionsNetHost
             public char* dotnet_root;
         };
 
-        [LibraryImport("hostfxr", EntryPoint = "hostfxr_initialize_for_dotnet_command_line")]
-        public unsafe static partial int Initialize(
-                int argc,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = 
+        [LibraryImport("hostfxr", EntryPoint = "hostfxr_initialize_for_dotnet_command_line",
 #if OS_LINUX
-    UnmanagedType.LPStr
+            StringMarshalling = StringMarshalling.Utf8
 #else
-     UnmanagedType.LPWStr
+            StringMarshalling = StringMarshalling.Utf16
 #endif
-            )] string[] argv,
-                ref hostfxr_initialize_parameters parameters,
-                out IntPtr host_context_handle
-            );
+        )]
+        public unsafe static partial int Initialize(
+            int argc,
+            string[] argv,
+            IntPtr parameters,
+            out IntPtr host_context_handle
+        );
 
         [LibraryImport("hostfxr", EntryPoint = "hostfxr_run_app")]
         public static partial int Run(IntPtr host_context_handle);
 
-        [LibraryImport("hostfxr", EntryPoint = "hostfxr_set_runtime_property_value")]
-        public static partial int SetAppContextData(IntPtr host_context_handle, [MarshalAs(
+        [LibraryImport("hostfxr", EntryPoint = "hostfxr_set_runtime_property_value",
 #if OS_LINUX
-    UnmanagedType.LPStr
+            StringMarshalling = StringMarshalling.Utf8
 #else
-     UnmanagedType.LPWStr
+            StringMarshalling = StringMarshalling.Utf16
 #endif
-            )] string name, [MarshalAs(
-#if OS_LINUX
-    UnmanagedType.LPStr
-#else
-     UnmanagedType.LPWStr
-#endif
-            )] string value);
+        )]
+        public static partial int SetAppContextData(IntPtr host_context_handle, string name, string value);
 
+        [LibraryImport("hostfxr", EntryPoint = "hostfxr_close")]
+        public static partial int Close(IntPtr host_context_handle);
     }
 }


### PR DESCRIPTION
- Call `hostfxr_close` in AppLoader instead of trying to free the handle
- Don't create/pass optional `hostfxr_initialize_parameters` when initializing
- Use `StringMarshalling` property on `LibraryImport` to set marshalling for all strings in the function

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
