### PR TITLE
Fix issue where IReadOnlyList<T> wasn't a valid binding type.

### DIFF
--- a/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
+++ b/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
@@ -16,9 +16,10 @@ namespace Microsoft.Azure.Functions.Worker.Extensions
     internal static class ParameterBinder
     {
         /// <summary>
-        /// An array of types that reasonably map back to a class that implements a generic list data structure. 
+        /// Read only property that contains all of the generic interfaces implemented by <see cref="System.Collections.Generic.List"/>.
         /// </summary>
-        private static Type[] validListInterfaceTypes = new Type[] {typeof(IList<>), typeof(ICollection<>), typeof(IEnumerable<>)};
+        /// <remarks>This property calls ToList at the end to force the resolution of the LINQ methods that leverage deferred execution.</remarks>
+        private static readonly IEnumerable<Type> validListInterfaceTypes = typeof(List<>).GetInterfaces().Where(t => t.IsGenericType).Select(t => t.GetGenericTypeDefinition()).ToList();
 
         private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
@@ -97,11 +98,15 @@ namespace Microsoft.Azure.Functions.Worker.Extensions
             }
         }
 
+        /// <summary>
+        /// A method that determines if a Type is a generic interface of the <see cref="System.Collections.Generic.List"/> concrete class.
+        /// </summary>
+        /// <param name="type">A generic interface type to be tested against the types available on the generic <see cref="System.Collections.Generic.List"/> type.</param>
+        /// <returns>True if the type is a generic type and it's an interface of the generic <see cref="System.Collections.Generic.List"/> type otherwise false.</returns>
         private static bool IsListInterface(Type type)
         {
             return type.IsGenericType &&
-                (validListInterfaceTypes.Contains(type.GetGenericTypeDefinition()) ||
-                 type.GetInterfaces().Select(t => t.GetGenericTypeDefinition()).Intersect(validListInterfaceTypes).Any());
+                validListInterfaceTypes.Any(t => t == type.GetGenericTypeDefinition());
         }
 
         private static Action<object> GetAddMethod(object collection)

--- a/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
+++ b/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
@@ -96,7 +96,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions
             return type.IsGenericType &&
                 (type.GetGenericTypeDefinition() == typeof(IList<>)
                 || type.GetGenericTypeDefinition() == typeof(ICollection<>)
-                || type.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+                || type.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                || type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>));
         }
 
         private static Action<object> GetAddMethod(object collection)

--- a/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
+++ b/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions
         /// Read only property that contains all of the generic interfaces implemented by <see cref="System.Collections.Generic.List"/>.
         /// </summary>
         /// <remarks>This property calls ToList at the end to force the resolution of the LINQ methods that leverage deferred execution.</remarks>
-        private static readonly IEnumerable<Type> validListInterfaceTypes = typeof(List<>).GetInterfaces().Where(t => t.IsGenericType).Select(t => t.GetGenericTypeDefinition()).ToList();
+        private static readonly HashSet<Type> validListInterfaceTypes = new HashSet<Type>(typeof(List<>).GetInterfaces().Where(t => t.IsGenericType).Select(t => t.GetGenericTypeDefinition()));
 
         private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions
         private static bool IsListInterface(Type type)
         {
             return type.IsGenericType &&
-                validListInterfaceTypes.Any(t => t == type.GetGenericTypeDefinition());
+                validListInterfaceTypes.Contains(type.GetGenericTypeDefinition());
         }
 
         private static Action<object> GetAddMethod(object collection)

--- a/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
+++ b/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -14,6 +15,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions
     /// </summary>
     internal static class ParameterBinder
     {
+        /// <summary>
+        /// An array of types that reasonably map back to a class that implements a generic list data structure. 
+        /// </summary>
+        private static Type[] validListInterfaceTypes = new Type[] {typeof(IList<>), typeof(ICollection<>), typeof(IEnumerable<>)};
+
         private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
         /// <summary>
@@ -94,10 +100,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions
         private static bool IsListInterface(Type type)
         {
             return type.IsGenericType &&
-                (type.GetGenericTypeDefinition() == typeof(IList<>)
-                || type.GetGenericTypeDefinition() == typeof(ICollection<>)
-                || type.GetGenericTypeDefinition() == typeof(IEnumerable<>)
-                || type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>));
+                (validListInterfaceTypes.Contains(type.GetGenericTypeDefinition()) ||
+                 type.GetInterfaces().Select(t => t.GetGenericTypeDefinition()).Intersect(validListInterfaceTypes).Any());
         }
 
         private static Action<object> GetAddMethod(object collection)

--- a/test/Worker.Extensions.Shared.Tests/Reflection/ParameterBinderTests.cs
+++ b/test/Worker.Extensions.Shared.Tests/Reflection/ParameterBinderTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Shared.Tests
         [InlineData(typeof(IEnumerable<int>))]
         [InlineData(typeof(ICollection<int>))]
         [InlineData(typeof(IList<int>))]
+        [InlineData(typeof(IReadOnlyList<int>))]
         public async Task BindCollection_Interface_GetsList(Type type)
         {
             object collection = await ParameterBinder.BindCollectionAsync(GetIntEnumerable, type);

--- a/test/Worker.Extensions.Shared.Tests/Reflection/ParameterBinderTests.cs
+++ b/test/Worker.Extensions.Shared.Tests/Reflection/ParameterBinderTests.cs
@@ -40,11 +40,23 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Shared.Tests
                 () => ParameterBinder.BindCollectionAsync(e => Mock.Of<IAsyncEnumerable<object>>(), type));
         }
 
+        [Fact]
+        public async Task BindCollection_Interface_AllListInterfacesSupported()
+        {
+            var interfaceTypes = new List<int>().GetType().GetInterfaces().Where(t => t.IsGenericType);
+
+            foreach(Type interfaceType in interfaceTypes)
+            {
+                Assert.IsType<List<int>>(await ParameterBinder.BindCollectionAsync(GetIntEnumerable, interfaceType));
+            }
+        }
+
         [Theory]
         [InlineData(typeof(IEnumerable<int>))]
         [InlineData(typeof(ICollection<int>))]
         [InlineData(typeof(IList<int>))]
         [InlineData(typeof(IReadOnlyList<int>))]
+        [InlineData(typeof(IReadOnlyCollection<int>))]
         public async Task BindCollection_Interface_GetsList(Type type)
         {
             object collection = await ParameterBinder.BindCollectionAsync(GetIntEnumerable, type);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #2173 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] ~~Otherwise: Documentation issue linked to PR~~
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] ~~Otherwise: I've added my notes to `release_notes.md`~~
* [x] My changes **do not** need to be backported to a previous version
  * [ ] ~~Otherwise: Backport tracked by issue/PR #issue_or_pr~~
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

I leveraged Linq to give what I felt was a "cleaner" approach where the IsListInterface can succinctly look at the value of the Type as well as the value of all of the Interfaces of the type to see if it's valid.  I think this should cover every situation where the passed in interface type inherits from one of the valid types.

I know this isn't an optimal runtime solution since LINQ can be slower but since we're talking reflection I figured it was a good tradeoff.  If there are performance issues with this approach I'd love to learn more.
