### PR TITLE
Reset Release Notes

### DIFF
--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -4,10 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.5.1
+### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB <version>
 
-- Add support for `IReadOnlyList<T>` and `IReadOnlyCollection<T>` for Cosmos input bindings. (#2174) (contributed by @savagemonitor)
-
-## Contribution Thanks
-
-- @savagemonitor
+- <entry>

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,15 +4,14 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker (metapackage) 1.20.1
+### Microsoft.Azure.Functions.Worker (metapackage) <version>
 
-- Updated to `Microsoft.Azure.Functions.Worker.Core` 1.16.1
+- <entry>
 
-### Microsoft.Azure.Functions.Worker.Core 1.16.1
+### Microsoft.Azure.Functions.Worker.Core <version>
 
-- Populating parameter value for nullable types (#1868)
-- Remove closure in DefaultFunctionExecutor (#2182) (contributed by @danielmarbach)
+- <entry>
 
-## Contributions Thanks
+### Microsoft.Azure.Functions.Worker.Grpc <version>
 
-- @danielmarbach
+- <etnry>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resetting release notes. Worker package released [here](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker) and tagged [here](https://github.com/Azure/azure-functions-dotnet-worker/releases/tag/1.20.1).

CosmosDB releaed [here](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.CosmosDB/#versions-body-tab) and tagged [here](https://github.com/Azure/azure-functions-dotnet-worker/releases/tag/cosmosdb-extension-4.5.1).

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

