### PR TITLE
Decouple FunctionsEnableMetadataSourceGen from FunctionsEnableWorkerIndexing to actually make it work properly when set

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -37,9 +37,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         <FunctionsEnablePlaceholder Condition="$(FunctionsEnablePlaceholder) == ''">false</FunctionsEnablePlaceholder>
         <FunctionsEnableWorkerIndexing Condition="$(FunctionsEnableWorkerIndexing) == '' Or $(FunctionsEnableWorkerIndexing)">true</FunctionsEnableWorkerIndexing>
         <FunctionsEnableMetadataSourceGen Condition="$(FunctionsEnableMetadataSourceGen) == '' Or $(FunctionsEnableMetadataSourceGen)">true</FunctionsEnableMetadataSourceGen>
-        <FunctionsAutoRegisterGeneratedMetadataProvider Condition="$(FunctionsAutoRegisterGeneratedMetadataProvider) == '' Or (FunctionsAutoRegisterGeneratedMetadataProvider)">true</FunctionsAutoRegisterGeneratedMetadataProvider>
+        <FunctionsAutoRegisterGeneratedMetadataProvider Condition="$(FunctionsAutoRegisterGeneratedMetadataProvider) == '' Or $(FunctionsAutoRegisterGeneratedMetadataProvider)">true</FunctionsAutoRegisterGeneratedMetadataProvider>
         <FunctionsEnableExecutorSourceGen Condition="$(FunctionsEnableExecutorSourceGen) == '' Or $(FunctionsEnableExecutorSourceGen)">true</FunctionsEnableExecutorSourceGen>
-        <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor) == '' Or (FunctionsAutoRegisterGeneratedFunctionsExecutor)">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
+        <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor) == '' Or $(FunctionsAutoRegisterGeneratedFunctionsExecutor)">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
         <FunctionsGeneratedCodeNamespace Condition="$(FunctionsGeneratedCodeNamespace) == ''">$(RootNamespace.Replace("-", "_"))</FunctionsGeneratedCodeNamespace> 
     </PropertyGroup>
 

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -36,11 +36,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       
         <FunctionsEnablePlaceholder Condition="$(FunctionsEnablePlaceholder) == ''">false</FunctionsEnablePlaceholder>
         <FunctionsEnableWorkerIndexing Condition="$(FunctionsEnableWorkerIndexing) == '' Or $(FunctionsEnableWorkerIndexing)">true</FunctionsEnableWorkerIndexing>
-        <FunctionsEnableMetadataSourceGen>$(FunctionsEnableWorkerIndexing)</FunctionsEnableMetadataSourceGen>
-        <FunctionsAutoRegisterGeneratedMetadataProvider>$(FunctionsEnableWorkerIndexing)</FunctionsAutoRegisterGeneratedMetadataProvider>
+        <FunctionsEnableMetadataSourceGen Condition="$(FunctionsEnableMetadataSourceGen) == '' Or $(FunctionsEnableMetadataSourceGen)">true</FunctionsEnableMetadataSourceGen>
+        <FunctionsAutoRegisterGeneratedMetadataProvider Condition="$(FunctionsAutoRegisterGeneratedMetadataProvider) == '' Or (FunctionsAutoRegisterGeneratedMetadataProvider)">true</FunctionsAutoRegisterGeneratedMetadataProvider>
         <FunctionsEnableExecutorSourceGen Condition="$(FunctionsEnableExecutorSourceGen) == '' Or $(FunctionsEnableExecutorSourceGen)">true</FunctionsEnableExecutorSourceGen>
-        <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor) == ''">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
-        <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor)">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
+        <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor) == '' Or (FunctionsAutoRegisterGeneratedFunctionsExecutor)">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
         <FunctionsGeneratedCodeNamespace Condition="$(FunctionsGeneratedCodeNamespace) == ''">$(RootNamespace.Replace("-", "_"))</FunctionsGeneratedCodeNamespace> 
     </PropertyGroup>
 


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #2209 

Unfortunately, I have no context of the project to be able to say this change of decoupling the properties is safe, but at least from the expectations I had from the description of the property and how the executor generation works, I would have expected to be able to disable the metadata source gen independently of the function indexing.

I did smoke test the package locally with the dev build, and it seems to work (see after GIF) and my function is still executing.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This changes potentially requires a backport
Happy to add necessary release notes once I get some feedback from the team.

#### Before

![Before](https://github.com/Azure/azure-functions-dotnet-worker/assets/174258/e4c22752-e337-4ffa-92cf-489a2bce686b)

#### After
![After](https://github.com/Azure/azure-functions-dotnet-worker/assets/174258/174df4ba-80c8-41b5-98a2-1894cf9c321a)

