### PR TITLE
Fix cosmos connection name in local.settings.json

### DIFF
--- a/samples/Extensions/local.settings.json
+++ b/samples/Extensions/local.settings.json
@@ -3,7 +3,7 @@
     "Values": {
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "AzureWebJobsStorage": "",
-        "CosmosConnection": "",
+        "CosmosDBConnection": "",
         "CosmosDb": "ItemDb",
         "CosmosContainerIn": "ItemContainerIn",
         "CosmosContainerOut": "ItemContainerOut",


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

The cosmos db extension samples expect the connection to be called `CosmosDBConnection` but in the local.settings.json file, it is specified as `CosmosConnection`. This fixes that.

### Pull request checklist

* [ x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
This extension doesn't have any tests.



