### PR TITLE
Worker Sdk 1.16.4 release

### DIFF
--- a/sdk/Sdk.Generators/Sdk.Generators.csproj
+++ b/sdk/Sdk.Generators/Sdk.Generators.csproj
@@ -11,7 +11,6 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <MinorProductVersion>1</MinorProductVersion>
     <PatchProductVersion>6</PatchProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <MinorProductVersion>16</MinorProductVersion>
     <PatchProductVersion>4</PatchProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,10 +4,10 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.16.4-preview1 (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk 1.16.4 (meta package)
 
-- Update Microsoft.Azure.Functions.Worker.Sdk.Generators dependency to 1.1.6-preview1
+- Update Microsoft.Azure.Functions.Worker.Sdk.Generators dependency to 1.1.6
 
-### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.1.6-preview1
+### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.1.6
 
 - Avoid executing source generators outside of an Azure Functions project. (#2119)


### PR DESCRIPTION
Worker Sdk 1.16.4 release. Removing `-preview1` suffix


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


