### PR TITLE
Change binding type name to camel case in source-gen

### DIFF
--- a/sdk/Sdk.Generators/Extensions/StringExtensions.cs
+++ b/sdk/Sdk.Generators/Extensions/StringExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
         {
             if (!string.IsNullOrEmpty(str))
             {
-                return Char.ToLowerInvariant(str.First()) + str.Substring(1);
+                return Char.ToLowerInvariant(str[0]) + str.Substring(1);
             }
             else
             {

--- a/sdk/Sdk.Generators/Extensions/StringExtensions.cs
+++ b/sdk/Sdk.Generators/Extensions/StringExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 {
@@ -28,6 +29,21 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Returns a copy of the string where the first character is in lower case.
+        /// </summary>
+        public static string ToLowerFirstCharacter(this string str)
+        {
+            if (!string.IsNullOrEmpty(str))
+            {
+                return Char.ToLowerInvariant(str.First()) + str.Substring(1);
+            }
+            else
+            {
+                return str;
+            }
         }
     }
 }

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.Parser.cs
@@ -4,13 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 {

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.Parser.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.Parser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -552,7 +553,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 string attributeName = bindingAttrData.AttributeClass!.Name;
 
                 // properly format binding types by removing "Attribute" and "Input" descriptors
-                string bindingType = attributeName.TrimStringsFromEnd(_functionsStringNamesToRemove);
+                string bindingType = attributeName.TrimStringsFromEnd(_functionsStringNamesToRemove).ToLowerFirstCharacter();
 
                 // Set binding direction
                 string bindingDirection = SymbolEqualityComparer.Default.Equals(bindingAttrData.AttributeClass?.BaseType, _knownFunctionMetadataTypes.OutputBindingAttribute) ? "Out" : "In";

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -10,3 +10,4 @@
     * If you have `<FunctionsEnableExecutorSourceGen>True</FunctionsEnableExecutorSourceGen>` in your `.csproj` file, you can remove that line after upgrading Azure.Functions.Worker.Sdk version 1.16.0 or later.
 - Default to source-generated function metadata (#1968).
     * If you have `<FunctionsEnableWorkerIndexing>True</FunctionsEnableWorkerIndexing>` in your `.csproj` file, you can remove that line after upgrading Azure.Functions.Worker.Sdk version 1.16.0 or later.
+- Fixed casing bug in source-generation. Binding types were changed from pascal case to camel case to match legacy generation (#2022).

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/AutoConfigureStartupTypeTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/AutoConfigureStartupTypeTests.cs
@@ -80,7 +80,7 @@ namespace TestProject
         {{
             var metadataList = new List<IFunctionMetadata>();
             var Function0RawBindings = new List<string>();
-            Function0RawBindings.Add(@""{{""""name"""":""""req"""",""""type"""":""""HttpTrigger"""",""""direction"""":""""In"""",""""authLevel"""":""""Admin"""",""""methods"""":[""""get"""",""""post""""],""""route"""":""""/api2""""}}"");
+            Function0RawBindings.Add(@""{{""""name"""":""""req"""",""""type"""":""""httpTrigger"""",""""direction"""":""""In"""",""""authLevel"""":""""Admin"""",""""methods"""":[""""get"""",""""post""""],""""route"""":""""/api2""""}}"");
 
             var Function0 = new DefaultFunctionMetadata
             {{

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/DependentAssemblyTest.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/DependentAssemblyTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
                             Function0RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function0);
                             var Function1RawBindings = new List<string>();
-                            Function1RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function1RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
                             Function1RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
                 
                             var Function1 = new DefaultFunctionMetadata
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function1);
                             var Function2RawBindings = new List<string>();
-                            Function2RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function2RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
                             Function2RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
                 
                             var Function2 = new DefaultFunctionMetadata
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function2);
                             var Function3RawBindings = new List<string>();
-                            Function3RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function3RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
                             Function3RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
                 
                             var Function3 = new DefaultFunctionMetadata

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""One""{{rawBindingSuffix}}
+                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""One""{{rawBindingSuffix}}
 
                 """);
 
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many""{{rawBindingSuffix}}
+                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many""{{rawBindingSuffix}}
 
 
                 """);
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many""}");
+                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many""}");
 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""String""}");
+                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""String""}");
 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -468,7 +468,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function0);
                             var Function1RawBindings = new List<string>();
-                            Function1RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""String""}");
+                            Function1RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""String""}");
 
                             var Function1 = new DefaultFunctionMetadata
                             {
@@ -480,7 +480,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function1);
                             var Function2RawBindings = new List<string>();
-                            Function2RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""String""}");
+                            Function2RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""String""}");
 
                             var Function2 = new DefaultFunctionMetadata
                             {
@@ -492,7 +492,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function2);
                             var Function3RawBindings = new List<string>();
-                            Function3RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""String""}");
+                            Function3RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""String""}");
 
                             var Function3 = new DefaultFunctionMetadata
                             {
@@ -605,7 +605,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""Binary""}");
+                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""Binary""}");
 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -617,7 +617,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function0);
                             var Function1RawBindings = new List<string>();
-                            Function1RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""Binary""}");
+                            Function1RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many"",""dataType"":""Binary""}");
 
                             var Function1 = new DefaultFunctionMetadata
                             {
@@ -717,7 +717,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many""}");
+                            Function0RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many""}");
 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -729,7 +729,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function0);
                             var Function1RawBindings = new List<string>();
-                            Function1RawBindings.Add(@"{""name"":""input"",""type"":""EventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many""}");
+                            Function1RawBindings.Add(@"{""name"":""input"",""type"":""eventHubTrigger"",""direction"":""In"",""eventHubName"":""test"",""connection"":""EventHubConnectionAppSetting"",""cardinality"":""Many""}");
 
                             var Function1 = new DefaultFunctionMetadata
                             {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
                             Function0RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Admin"",""methods"":[""get"",""post""],""route"":""/api2""}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Admin"",""methods"":[""get"",""post""],""route"":""/api2""}");
 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""methods"":[""get""],""dataType"":""String""}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""methods"":[""get""],""dataType"":""String""}");
                             Function0RawBindings.Add(@"{""name"":""httpResponseProp"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
@@ -101,8 +101,8 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
-                            Function0RawBindings.Add(@"{""name"":""Name"",""type"":""Queue"",""direction"":""Out"",""queueName"":""functionstesting2"",""connection"":""AzureWebJobsStorage""}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function0RawBindings.Add(@"{""name"":""Name"",""type"":""queue"",""direction"":""Out"",""queueName"":""functionstesting2"",""connection"":""AzureWebJobsStorage""}");
                             Function0RawBindings.Add(@"{""name"":""HttpResponse"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata
@@ -215,9 +215,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
-                            Function0RawBindings.Add(@"{""name"":""myBlob"",""type"":""Blob"",""direction"":""In"",""properties"":{""supportsDeferredBinding"":""True""},""blobPath"":""test-samples/sample1.txt"",""connection"":""AzureWebJobsStorage"",""dataType"":""String""}");
-                            Function0RawBindings.Add(@"{""name"":""Book"",""type"":""Queue"",""direction"":""Out"",""queueName"":""functionstesting2"",""connection"":""AzureWebJobsStorage""}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function0RawBindings.Add(@"{""name"":""myBlob"",""type"":""blob"",""direction"":""In"",""properties"":{""supportsDeferredBinding"":""True""},""blobPath"":""test-samples/sample1.txt"",""connection"":""AzureWebJobsStorage"",""dataType"":""String""}");
+                            Function0RawBindings.Add(@"{""name"":""Book"",""type"":""queue"",""direction"":""Out"",""queueName"":""functionstesting2"",""connection"":""AzureWebJobsStorage""}");
                             Function0RawBindings.Add(@"{""name"":""HttpResponse"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get""]}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get""]}");
                             Function0RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata
@@ -404,7 +404,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""timer"",""type"":""TimerTrigger"",""direction"":""In"",""schedule"":""0 0 0 * * *"",""runOnStartup"":""False""}");
+                            Function0RawBindings.Add(@"{""name"":""timer"",""type"":""timerTrigger"",""direction"":""In"",""schedule"":""0 0 0 * * *"",""runOnStartup"":""False""}");
 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -490,7 +490,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""myReq"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Admin"",""methods"":[""get"",""Post""],""route"":""/api2""}");
+                            Function0RawBindings.Add(@"{""name"":""myReq"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Admin"",""methods"":[""get"",""Post""],""route"":""/api2""}");
                             Function0RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata
@@ -586,7 +586,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
                             Function0RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata
@@ -599,7 +599,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function0);
                             var Function1RawBindings = new List<string>();
-                            Function1RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function1RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
                             Function1RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function1 = new DefaultFunctionMetadata
@@ -612,7 +612,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function1);
                             var Function2RawBindings = new List<string>();
-                            Function2RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function2RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
                             Function2RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function2 = new DefaultFunctionMetadata

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/NestedTypesTest.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/NestedTypesTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""User"",""methods"":[""get""]}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""User"",""methods"":[""get""]}");
                             Function0RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""HttpTrigger"",""direction"":""In"",""authLevel"":""User"",""methods"":[""get""]}");
+                            Function0RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""User"",""methods"":[""get""]}");
                             Function0RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
 
                             var Function0 = new DefaultFunctionMetadata

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/RetryOptionsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/RetryOptionsTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""timerInfo"",""type"":""TimerTrigger"",""direction"":""In"",""schedule"":""0 */5 * * * *""}");
+                            Function0RawBindings.Add(@"{""name"":""timerInfo"",""type"":""timerTrigger"",""direction"":""In"",""schedule"":""0 */5 * * * *""}");
                 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""timerInfo"",""type"":""TimerTrigger"",""direction"":""In"",""schedule"":""0 */5 * * * *""}");
+                            Function0RawBindings.Add(@"{""name"":""timerInfo"",""type"":""timerTrigger"",""direction"":""In"",""schedule"":""0 */5 * * * *""}");
                 
                             var Function0 = new DefaultFunctionMetadata
                             {

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -88,8 +88,8 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""$return"",""type"":""Queue"",""direction"":""Out"",""queueName"":""test-output-dotnet-isolated""}");
-                            Function0RawBindings.Add(@"{""name"":""message"",""type"":""QueueTrigger"",""direction"":""In"",""queueName"":""test-input-dotnet-isolated"",""dataType"":""String""}");
+                            Function0RawBindings.Add(@"{""name"":""$return"",""type"":""queue"",""direction"":""Out"",""queueName"":""test-output-dotnet-isolated""}");
+                            Function0RawBindings.Add(@"{""name"":""message"",""type"":""queueTrigger"",""direction"":""In"",""queueName"":""test-input-dotnet-isolated"",""dataType"":""String""}");
 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -194,8 +194,8 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         {
                             var metadataList = new List<IFunctionMetadata>();
                             var Function0RawBindings = new List<string>();
-                            Function0RawBindings.Add(@"{""name"":""$return"",""type"":""Blob"",""direction"":""Out"",""blobPath"":""container1/hello.txt"",""connection"":""MyOtherConnection""}");
-                            Function0RawBindings.Add(@"{""name"":""queuePayload"",""type"":""QueueTrigger"",""direction"":""In"",""queueName"":""queueName"",""connection"":""MyConnection"",""dataType"":""String""}");
+                            Function0RawBindings.Add(@"{""name"":""$return"",""type"":""blob"",""direction"":""Out"",""blobPath"":""container1/hello.txt"",""connection"":""MyOtherConnection""}");
+                            Function0RawBindings.Add(@"{""name"":""queuePayload"",""type"":""queueTrigger"",""direction"":""In"",""queueName"":""queueName"",""connection"":""MyConnection"",""dataType"":""String""}");
 
                             var Function0 = new DefaultFunctionMetadata
                             {
@@ -207,8 +207,8 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function0);
                             var Function1RawBindings = new List<string>();
-                            Function1RawBindings.Add(@"{""name"":""$return"",""type"":""Queue"",""direction"":""Out"",""queueName"":""queue2""}");
-                            Function1RawBindings.Add(@"{""name"":""blob"",""type"":""BlobTrigger"",""direction"":""In"",""properties"":{""supportsDeferredBinding"":""True""},""path"":""container2/%file%"",""source"":""EventGrid"",""dataType"":""String""}");
+                            Function1RawBindings.Add(@"{""name"":""$return"",""type"":""queue"",""direction"":""Out"",""queueName"":""queue2""}");
+                            Function1RawBindings.Add(@"{""name"":""blob"",""type"":""blobTrigger"",""direction"":""In"",""properties"":{""supportsDeferredBinding"":""True""},""path"":""container2/%file%"",""source"":""EventGrid"",""dataType"":""String""}");
 
                             var Function1 = new DefaultFunctionMetadata
                             {
@@ -220,8 +220,8 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             };
                             metadataList.Add(Function1);
                             var Function2RawBindings = new List<string>();
-                            Function2RawBindings.Add(@"{""name"":""$return"",""type"":""Queue"",""direction"":""Out"",""queueName"":""queue2""}");
-                            Function2RawBindings.Add(@"{""name"":""blobs"",""type"":""Blob"",""direction"":""In"",""properties"":{""supportsDeferredBinding"":""True""},""blobPath"":""container2""}");
+                            Function2RawBindings.Add(@"{""name"":""$return"",""type"":""queue"",""direction"":""Out"",""queueName"":""queue2""}");
+                            Function2RawBindings.Add(@"{""name"":""blobs"",""type"":""blob"",""direction"":""In"",""properties"":{""supportsDeferredBinding"":""True""},""blobPath"":""container2""}");
 
                             var Function2 = new DefaultFunctionMetadata
                             {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Changes binding type name to camel case in source-gen as customers and partner services may check casing. Consistent with legacy behavior (#589).

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
