### PR TITLE
[ApplicationInsights] removing env var reads from hot path

### DIFF
--- a/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
+++ b/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.ApplicationInsights</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.ApplicationInsights</RootNamespace>
     <MajorProductVersion>1</MajorProductVersion>
-    <MinorProductVersion>0</MinorProductVersion>
+    <MinorProductVersion>1</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <BeforePack>$(BeforePack);GetReleaseNotes</BeforePack>

--- a/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
+++ b/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
@@ -9,6 +9,7 @@
     <MinorProductVersion>1</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <VersionSuffix>-preview1</VersionSuffix>
     <BeforePack>$(BeforePack);GetReleaseNotes</BeforePack>
   </PropertyGroup>
 

--- a/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsExtensions.cs
+++ b/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsExtensions.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Azure.Functions.Worker
                 throw new ArgumentNullException(nameof(services));
             }
 
+            services.AddSingleton<IConfigureOptions<AppServiceOptions>, AppServiceOptionsInitializer>();
+            services.AddSingleton<AppServiceEnvironmentVariableMonitor>();
+            services.AddSingleton<IOptionsChangeTokenSource<AppServiceOptions>>(p => p.GetRequiredService<AppServiceEnvironmentVariableMonitor>());
+            services.AddSingleton<IHostedService>(p => p.GetRequiredService<AppServiceEnvironmentVariableMonitor>());
+
             services.AddSingleton<FunctionsRoleInstanceProvider>();
 
             services.TryAddEnumerable(ServiceDescriptor.Singleton<ITelemetryInitializer, FunctionsTelemetryInitializer>());

--- a/src/DotNetWorker.ApplicationInsights/Initializers/AppServiceEnvironmentVariableMonitor.cs
+++ b/src/DotNetWorker.ApplicationInsights/Initializers/AppServiceEnvironmentVariableMonitor.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers;
+
+internal class AppServiceEnvironmentVariableMonitor : BackgroundService, IOptionsChangeTokenSource<AppServiceOptions>
+{
+    private readonly TimeSpan _refreshInterval;
+
+    private IChangeToken _changeToken;
+    private CancellationTokenSource _cancellationTokenSource = new();
+
+    private readonly Dictionary<string, string?> _monitoredVariableCache = new(StringComparer.OrdinalIgnoreCase);
+
+    public AppServiceEnvironmentVariableMonitor() : this(TimeSpan.FromSeconds(5))
+    {
+    }
+
+    public AppServiceEnvironmentVariableMonitor(TimeSpan refreshInterval)
+    {
+        _refreshInterval = refreshInterval;
+        _changeToken = new CancellationChangeToken(_cancellationTokenSource.Token);
+    }
+
+    public string Name => string.Empty;
+
+    public IChangeToken GetChangeToken() => _changeToken;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            bool changeDetected = false;
+
+            foreach (string envVar in AppServiceOptionsInitializer.EnvironmentVariablesToMonitor)
+            {
+                string? currentVal = Environment.GetEnvironmentVariable(envVar);
+                _monitoredVariableCache.TryGetValue(envVar, out string? cachedVal);
+
+                if (!string.Equals(currentVal, cachedVal, StringComparison.Ordinal))
+                {
+                    changeDetected = true;
+                    _monitoredVariableCache[envVar] = currentVal;
+                }
+            }
+
+            if (changeDetected)
+            {
+                var oldTokenSource = Interlocked.Exchange(ref _cancellationTokenSource, new CancellationTokenSource());
+                Interlocked.Exchange(ref _changeToken, new CancellationChangeToken(_cancellationTokenSource.Token));
+
+                if (!oldTokenSource.IsCancellationRequested)
+                {
+                    oldTokenSource.Cancel();
+                    oldTokenSource.Dispose();
+                }
+            }
+
+            try
+            {
+                await Task.Delay(_refreshInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // happens during normal shutdown
+                break;
+            }
+        }
+    }
+}

--- a/src/DotNetWorker.ApplicationInsights/Initializers/AppServiceOptions.cs
+++ b/src/DotNetWorker.ApplicationInsights/Initializers/AppServiceOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers;
+
+internal class AppServiceOptions
+{
+    public string? AzureWebsiteName { get; set; }
+
+    public string? AzureWebsiteSlotName { get; set; }
+
+    public string? AzureWebsiteCloudRoleName { get; set; }
+}
+

--- a/src/DotNetWorker.ApplicationInsights/Initializers/AppServiceOptionsInitializer.cs
+++ b/src/DotNetWorker.ApplicationInsights/Initializers/AppServiceOptionsInitializer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers;
+using Microsoft.Extensions.Options;
+
+internal class AppServiceOptionsInitializer : IConfigureOptions<AppServiceOptions>
+{
+    internal const string AzureWebsiteName = "WEBSITE_SITE_NAME";
+    internal const string AzureWebsiteSlotName = "WEBSITE_SLOT_NAME";
+    internal const string AzureWebsiteCloudRoleName = "WEBSITE_CLOUD_ROLENAME";
+    internal const string DefaultProductionSlotName = "production";
+
+    internal static string[] EnvironmentVariablesToMonitor = [AzureWebsiteName, AzureWebsiteSlotName, AzureWebsiteCloudRoleName];
+
+    public void Configure(AppServiceOptions options)
+    {
+        options.AzureWebsiteName = Environment.GetEnvironmentVariable(AzureWebsiteName);
+        options.AzureWebsiteCloudRoleName = Environment.GetEnvironmentVariable(AzureWebsiteCloudRoleName);
+
+        // Compute the slot name by appending non-production slot to the site name (i.e. mysite-staging)
+        string slotName = Environment.GetEnvironmentVariable(AzureWebsiteSlotName);
+        options.AzureWebsiteSlotName = GetAzureWebsiteUniqueSlotName(options.AzureWebsiteName, slotName);
+    }
+
+    /// <summary>
+    /// Gets a value that uniquely identifies the site and slot.
+    /// </summary>
+    private static string? GetAzureWebsiteUniqueSlotName(string? websiteName, string? slotName)
+    {
+        if (!string.IsNullOrEmpty(slotName) &&
+            !string.Equals(slotName, DefaultProductionSlotName, StringComparison.OrdinalIgnoreCase))
+        {
+            websiteName += $"-{slotName}";
+        }
+
+        return websiteName?.ToLowerInvariant();
+    }
+}

--- a/src/DotNetWorker.ApplicationInsights/Initializers/AppServiceOptionsInitializer.cs
+++ b/src/DotNetWorker.ApplicationInsights/Initializers/AppServiceOptionsInitializer.cs
@@ -9,7 +9,7 @@ internal class AppServiceOptionsInitializer : IConfigureOptions<AppServiceOption
     internal const string AzureWebsiteCloudRoleName = "WEBSITE_CLOUD_ROLENAME";
     internal const string DefaultProductionSlotName = "production";
 
-    internal static string[] EnvironmentVariablesToMonitor = [AzureWebsiteName, AzureWebsiteSlotName, AzureWebsiteCloudRoleName];
+    internal static string[] EnvironmentVariablesToMonitor = new[] { AzureWebsiteName, AzureWebsiteSlotName, AzureWebsiteCloudRoleName };
 
     public void Configure(AppServiceOptions options)
     {

--- a/src/DotNetWorker.ApplicationInsights/release_notes.md
+++ b/src/DotNetWorker.ApplicationInsights/release_notes.md
@@ -1,3 +1,3 @@
 ## What's Changed
 
-- GA release (no functional changes)
+- Moving hot-path environment variable checks to a background task (#1996)

--- a/test/DotNetWorkerTests/ApplicationInsights/EndToEndTests.cs
+++ b/test/DotNetWorkerTests/ApplicationInsights/EndToEndTests.cs
@@ -31,8 +31,6 @@ public class EndToEndTests
     private IInvocationFeaturesFactory _invocationFeaturesFactory;
     private readonly AppInsightsFunctionDefinition _funcDefinition = new();
 
-    private bool _isSwapped = false;
-
     public EndToEndTests()
     {
         _channel = new TestTelemetryChannel();

--- a/test/DotNetWorkerTests/DotNetWorkerTests.csproj
+++ b/test/DotNetWorkerTests/DotNetWorkerTests.csproj
@@ -9,6 +9,7 @@
     <LangVersion>preview</LangVersion>
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
     <Nullable>disable</Nullable>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
resolves #1827 

During the (long) investigation into the issue above we have found that in some cases environment variable reads can be very expensive in App Service. But we cannot fully cache the variables because during certain App Service events (slot swaps, for example), the environment variables can change out from underneath us. 

This change adds a background monitor to watch for the changes in these few environment variables, then triggers an Options change when it occurs. This keeps the expensive reads off the hot path.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)