### PR TITLE
Default to optimized function executor

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -39,7 +39,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         <FunctionsEnableMetadataSourceGen>$(FunctionsEnableWorkerIndexing)</FunctionsEnableMetadataSourceGen>
         <FunctionsAutoRegisterGeneratedMetadataProvider>$(FunctionsEnableWorkerIndexing)</FunctionsAutoRegisterGeneratedMetadataProvider>
 
-        <FunctionsEnableExecutorSourceGen Condition="$(FunctionsEnableExecutorSourceGen) == ''">false</FunctionsEnableExecutorSourceGen>
+        <FunctionsEnableExecutorSourceGen Condition="$(FunctionsEnableExecutorSourceGen) == '' Or $(FunctionsEnableExecutorSourceGen)">true</FunctionsEnableExecutorSourceGen>
         <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor) == ''">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
         <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor)">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
     </PropertyGroup>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -6,5 +6,7 @@
 
 ### Microsoft.Azure.Functions.Worker.Sdk 1.16.0 (meta package)
 
+- Default to optimized function executor.
+    * If you have `<FunctionsEnableExecutorSourceGen>True</FunctionsEnableExecutorSourceGen>` in your `.csproj` file, you can remove that line after upgrading Azure.Functions.Worker.Sdk version 1.16.0 or later.
 - Default to source-generated function metadata (#1968).
     * If you have `<FunctionsEnableWorkerIndexing>True</FunctionsEnableWorkerIndexing>` in your `.csproj` file, you can remove that line after upgrading Azure.Functions.Worker.Sdk version 1.16.0 or later.


### PR DESCRIPTION
Fixes #2011 

With this change we will register the optimized function executor. This behavior can be prevented by setting `<FunctionsEnableExecutorSourceGen>false</FunctionsEnableExecutorSourceGen>` in the `.csproj` file

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

