### PR TITLE
Adding a Info level log entry after function app assembly load

### DIFF
--- a/host/src/FunctionsNetHost/Environment/EnvironmentVariables.cs
+++ b/host/src/FunctionsNetHost/Environment/EnvironmentVariables.cs
@@ -3,10 +3,15 @@
 
 namespace FunctionsNetHost;
 
-internal static class EnvironmentSettingNames
+internal static class EnvironmentVariables
 {
     /// <summary>
     /// Set value to "1" for enabling extra trace logs in FunctionsNetHost.
     /// </summary>
     internal const string FunctionsNetHostTrace = "AZURE_FUNCTIONS_FUNCTIONSNETHOST_TRACE";
+
+    /// <summary>
+    /// Application pool Id for the placeholder app. Only available in Windows(when running in IIS).
+    /// </summary>
+    internal const string AppPoolId  = "APP_POOL_ID";
 }

--- a/host/src/FunctionsNetHost/Grpc/IncomingGrpcMessageHandler.cs
+++ b/host/src/FunctionsNetHost/Grpc/IncomingGrpcMessageHandler.cs
@@ -87,7 +87,13 @@ namespace FunctionsNetHost.Grpc
 
                     Logger.LogTrace($"Will wait for worker loaded signal.");
                     WorkerLoadStatusSignalManager.Instance.Signal.WaitOne();
-                    Logger.LogTrace($"Received worker loaded signal. Forwarding environment reload request to worker.");
+
+                    var logMessage = $"FunctionApp assembly loaded successfully. ProcessId:{Environment.ProcessId}";
+                    if (OperatingSystem.IsWindows())
+                    {
+                        logMessage += $", AppPoolId:{Environment.GetEnvironmentVariable(EnvironmentVariables.AppPoolId)}";
+                    }
+                    Logger.Log(logMessage);
 
                     await MessageChannel.Instance.SendInboundAsync(msg);
                     _specializationDone = true;

--- a/host/src/FunctionsNetHost/Logger.cs
+++ b/host/src/FunctionsNetHost/Logger.cs
@@ -22,7 +22,7 @@ namespace FunctionsNetHost
         {
             get
             {
-                return string.Equals(EnvironmentUtils.GetValue(EnvironmentSettingNames.FunctionsNetHostTrace), "1");
+                return string.Equals(EnvironmentUtils.GetValue(EnvironmentVariables.FunctionsNetHostTrace), "1");
             }
         }
 

--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>


### PR DESCRIPTION
Adding a log statement after worker assembly is successfully loaded during language worker specialization. We had a previous log statement, but that was a trace level log entry. Changed it to INFO level and including the process id and APP_POOL_ID environment variable value.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
