### PR TITLE
Remove closure in DefaultFunctionExecutor

### DIFF
--- a/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.cs
+++ b/src/DotNetWorker.Core/Invocation/DefaultFunctionExecutor.cs
@@ -25,7 +25,11 @@ namespace Microsoft.Azure.Functions.Worker.Invocation
         public async ValueTask ExecuteAsync(FunctionContext context)
         {
             var invoker = _invokerCache.GetOrAdd(context.FunctionId,
-                _ => _invokerFactory.Create(context.FunctionDefinition));
+                static (_, state) =>
+                {
+                    var (factory, context) = state;
+                    return factory.Create(context.FunctionDefinition);
+                }, (_invokerFactory, context));
 
             object? instance = invoker.CreateInstance(context);
             var inputBindingFeature = context.Features.Get<IFunctionInputBindingFeature>();


### PR DESCRIPTION
### Issue describing the changes in this PR

Removes the `GetOrAdd` closure in the DefaultFunctionExecutor

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

None
