### PR TITLE
fix service bus sample

### DIFF
--- a/samples/Extensions/ServiceBus/ServiceBusReceivedMessageFunctions.cs
+++ b/samples/Extensions/ServiceBus/ServiceBusReceivedMessageFunctions.cs
@@ -76,7 +76,7 @@ namespace SampleApp
             _logger.LogInformation("Delivery Count: {count}", deliveryCount);
         }
         //<docsnippet_servicebus_message_actions>
-        [Function(nameof(ServiceBusReceivedMessageFunction))]
+        [Function(nameof(ServiceBusMessageActionsFunction))]
         public async Task ServiceBusMessageActionsFunction(
             [ServiceBusTrigger("queue", Connection = "ServiceBusConnection")]
             ServiceBusReceivedMessage message,


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

The service bus extension sample has a bug where the Function nameof attribute was cut/pasted from the function above it, causing the sample to not compile because of a duplicate function name. This fixes that.

resolves #issue_for_this_pr

### Pull request checklist

* [x ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
This extension does not have any tests.
