### PR TITLE
Populating parameter value for nullable types when input binding data is missing the value for the parameter

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,19 +4,10 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker (metapackage) 1.20.0
+### Microsoft.Azure.Functions.Worker (metapackage) 1.20.1
 
-- Updated to `Microsoft.Azure.Functions.Worker.Core` 1.16.0
-- Updated to `Microsoft.Azure.Functions.Worker.Grpc` 1.15.0
+- Updated to `Microsoft.Azure.Functions.Worker.Core` 1.16.1
 
-### Microsoft.Azure.Functions.Worker.Core 1.16.0
+### Microsoft.Azure.Functions.Worker.Core 1.16.1
 
-- Adding optional parameter support (#1868)
-- Unsealed `Microsoft.Azure.Functions.Worker.Http.HttpHeadersCollection`
-
-### Microsoft.Azure.Functions.Worker.Grpc 1.15.0
-
-- Added support for handling the new command line arguments with "functions-" prefix. (#1897)
-- Adding optional parameter support (#1868)
-- Enhancements to interop in hosted placeholder scenarios
-  
+- Populating parameter value for nullable types (#1868)

--- a/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
@@ -72,6 +72,11 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                         {
                             parameterValues[i] = parameter.DefaultValue;
                         }
+                        else if (parameter.IsReferenceOrNullableType)
+                        {
+                            // If the parameter is a reference type or nullable type, set it to null.
+                            parameterValues[i] = null;
+                        }
                         else
                         {
                             // We could not find a value for this param. should throw.

--- a/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
@@ -79,10 +79,11 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                         }
                         else
                         {
+                            // Non nullable value type with no default value.
                             // We could not find a value for this param. should throw.
                             errors ??= new List<string>();
                             errors.Add(
-                                $"Could not populate the value for '{parameter.Name}' parameter. Consider updating the parameter with a default value.");
+                                $"Could not populate the value for '{parameter.Name}' parameter. Consider adding a default value or making the parameter nullable.");
                         }
                     }
                 }
@@ -111,7 +112,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
         {
             var converterContextFactory = context.InstanceServices.GetRequiredService<IConverterContextFactory>();
             var inputConversionFeature = context.Features.Get<IInputConversionFeature>()
-                ?? throw new InvalidOperationException($"The {nameof(IInputConversionFeature)} is not availabe in the current context.");
+                ?? throw new InvalidOperationException($"The {nameof(IInputConversionFeature)} is not available in the current context.");
 
             TryGetBindingSource(parameter.Name, context, out object? source);
 

--- a/src/DotNetWorker.Core/Definition/FunctionParameter.cs
+++ b/src/DotNetWorker.Core/Definition/FunctionParameter.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.Functions.Worker
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Type = type ?? throw new ArgumentNullException(nameof(type));
+            IsReferenceOrNullableType = !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
             Properties = properties ?? throw new ArgumentNullException(nameof(properties));
         }
 
@@ -61,6 +62,7 @@ namespace Microsoft.Azure.Functions.Worker
             Type = type ?? throw new ArgumentNullException(nameof(type));
             DefaultValue = defaultValue ?? default;
             HasDefaultValue = hasDefaultValue;
+            IsReferenceOrNullableType = !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
             Properties = properties ?? throw new ArgumentNullException(nameof(properties));
         }
 
@@ -78,6 +80,11 @@ namespace Microsoft.Azure.Functions.Worker
         /// Gets a value that indicates whether this parameter has a default value.
         /// </summary>
         public bool HasDefaultValue { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the parameter allows null values.
+        /// </summary>
+        public bool IsReferenceOrNullableType { get; }
 
         /// <summary>
         /// Gets the default value of the parameter if exists, else null.

--- a/src/DotNetWorker.Core/DotNetWorker.Core.csproj
+++ b/src/DotNetWorker.Core/DotNetWorker.Core.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <MinorProductVersion>16</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Microsoft.Azure.Functions.Worker</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <MinorProductVersion>20</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
+++ b/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             inputBindings: new Dictionary<string, BindingMetadata>
             {
                  { "req", new TestBindingMetadata("req","httpTrigger",BindingDirection.In) }
-            }); ;
+            }); 
             features.Set<FunctionDefinition>(httpFunctionDefinition);
 
             var functionContext = new TestFunctionContext(httpFunctionDefinition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
@@ -107,12 +107,13 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             {
                  new("req", typeof(HttpRequestData)),
                  new("bar", typeof(string)),
-                 new("fooId", typeof(int?))
+                 new("fooId", typeof(int?)),
+                 new("bazDate", typeof(DateTime?))
             },
             inputBindings: new Dictionary<string, BindingMetadata>
             {
                  { "req", new TestBindingMetadata("req","httpTrigger",BindingDirection.In) }
-             }); ;
+             }); 
             features.Set<FunctionDefinition>(httpFunctionDefinition);
 
             var functionContext = new TestFunctionContext(httpFunctionDefinition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
@@ -132,12 +133,14 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var httpReqData = TestUtility.AssertIsTypeAndConvert<HttpRequestData>(parameterValuesArray[0]);
             Assert.NotNull(httpReqData);
 
-            // The input binding data does not have values for "bar" and "fooId",
+            // The input binding data does not have values for "bar","fooId" and "bazDate"
             // but since the are nullable or reference types, they should be populated with null.
             var bar = parameterValuesArray[1];
             Assert.Null(bar);
             var fooId = parameterValuesArray[2];
             Assert.Null(fooId);
+            var bazDate = parameterValuesArray[3];
+            Assert.Null(bazDate);
         }
 
         [Fact]
@@ -155,7 +158,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             inputBindings: new Dictionary<string, BindingMetadata>
             {
                  { "req", new TestBindingMetadata("req","httpTrigger",BindingDirection.In) }
-            }); ;
+            }); 
             features.Set<FunctionDefinition>(httpFunctionDefinition);
 
             var functionContext = new TestFunctionContext(httpFunctionDefinition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
@@ -169,7 +172,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
             // Assert
             var exception = await Assert.ThrowsAsync<FunctionInputConverterException>(async () => await _functionInputBindingFeature.BindFunctionInputAsync(functionContext));
-            Assert.Equal("Error converting 1 input parameters for Function 'TestName': Could not populate the value for 'fooId' parameter. Consider updating the parameter with a default value.", exception.Message);
+            Assert.Equal("Error converting 1 input parameters for Function 'TestName': Could not populate the value for 'fooId' parameter. Consider adding a default value or making the parameter nullable.", exception.Message);
         }
 
         [Fact]

--- a/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
+++ b/test/DotNetWorkerTests/DefaultModelBindingFeatureTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             inputBindings: new Dictionary<string, BindingMetadata>
             {
                  { "req", new TestBindingMetadata("req","httpTrigger",BindingDirection.In) }
-            });  ;
+            }); ;
             features.Set<FunctionDefinition>(httpFunctionDefinition);
 
             var functionContext = new TestFunctionContext(httpFunctionDefinition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
@@ -100,11 +100,52 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         }
 
         [Fact]
+        public async void BindFunctionInputAsync_Populates_Parameter_For_Nullable_Or_ReferenceTypes()
+        {
+            var features = new InvocationFeatures(Enumerable.Empty<IInvocationFeatureProvider>());
+            var httpFunctionDefinition = new TestFunctionDefinition(parameters: new FunctionParameter[]
+            {
+                 new("req", typeof(HttpRequestData)),
+                 new("bar", typeof(string)),
+                 new("fooId", typeof(int?))
+            },
+            inputBindings: new Dictionary<string, BindingMetadata>
+            {
+                 { "req", new TestBindingMetadata("req","httpTrigger",BindingDirection.In) }
+             }); ;
+            features.Set<FunctionDefinition>(httpFunctionDefinition);
+
+            var functionContext = new TestFunctionContext(httpFunctionDefinition, invocation: null, CancellationToken.None, serviceProvider: _serviceProvider, features: features);
+            var grpcHttpReq = new GrpcHttpRequestData(TestUtility.CreateRpcHttp(), functionContext);
+            var functionBindings = new TestFunctionBindingsFeature
+            {
+                InputData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "req", grpcHttpReq } })
+            };
+            features.Set<IFunctionBindingsFeature>(functionBindings);
+            features.Set(_serviceProvider.GetService<IInputConversionFeature>());
+
+            // Act
+            var bindingResult = await _functionInputBindingFeature.BindFunctionInputAsync(functionContext);
+            var parameterValuesArray = bindingResult.Values;
+
+            // Assert
+            var httpReqData = TestUtility.AssertIsTypeAndConvert<HttpRequestData>(parameterValuesArray[0]);
+            Assert.NotNull(httpReqData);
+
+            // The input binding data does not have values for "bar" and "fooId",
+            // but since the are nullable or reference types, they should be populated with null.
+            var bar = parameterValuesArray[1];
+            Assert.Null(bar);
+            var fooId = parameterValuesArray[2];
+            Assert.Null(fooId);
+        }
+
+        [Fact]
         public async void BindFunctionInputAsync_Throws_When_Explicit_OptionalParametersValueNotPresent()
         {
             // 'fooId' is a parameter defined for the function without a default value
             // and 'InputData' does not have a corresponding entry for that we could use to populate that parameter.
-            
+
             IInvocationFeatures features = new InvocationFeatures(Enumerable.Empty<IInvocationFeatureProvider>());
             var httpFunctionDefinition = new TestFunctionDefinition(parameters: new FunctionParameter[]
             {

--- a/test/Sdk.Generator.Tests/FunctionExecutor/DependentAssemblyTest.cs
+++ b/test/Sdk.Generator.Tests/FunctionExecutor/DependentAssemblyTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                                        
                                                private IFunctionExecutor CreateDefaultExecutorInstance(FunctionContext context)
                                                {
-                                                   var defaultExecutorFullName = "Microsoft.Azure.Functions.Worker.Invocation.DefaultFunctionExecutor, Microsoft.Azure.Functions.Worker.Core, Version=1.16.0.0, Culture=neutral, PublicKeyToken=551316b6919f366c";
+                                                   var defaultExecutorFullName = "Microsoft.Azure.Functions.Worker.Invocation.DefaultFunctionExecutor, Microsoft.Azure.Functions.Worker.Core, Version=1.16.1.0, Culture=neutral, PublicKeyToken=551316b6919f366c";
                                                    var defaultExecutorType = Type.GetType(defaultExecutorFullName);
                                        
                                                    return ActivatorUtilities.CreateInstance(context.InstanceServices, defaultExecutorType) as IFunctionExecutor;


### PR DESCRIPTION
Populating parameter value for nullable types when input binding data is missing the value for the parameter. 
Currently when the parameter is nullable type & default value not defined, we are throwing an exception

https://github.com/Azure/azure-functions-dotnet-worker/blob/5045bf5bd35e9b252c273d3efb7c2fbf60dfee76/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs#L71-L81

which was different than previous behavior where null value was assigned.

In this PR, If the parameter is nullable or reference types and no value was present in input binding data, we will set the value as `null`.

Behavior with changes from this PR, when input binding data is missing the value for the parameter/binding.

| Parameter signature | Populated parameter value | Error                                                                                                  |
|---------------------|---------------------------|--------------------------------------------------------------------------------------------------------|
| int foo             |                           | Could not populate the value for 'foo' parameter. Consider updating the parameter with a default value |
| int? foo            | null                      |                                                                                                        |
| string foo          | null                      |                                                                                                        |
| string? foo         | null                      |                                                                                                        |
| int foo = 100       | 100                       |                                                                                                        |
| int? foo = 100      | 100                       |                                                                                                        |
| string foo = "bar"  | "bar"                     |



### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
