### PR TITLE
Fix possible namespace conflict in ExtensionStartupRunnerGenerator

### DIFF
--- a/sdk/Sdk.Generators/ExtensionStartupRunnerGenerator.cs
+++ b/sdk/Sdk.Generators/ExtensionStartupRunnerGenerator.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                 builder.Append($$"""
                                     try
                                     {
-                                        new {{typeName}}().Configure(applicationBuilder);
+                                        new global::{{typeName}}().Configure(applicationBuilder);
                                     }
                                     catch (Exception ex)
                                     {

--- a/test/Sdk.Generator.Tests/ExtensionStartup/ExtensionStartupRunnerGeneratorTests.cs
+++ b/test/Sdk.Generator.Tests/ExtensionStartup/ExtensionStartupRunnerGeneratorTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                                             {
                                                 try
                                                 {
-                                                    new Microsoft.Azure.Functions.Tests.WorkerExtensionsSample.SampleExtensionStartup().Configure(applicationBuilder);
+                                                    new global::Microsoft.Azure.Functions.Tests.WorkerExtensionsSample.SampleExtensionStartup().Configure(applicationBuilder);
                                                 }
                                                 catch (Exception ex)
                                                 {
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                                             {
                                                 try
                                                 {
-                                                    new Microsoft.Azure.Functions.Tests.WorkerExtensionsSample.SampleExtensionStartup().Configure(applicationBuilder);
+                                                    new global::Microsoft.Azure.Functions.Tests.WorkerExtensionsSample.SampleExtensionStartup().Configure(applicationBuilder);
                                                 }
                                                 catch (Exception ex)
                                                 {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Fixes a potential namespace conflict in the code generated by `ExtensionStartupRunnerGenerator`. Using the generator from a namespace that contains `Microsoft`, like `Company.Integration.Microsoft` would cause the generated `WorkerExtensionStartupCodeExecutor` to generate an invalid qualified name for `ServiceBusExtensionStartup`.

resolves #1762

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
