### PR TITLE
Ensure generated types are properly documented

### DIFF
--- a/sdk/Sdk.Generators/ExtensionStartupRunnerGenerator.cs
+++ b/sdk/Sdk.Generators/ExtensionStartupRunnerGenerator.cs
@@ -96,8 +96,13 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
        
                    namespace {{namespaceValue}}
                    {
+                       [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                        internal class WorkerExtensionStartupCodeExecutor : WorkerExtensionStartup
                        {
+                           /// <summary>
+                           /// Configures the worker to register extension startup services.
+                           /// </summary>
+                           /// <param name="applicationBuilder">The <see cref="IFunctionsWorkerApplicationBuilder"/> to configure.</param>
                            public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
                            {
                    {{startupCodeExecutor}}

--- a/sdk/Sdk.Generators/FunctionExecutor/FunctionExecutorGenerator.Emitter.cs
+++ b/sdk/Sdk.Generators/FunctionExecutor/FunctionExecutorGenerator.Emitter.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                          using Microsoft.Azure.Functions.Worker.Invocation;
                          namespace {{FunctionsUtil.GetNamespaceForGeneratedCode(context)}}
                          {
+                             [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                              internal class DirectFunctionExecutor : IFunctionExecutor
                              {
                                  private readonly IFunctionActivator _functionActivator;
@@ -37,11 +38,16 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                                      _functionActivator = functionActivator ?? throw new ArgumentNullException(nameof(functionActivator));
                                  }
 
+                                 /// <inheritdoc/>
                                  public async ValueTask ExecuteAsync(FunctionContext context)
                                  {
                                      {{GetMethodBody(functions)}}
                                  }
                              }
+
+                             /// <summary>
+                             /// Extension methods to enable registration of the custom <see cref="IFunctionExecutor"/> implementation generated for the current worker.
+                             /// </summary>
                              public static class FunctionExecutorHostBuilderExtensions
                              {
                                  ///<summary>
@@ -86,8 +92,16 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 {
                     string result = $$"""
 
+                                      /// <summary>
+                                      /// Auto startup class to register the custom <see cref="IFunctionExecutor"/> implementation generated for the current worker.
+                                      /// </summary>
+                                      [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                                       public class FunctionExecutorAutoStartup : IAutoConfigureStartup
                                       {
+                                          /// <summary>
+                                          /// Configures the <see cref="IHostBuilder"/> to use the custom <see cref="IFunctionExecutor"/> implementation generated for the current worker.
+                                          /// </summary>
+                                          /// <param name="hostBuilder">The <see cref="IHostBuilder"/> instance to use for service registration.</param>
                                           public void Configure(IHostBuilder hostBuilder)
                                           {
                                               hostBuilder.ConfigureGeneratedFunctionExecutor();

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.Emitter.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.Emitter.cs
@@ -34,11 +34,16 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                          using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
                          using Microsoft.Extensions.DependencyInjection;
                          using Microsoft.Extensions.Hosting;
-                     
+
                          namespace {{FunctionsUtil.GetNamespaceForGeneratedCode(context)}}
                          {
+                             /// <summary>
+                             /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                             /// </summary>
+                             [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                              public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                              {
+                                 /// <inheritdoc/>
                                  public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                                  {
                                      var metadataList = new List<IFunctionMetadata>();
@@ -46,7 +51,10 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                                      return Task.FromResult(metadataList.ToImmutableArray());
                                  }
                              }
-                     
+
+                             /// <summary>
+                             /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                             /// </summary>
                              public static class WorkerHostBuilderFunctionMetadataProviderExtension
                              {
                                  ///<summary>
@@ -72,8 +80,16 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 {
                     string result = $$"""
 
+                                      /// <summary>
+                                      /// Auto startup class to register the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                                      /// </summary>
+                                      [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                                       public class FunctionMetadataProviderAutoStartup : IAutoConfigureStartup
                                       {
+                                          /// <summary>
+                                          /// Configures the <see cref="IHostBuilder"/> to use the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                                          /// </summary>
+                                          /// <param name="hostBuilder">The <see cref="IHostBuilder"/> instance to use for service registration.</param>
                                           public void Configure(IHostBuilder hostBuilder)
                                           {
                                               hostBuilder.ConfigureGeneratedFunctionMetadataProvider();

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -14,5 +14,7 @@
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 
-- Updated source generated versions of FunctionExecutor to use `global::` namespace prefix to avoid build errors for function class with the same name as its containing namespace. (#1993)
+- Updated source generated versions of IFunctionExecutor to use `global::` namespace prefix to avoid build errors for function class with the same name as its containing namespace. (#1993)
+- Updated source generated versions of IFunctionExecutor to include XML documentation for all public types and members
+- Updated source generated versions of IFunctionMedatadaProvider to include XML documentation for all public types and members
 

--- a/test/Sdk.Generator.Tests/ExtensionStartupRunnerGeneratorTests.cs
+++ b/test/Sdk.Generator.Tests/ExtensionStartupRunnerGeneratorTests.cs
@@ -39,8 +39,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                                     namespace TestProject
                                     {
+                                        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                                         internal class WorkerExtensionStartupCodeExecutor : WorkerExtensionStartup
                                         {
+                                            /// <summary>
+                                            /// Configures the worker to register extension startup services.
+                                            /// </summary>
+                                            /// <param name="applicationBuilder">The <see cref="IFunctionsWorkerApplicationBuilder"/> to configure.</param>
                                             public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
                                             {
                                                 try
@@ -103,8 +108,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                                     namespace MyCompany.MyProject.MyApp
                                     {
+                                        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                                         internal class WorkerExtensionStartupCodeExecutor : WorkerExtensionStartup
                                         {
+                                            /// <summary>
+                                            /// Configures the worker to register extension startup services.
+                                            /// </summary>
+                                            /// <param name="applicationBuilder">The <see cref="IFunctionsWorkerApplicationBuilder"/> to configure.</param>
                                             public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
                                             {
                                                 try

--- a/test/Sdk.Generator.Tests/FunctionExecutor/FunctionExecutorGeneratorTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionExecutor/FunctionExecutorGeneratorTests.cs
@@ -110,6 +110,7 @@ using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.Invocation;
 namespace TestProject
 {{
+    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal class DirectFunctionExecutor : IFunctionExecutor
     {{
         private readonly IFunctionActivator _functionActivator;
@@ -125,6 +126,7 @@ namespace TestProject
             _functionActivator = functionActivator ?? throw new ArgumentNullException(nameof(functionActivator));
         }}
 
+        /// <inheritdoc/>
         public async ValueTask ExecuteAsync(FunctionContext context)
         {{
             var inputBindingFeature = context.Features.Get<IFunctionInputBindingFeature>()!;
@@ -217,6 +219,7 @@ using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.Invocation;
 namespace MyCompany.MyProject.MyApp
 {{
+    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal class DirectFunctionExecutor : IFunctionExecutor
     {{
         private readonly IFunctionActivator _functionActivator;
@@ -230,6 +233,7 @@ namespace MyCompany.MyProject.MyApp
             _functionActivator = functionActivator ?? throw new ArgumentNullException(nameof(functionActivator));
         }}
 
+        /// <inheritdoc/>
         public async ValueTask ExecuteAsync(FunctionContext context)
         {{
             var inputBindingFeature = context.Features.Get<IFunctionInputBindingFeature>()!;
@@ -352,6 +356,7 @@ using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.Invocation;
 namespace TestProject
 {{
+    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal class DirectFunctionExecutor : IFunctionExecutor
     {{
         private readonly IFunctionActivator _functionActivator;
@@ -361,6 +366,7 @@ namespace TestProject
             _functionActivator = functionActivator ?? throw new ArgumentNullException(nameof(functionActivator));
         }}
 
+        /// <inheritdoc/>
         public async ValueTask ExecuteAsync(FunctionContext context)
         {{
             var inputBindingFeature = context.Features.Get<IFunctionInputBindingFeature>()!;
@@ -459,6 +465,7 @@ using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.Invocation;
 namespace TestProject
 {{
+    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal class DirectFunctionExecutor : IFunctionExecutor
     {{
         private readonly IFunctionActivator _functionActivator;
@@ -472,6 +479,7 @@ namespace TestProject
             _functionActivator = functionActivator ?? throw new ArgumentNullException(nameof(functionActivator));
         }}
 
+        /// <inheritdoc/>
         public async ValueTask ExecuteAsync(FunctionContext context)
         {{
             var inputBindingFeature = context.Features.Get<IFunctionInputBindingFeature>()!;
@@ -542,6 +550,7 @@ using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.Invocation;
 namespace TestProject
 {{
+    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal class DirectFunctionExecutor : IFunctionExecutor
     {{
         private readonly IFunctionActivator _functionActivator;
@@ -555,6 +564,7 @@ namespace TestProject
             _functionActivator = functionActivator ?? throw new ArgumentNullException(nameof(functionActivator));
         }}
 
+        /// <inheritdoc/>
         public async ValueTask ExecuteAsync(FunctionContext context)
         {{
             var inputBindingFeature = context.Features.Get<IFunctionInputBindingFeature>()!;
@@ -588,6 +598,10 @@ namespace TestProject
             if (includeAutoStartupType)
             {
                 return """
+
+                            /// <summary>
+                            /// Extension methods to enable registration of the custom <see cref="IFunctionExecutor"/> implementation generated for the current worker.
+                            /// </summary>
                             public static class FunctionExecutorHostBuilderExtensions
                             {
                                 ///<summary>
@@ -601,8 +615,16 @@ namespace TestProject
                                     });
                                 }
                             }
+                            /// <summary>
+                            /// Auto startup class to register the custom <see cref="IFunctionExecutor"/> implementation generated for the current worker.
+                            /// </summary>
+                            [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                             public class FunctionExecutorAutoStartup : IAutoConfigureStartup
                             {
+                                /// <summary>
+                                /// Configures the <see cref="IHostBuilder"/> to use the custom <see cref="IFunctionExecutor"/> implementation generated for the current worker.
+                                /// </summary>
+                                /// <param name="hostBuilder">The <see cref="IHostBuilder"/> instance to use for service registration.</param>
                                 public void Configure(IHostBuilder hostBuilder)
                                 {
                                     hostBuilder.ConfigureGeneratedFunctionExecutor();
@@ -612,6 +634,10 @@ namespace TestProject
             }
 
             return """
+
+                        /// <summary>
+                        /// Extension methods to enable registration of the custom <see cref="IFunctionExecutor"/> implementation generated for the current worker.
+                        /// </summary>
                         public static class FunctionExecutorHostBuilderExtensions
                         {
                             ///<summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/AutoConfigureStartupTypeTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/AutoConfigureStartupTypeTests.cs
@@ -74,8 +74,13 @@ using Microsoft.Extensions.Hosting;
 
 namespace TestProject
 {{
+    /// <summary>
+    /// Custom <see cref=""IFunctionMetadataProvider""/> implementation that returns function metadata definitions for the current worker.""/>
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
     {{
+        /// <inheritdoc/>
         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
         {{
             var metadataList = new List<IFunctionMetadata>();
@@ -116,6 +121,9 @@ namespace TestProject
             if (includeAutoStartupType)
             {
                 return """
+                            /// <summary>
+                            /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                            /// </summary>
                             public static class WorkerHostBuilderFunctionMetadataProviderExtension
                             {
                                 ///<summary>
@@ -131,8 +139,16 @@ namespace TestProject
                                     return builder;
                                 }
                             }
+                            /// <summary>
+                            /// Auto startup class to register the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                            /// </summary>
+                            [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                             public class FunctionMetadataProviderAutoStartup : IAutoConfigureStartup
                             {
+                                /// <summary>
+                                /// Configures the <see cref="IHostBuilder"/> to use the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                                /// </summary>
+                                /// <param name="hostBuilder">The <see cref="IHostBuilder"/> instance to use for service registration.</param>
                                 public void Configure(IHostBuilder hostBuilder)
                                 {
                                     hostBuilder.ConfigureGeneratedFunctionMetadataProvider();
@@ -142,6 +158,9 @@ namespace TestProject
             }
 
             return """
+                        /// <summary>
+                        /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                        /// </summary>
                         public static class WorkerHostBuilderFunctionMetadataProviderExtension
                         {
                             ///<summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/DependentAssemblyTest.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/DependentAssemblyTest.cs
@@ -74,8 +74,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -136,6 +141,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/EventHubsBindingsTests.cs
@@ -94,8 +94,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -120,6 +125,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             }
                         }
 
+                        /// <summary>
+                        /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                        /// </summary>
                         public static class WorkerHostBuilderFunctionMetadataProviderExtension
                         {
                             ///<summary>
@@ -219,8 +227,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -245,6 +258,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -311,8 +327,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -333,6 +354,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -450,8 +474,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -508,6 +537,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -599,8 +631,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -633,6 +670,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -711,8 +751,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -745,6 +790,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/HttpTriggerTests.cs
@@ -73,8 +73,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -96,6 +101,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -159,8 +167,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -181,6 +194,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -249,8 +265,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace MyCompany.MyProject.MyApp
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -272,6 +293,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/IntegratedTriggersAndBindingsTests.cs
@@ -95,8 +95,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -119,6 +124,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -209,8 +217,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -234,6 +247,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -311,8 +327,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -334,6 +355,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -398,8 +422,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -420,6 +449,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -484,8 +516,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -507,6 +544,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -580,8 +620,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -629,6 +674,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/NestedTypesTest.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/NestedTypesTest.cs
@@ -78,8 +78,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -101,6 +106,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -165,8 +173,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -188,6 +201,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/RetryOptionsTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/RetryOptionsTests.cs
@@ -79,8 +79,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -105,7 +110,10 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             return Task.FromResult(metadataList.ToImmutableArray());
                         }
                     }
-                
+
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -169,8 +177,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -196,7 +209,10 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                             return Task.FromResult(metadataList.ToImmutableArray());
                         }
                     }
-                
+
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/StorageBindingTests.cs
@@ -82,8 +82,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -105,6 +110,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>
@@ -188,8 +196,13 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
 
                 namespace TestProject
                 {
+                    /// <summary>
+                    /// Custom <see cref="IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+                    /// </summary>
+                    [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
                     public class GeneratedFunctionMetadataProvider : IFunctionMetadataProvider
                     {
+                        /// <inheritdoc/>
                         public Task<ImmutableArray<IFunctionMetadata>> GetFunctionMetadataAsync(string directory)
                         {
                             var metadataList = new List<IFunctionMetadata>();
@@ -237,6 +250,9 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                         }
                     }
 
+                    /// <summary>
+                    /// Extension methods to enable registration of the custom <see cref="IFunctionMetadataProvider"/> implementation generated for the current worker.
+                    /// </summary>
                     public static class WorkerHostBuilderFunctionMetadataProviderExtension
                     {
                         ///<summary>


### PR DESCRIPTION
Issue describing the changes in this PR

resolves #2027 

The changes ensure public types and members are documented. It also adds `EditorBrowsableAttribute` where appropriate to avoid having confusion with those APIs 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

