### PR TITLE
Added default encoding in case it is not specified by the caller

### DIFF
--- a/src/DotNetWorker.Core/Http/HttpRequestDataExtensions.cs
+++ b/src/DotNetWorker.Core/Http/HttpRequestDataExtensions.cs
@@ -5,12 +5,11 @@ using System;
 using System.IO;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Azure.Core.Serialization;
 using System.Threading;
-using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Core.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.Functions.Worker.Http
 {
@@ -37,7 +36,7 @@ namespace Microsoft.Azure.Functions.Worker.Http
                 return null;
             }
 
-            using (var reader = new StreamReader(request.Body, bufferSize: 1024, detectEncodingFromByteOrderMarks: true, encoding: encoding, leaveOpen: true))
+            using (var reader = new StreamReader(request.Body, bufferSize: 1024, detectEncodingFromByteOrderMarks: true, encoding: encoding ?? Encoding.UTF8, leaveOpen: true))
             {
                 return await reader.ReadToEndAsync();
             }
@@ -61,7 +60,7 @@ namespace Microsoft.Azure.Functions.Worker.Http
                 return null;
             }
 
-            using (var reader = new StreamReader(request.Body, bufferSize: 1024, detectEncodingFromByteOrderMarks: true, encoding: encoding, leaveOpen: true))
+            using (var reader = new StreamReader(request.Body, bufferSize: 1024, detectEncodingFromByteOrderMarks: true, encoding: encoding ?? Encoding.UTF8, leaveOpen: true))
             {
                 return reader.ReadToEnd();
             }
@@ -123,7 +122,6 @@ namespace Microsoft.Azure.Functions.Worker.Http
 
             return new ValueTask<T?>(result.AsTask().ContinueWith(t => TryCast(t.Result)));
         }
-
 
         /// <summary>
         /// Creates a response for the the provided <see cref="HttpRequestData"/>.

--- a/test/DotNetWorkerTests/Http/HttpRequestDataExtensionsTests.cs
+++ b/test/DotNetWorkerTests/Http/HttpRequestDataExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -15,6 +16,101 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 {
     public class HttpRequestDataExtensionsTests
     {
+        /// <summary>
+        /// Tests if ReadAsString throws ArgumentNullException when the HttpRequestData is null.
+        /// </summary>
+        [Fact]
+        public void ReadAsString_RequestIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange, Act & Assert
+            Assert.Throws<ArgumentNullException>(() => HttpRequestDataExtensions.ReadAsString(null!));
+        }
+
+        /// <summary>
+        /// Tests if ReadAsString correctly reads the body with the default UTF-8 encoding.
+        /// </summary>
+        [Fact]
+        public void ReadAsString_BodyIsNotNull_ReadsBodyCorrectly()
+        {
+            // Arrange
+            FunctionContext context = TestFunctionContext.Create();
+            var body = "Test String";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+            var request = new TestHttpRequestData(context, body: stream);
+
+            // Act
+            var result = request.ReadAsString();
+
+            // Assert
+            Assert.Equal("Test String", result);
+        }
+
+        /// <summary>
+        /// Tests if ReadAsString correctly reads the body with a specified encoding.
+        /// </summary>
+        [Fact]
+        public void ReadAsString_WithEncoding_ReadsBodyCorrectly()
+        {
+            // Arrange
+            FunctionContext context = TestFunctionContext.Create();
+            var body = "Test String";
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes(body));
+            var request = new TestHttpRequestData(context, body: stream);
+
+            // Act
+            var result = request.ReadAsString(Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("Test String", result);
+        }
+
+        /// <summary>
+        /// Tests if ReadAsStringAsync throws ArgumentNullException when the HttpRequestData is null.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsStringAsync_RequestIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange, Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => HttpRequestDataExtensions.ReadAsStringAsync(null!));
+        }
+
+        /// <summary>
+        /// Tests if ReadAsStringAsync correctly reads the body with the default UTF-8 encoding.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsStringAsync_BodyIsNotNull_ReadsBodyCorrectly()
+        {
+            // Arrange
+            FunctionContext context = TestFunctionContext.Create();
+            var body = "Test String";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+            var request = new TestHttpRequestData(context, body: stream);
+
+            // Act
+            var result = await request.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal("Test String", result);
+        }
+
+        /// <summary>
+        /// Tests if ReadAsStringAsync correctly reads the body with a specified encoding.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsStringAsync_WithEncoding_ReadsBodyCorrectly()
+        {
+            // Arrange
+            FunctionContext context = TestFunctionContext.Create();
+            var body = "Test String";
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes(body));
+            var request = new TestHttpRequestData(context, body: stream);
+
+            // Act
+            var result = await request.ReadAsStringAsync(Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("Test String", result);
+        }
 
         [Fact]
         public async Task ReadAsJsonAsync_SimpleOverload_AppliesDefaults()
@@ -60,4 +156,3 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         }
     }
 }
-


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1986 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
