### PR TITLE
Adding support for locating functions within nested types and nested namespaces from referenced assemblies

### DIFF
--- a/sdk/Sdk.Generators/Sdk.Generators.csproj
+++ b/sdk/Sdk.Generators/Sdk.Generators.csproj
@@ -10,7 +10,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <MinorProductVersion>1</MinorProductVersion>
-    <PatchProductVersion>3</PatchProductVersion>
+    <PatchProductVersion>4</PatchProductVersion>
     <VersionSuffix></VersionSuffix>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>16</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
+    <PatchProductVersion>2</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,15 +4,10 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.16.1 (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk 1.16.2 (meta package)
 
-- Update Microsoft.Azure.Functions.Worker.Sdk.Generators dependency to 1.1.3
+- Update Microsoft.Azure.Functions.Worker.Sdk.Generators dependency to 1.1.4
 
-### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.1.3
+### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.1.4
 
-- Fixed casing bug in source-generation. Binding types were changed from pascal case to camel case to match legacy generation (#2022)
-- Reverted: Default to optimized function executor (#2012)
-- Updated source generated versions of IFunctionExecutor to use `global::` namespace prefix to avoid build errors for function class with the same name as its containing namespace. (#1993)
-- Updated source generated versions of IFunctionExecutor to include XML documentation for all public types and members
-- Updated source generated versions of IFunctionMedatadaProvider to include XML documentation for all public types and members
-- Updated source generated versions of IFunctionExecutor to use case-sensitive comparison to fix incorrect invocation of functions with method names only differ in casing. (#2003)
+- Adding support for locating functions within nested types and nested namespaces from referenced assemblies (#2054)

--- a/test/DependentAssemblyWithFunctions/NestedNamespaceFunction.cs
+++ b/test/DependentAssemblyWithFunctions/NestedNamespaceFunction.cs
@@ -4,11 +4,11 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 
-namespace DependentAssemblyWithFunctions
+namespace MyCompany.MyProduct.MyApp
 {
-    public class DependencyFunction
+    public class HttpFunctions
     {
-        [Function("DependencyFunc")]
+        [Function("NestedNamespaceFunc1")]
         public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
         {
             throw new NotImplementedException();

--- a/test/DependentAssemblyWithFunctions/NestedTypesFunction.cs
+++ b/test/DependentAssemblyWithFunctions/NestedTypesFunction.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.;
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace MyCompany.MyProduct.MyApp
+{
+    public sealed class Foo
+    {
+        public sealed class Bar
+        {
+            [Function("NestedTypeFunc")]
+            public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/DependentAssemblyTest.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProviderGeneratorTests/DependentAssemblyTest.cs
@@ -136,6 +136,32 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                                 ScriptFile = "DependentAssemblyWithFunctions.dll"
                             };
                             metadataList.Add(Function3);
+                            var Function4RawBindings = new List<string>();
+                            Function4RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function4RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
+                
+                            var Function4 = new DefaultFunctionMetadata
+                            {
+                                Language = "dotnet-isolated",
+                                Name = "NestedNamespaceFunc1",
+                                EntryPoint = "MyCompany.MyProduct.MyApp.HttpFunctions.Run",
+                                RawBindings = Function4RawBindings,
+                                ScriptFile = "DependentAssemblyWithFunctions.dll"
+                            };
+                            metadataList.Add(Function4);
+                            var Function5RawBindings = new List<string>();
+                            Function5RawBindings.Add(@"{""name"":""req"",""type"":""httpTrigger"",""direction"":""In"",""authLevel"":""Anonymous"",""methods"":[""get"",""post""]}");
+                            Function5RawBindings.Add(@"{""name"":""$return"",""type"":""http"",""direction"":""Out""}");
+
+                            var Function5 = new DefaultFunctionMetadata
+                            {
+                                Language = "dotnet-isolated",
+                                Name = "NestedTypeFunc",
+                                EntryPoint = "MyCompany.MyProduct.MyApp.Foo.Bar.Run",
+                                RawBindings = Function5RawBindings,
+                                ScriptFile = "DependentAssemblyWithFunctions.dll"
+                            };
+                            metadataList.Add(Function5);
 
                             return Task.FromResult(metadataList.ToImmutableArray());
                         }


### PR DESCRIPTION
Adding support for locating functions within nested types and nested namespaces from referenced assemblies.

Fixes #2052 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

