### PR TITLE
Handle self-contained application load

### DIFF
--- a/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
+++ b/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
@@ -1,10 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace FunctionsNetHost
 {
+    // If having problems with the managed host, enable the following:
+    // Environment.SetEnvironmentVariable("COREHOST_TRACE", "1");
+    // In Unix environment, you need to run the below command in the terminal to set the environment variable.
+    // export COREHOST_TRACE=1
+
     /// <summary>
     /// Manages loading hostfxr & worker assembly.
     /// </summary>
@@ -14,37 +20,35 @@ namespace FunctionsNetHost
         private IntPtr _hostContextHandle = IntPtr.Zero;
         private bool _disposed;
 
-        internal AppLoader()
-        {
-            LoadHostfxrLibrary();
-        }
-
-        private void LoadHostfxrLibrary()
-        {
-            // If having problems with the managed host, enable the following:
-            // Environment.SetEnvironmentVariable("COREHOST_TRACE", "1");
-            // In Unix environment, you need to run the below command in the terminal to set the environment variable.
-            // export COREHOST_TRACE=1
-
-            var hostfxrFullPath = NetHost.GetHostFxrPath();
-            Logger.LogTrace($"hostfxr path:{hostfxrFullPath}");
-
-            _hostfxrHandle = NativeLibrary.Load(hostfxrFullPath);
-            if (_hostfxrHandle == IntPtr.Zero)
-            {
-                Logger.Log($"Failed to load hostfxr. hostfxr path:{hostfxrFullPath}");
-                return;
-            }
-
-            Logger.LogTrace($"hostfxr library loaded successfully.");
-        }
-
         internal int RunApplication(string? assemblyPath)
         {
             ArgumentNullException.ThrowIfNull(assemblyPath, nameof(assemblyPath));
 
             unsafe
             {
+                var parameters = new NetHost.get_hostfxr_parameters
+                {
+                    size = sizeof(NetHost.get_hostfxr_parameters),
+                    assembly_path = GetCharArrayPointer(assemblyPath)
+                };
+
+                var sw = Stopwatch.StartNew();
+                var hostfxrFullPath = NetHost.GetHostFxrPath(&parameters);
+                sw.Stop();
+                Logger.LogTrace($"hostfxr path:{hostfxrFullPath}. get_hostfxr_path took {sw.ElapsedMilliseconds}ms");
+                
+                sw.Restart();
+                _hostfxrHandle = NativeLibrary.Load(hostfxrFullPath);
+                sw.Stop();
+
+                if (_hostfxrHandle == IntPtr.Zero)
+                {
+                    Logger.Log($"Failed to load hostfxr. hostfxrFullPath:{hostfxrFullPath}");
+                    return -1;
+                }
+                
+                Logger.LogTrace($"hostfxr loaded in {sw.ElapsedMilliseconds}ms");
+
                 var error = HostFxr.Initialize(1, new[] { assemblyPath }, IntPtr.Zero, out _hostContextHandle);
 
                 if (_hostContextHandle == IntPtr.Zero)
@@ -97,6 +101,15 @@ namespace FunctionsNetHost
 
                 _disposed = true;
             }
+        }
+
+        private static unsafe char*  GetCharArrayPointer(string assemblyPath)
+        {
+#if OS_LINUX
+            return (char*)Marshal.StringToHGlobalAnsi(assemblyPath).ToPointer();
+#else
+            return (char*)Marshal.StringToHGlobalUni(assemblyPath).ToPointer();
+#endif
         }
     }
 }

--- a/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
+++ b/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
@@ -32,29 +32,24 @@ namespace FunctionsNetHost
                     assembly_path = GetCharArrayPointer(assemblyPath)
                 };
 
-                var sw = Stopwatch.StartNew();
                 var hostfxrFullPath = NetHost.GetHostFxrPath(&parameters);
-                sw.Stop();
-                Logger.LogTrace($"hostfxr path:{hostfxrFullPath}. get_hostfxr_path took {sw.ElapsedMilliseconds}ms");
-                
-                sw.Restart();
+                Logger.LogTrace($"hostfxr path:{hostfxrFullPath}");
+
                 _hostfxrHandle = NativeLibrary.Load(hostfxrFullPath);
-                sw.Stop();
 
                 if (_hostfxrHandle == IntPtr.Zero)
                 {
                     Logger.Log($"Failed to load hostfxr. hostfxrFullPath:{hostfxrFullPath}");
                     return -1;
                 }
-                
-                Logger.LogTrace($"hostfxr loaded in {sw.ElapsedMilliseconds}ms");
+
+                Logger.LogTrace($"hostfxr loaded.");
 
                 var error = HostFxr.Initialize(1, new[] { assemblyPath }, IntPtr.Zero, out _hostContextHandle);
 
                 if (_hostContextHandle == IntPtr.Zero)
                 {
-                    Logger.Log(
-                        $"Failed to initialize the .NET Core runtime. Assembly path:{assemblyPath}");
+                    Logger.Log($"Failed to initialize the .NET Core runtime. Assembly path:{assemblyPath}");
                     return -1;
                 }
 
@@ -103,7 +98,7 @@ namespace FunctionsNetHost
             }
         }
 
-        private static unsafe char*  GetCharArrayPointer(string assemblyPath)
+        private static unsafe char* GetCharArrayPointer(string assemblyPath)
         {
 #if OS_LINUX
             return (char*)Marshal.StringToHGlobalAnsi(assemblyPath).ToPointer();

--- a/host/src/FunctionsNetHost/AppLoader/NetHost.cs
+++ b/host/src/FunctionsNetHost/AppLoader/NetHost.cs
@@ -7,18 +7,28 @@ namespace FunctionsNetHost
 {
     internal class NetHost
     {
+        public unsafe struct get_hostfxr_parameters
+        {
+            public nint size;
+
+            // Optional.Path to the application assembly,
+            // If specified, hostfxr is located from this directory if present (For self-contained deployments)
+            public char* assembly_path;
+            public char* dotnet_root;
+        }
+
         [DllImport("nethost", CharSet = CharSet.Auto)]
-        private static extern int get_hostfxr_path(
+        private unsafe static extern int get_hostfxr_path(
         [Out] char[] buffer,
         [In] ref int buffer_size,
-        IntPtr reserved);
+        get_hostfxr_parameters* parameters);
 
-        internal static string GetHostFxrPath()
+        internal unsafe static string GetHostFxrPath(get_hostfxr_parameters* parameters)
         {
             char[] buffer = new char[200];
             int bufferSize = buffer.Length;
 
-            int rc = get_hostfxr_path(buffer, ref bufferSize, IntPtr.Zero);
+            int rc = get_hostfxr_path(buffer, ref bufferSize, parameters);
 
             if (rc != 0)
             {


### PR DESCRIPTION
FunctionsNetHost changes to handle self contained apps.

The major change is how we are getting the hostfxr path. Previously we were preload hostfxr in placeholder mode. With this change, we find the hostfxr path and load during cold start.

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->

