### PR TITLE
Revert "Setting text encoding to fix the newline char issue when using StreamReader"

### DIFF
--- a/test/E2ETests/E2EApps/E2EApp/Blob/BlobTriggerBindingFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Blob/BlobTriggerBindingFunctions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.IO;
-using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
@@ -56,7 +55,7 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp.Blob
             [BlobTrigger("test-trigger-stream-dotnet-isolated/{name}")] Stream stream, string name,
             FunctionContext context)
         {
-            var blobStreamReader = new StreamReader(stream, Encoding.UTF8);
+            var blobStreamReader = new StreamReader(stream);
             string content = await blobStreamReader.ReadToEndAsync();
             _logger.LogInformation("StreamTriggerOutput: {c}", content);
         }

--- a/test/E2ETests/E2ETests/Storage/BlobEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/Storage/BlobEndToEndTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests.Storage
             Assert.Equal("Hello World", result);
         }
 
-        [Fact]
+        [Fact(Skip = "TODO: https://github.com/Azure/azure-functions-dotnet-worker/issues/1935")]
         public async Task BlobTrigger_Stream_Succeeds()
         {
             string key = "StreamTriggerOutput: ";


### PR DESCRIPTION
Reverts Azure/azure-functions-dotnet-worker#2023

We're still experiencing the issue. 

Setting the encoding explicitly won't change the behavior of the `StreamReader` as it sets it to `UTF8` implicitly when calling any of the constructors that don't take an `Encoding` (or when it's null, on .NET Core +)