### PR TITLE
Run worker pipeline on extension changes

### DIFF
--- a/src/ci.yml
+++ b/src/ci.yml
@@ -24,6 +24,7 @@ pr:
     - sdk/
     - samples/FunctionApp
     - tools/
+    - extensions/
 
 jobs:
 - job: "Build_And_Test_Windows"


### PR DESCRIPTION
This is a short-term fix to prevent more accidental check-ins to extension changes without running the unit and E2E tests.