### PR TITLE
Assert inner-build TFM is what we expect

### DIFF
--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -76,21 +76,15 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
         <TargetFramework>{targetFramework}</TargetFramework>
-        <LangVersion>preview</LangVersion>
         <Configuration>Release</Configuration>
         <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
-        <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions</RootNamespace>
-        <MajorMinorProductVersion>1.0</MajorMinorProductVersion>
-        <Version>$(MajorMinorProductVersion).0</Version>
-        <AssemblyVersion>$(MajorMinorProductVersion).0.0</AssemblyVersion>
-        <FileVersion>$(Version)</FileVersion>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include=""Microsoft.NETCore.Targets"" Version=""3.0.0"" PrivateAssets=""all"" />
         <PackageReference Include=""Microsoft.NET.Sdk.Functions"" Version=""{netSdkVersion}"" />
-        {extensionReferences}
-    </ItemGroup>
+{extensionReferences}    </ItemGroup>
 
     <Target Name=""_VerifyTargetFramework"" BeforeTargets=""Build"">
         <!-- It is possible to override our TFM via global properties. This can lead to successful builds, but runtime errors due to incompatible dependencies being brought in. -->
@@ -114,7 +108,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
 
         private static string GetPackageReferenceFromExtension(string name, string version)
         {
-            return $@"<PackageReference Include=""{name}"" Version=""{version}"" />";
+            return $"        <PackageReference Include=\"{name}\" Version=\"{version}\" />";
         }
     }
 }

--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -91,6 +91,11 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         <PackageReference Include=""Microsoft.NET.Sdk.Functions"" Version=""{netSdkVersion}"" />
         {extensionReferences}
     </ItemGroup>
+
+    <Target Name=""_VerifyTargetFramework"" BeforeTargets=""Build"">
+        <!-- It is possible to override our TFM via global properties. This can lead to successful builds, but runtime errors due to incompatible dependencies being brought in. -->
+        <Error Condition=""'$(TargetFramework)' != '{targetFramework}'"" Text=""The target framework '$(TargetFramework)' must be '{targetFramework}'. Verify if target framework has been overridden by a global property."" />
+    </Target>
 </Project>
 ";
         }

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>17</MinorProductVersion>
-    <VersionSuffix>-preview1</VersionSuffix>
+    <VersionSuffix>-preview2</VersionSuffix>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -5,12 +5,6 @@
 -->
 
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.17.0-preview1 (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk 1.17.0-preview2 (meta package)
 
-- Improve incremental build support for worker extension project inner build (https://github.com/Azure/azure-functions-dotnet-worker/pull/1749) 
-  - Now builds to intermediate output path
-- Resolve and pass nuget restore sources as explicit property to inner build (https://github.com/Azure/azure-functions-dotnet-worker/pull/1937)
-- Integrate inner build with existing .NET SDK targets (https://github.com/Azure/azure-functions-dotnet-worker/pull/1861)
-  - Targets have been refactored to participate with `CopyToOutputDirectory` and `CopyToPublishDirectory` instead of manually copying
-  - Incremental build support further improved
 - Explicitly error out if inner-builds TFM is altered. (https://github.com/Azure/azure-functions-dotnet-worker/pull/2222)

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -13,3 +13,4 @@
 - Integrate inner build with existing .NET SDK targets (https://github.com/Azure/azure-functions-dotnet-worker/pull/1861)
   - Targets have been refactored to participate with `CopyToOutputDirectory` and `CopyToPublishDirectory` instead of manually copying
   - Incremental build support further improved
+- Explicitly error out if inner-builds TFM is altered. (https://github.com/Azure/azure-functions-dotnet-worker/pull/2222)

--- a/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
@@ -101,6 +101,11 @@ namespace Microsoft.Azure.Functions.SdkTests
 <PackageReference Include=""Microsoft.Azure.WebJobs.Extensions"" Version=""2.0.0"" />
 
     </ItemGroup>
+
+    <Target Name=""_VerifyTargetFramework"" BeforeTargets=""Build"">
+        <!-- It is possible to override our TFM via global properties. This can lead to successful builds, but runtime errors due to incompatible dependencies being brought in. -->
+        <Error Condition=""'$(TargetFramework)' != 'netcoreapp3.1'"" Text=""The target framework '$(TargetFramework)' must be 'netcoreapp3.1'. Verify if target framework has been overridden by a global property."" />
+    </Target>
 </Project>
 ";
         }
@@ -129,6 +134,11 @@ namespace Microsoft.Azure.Functions.SdkTests
 <PackageReference Include=""Microsoft.Azure.WebJobs.Extensions"" Version=""2.0.0"" />
 
     </ItemGroup>
+
+    <Target Name=""_VerifyTargetFramework"" BeforeTargets=""Build"">
+        <!-- It is possible to override our TFM via global properties. This can lead to successful builds, but runtime errors due to incompatible dependencies being brought in. -->
+        <Error Condition=""'$(TargetFramework)' != 'net6.0'"" Text=""The target framework '$(TargetFramework)' must be 'net6.0'. Verify if target framework has been overridden by a global property."" />
+    </Target>
 </Project>
 ";
         }

--- a/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
@@ -83,23 +83,17 @@ namespace Microsoft.Azure.Functions.SdkTests
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>preview</LangVersion>
         <Configuration>Release</Configuration>
         <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
-        <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions</RootNamespace>
-        <MajorMinorProductVersion>1.0</MajorMinorProductVersion>
-        <Version>$(MajorMinorProductVersion).0</Version>
-        <AssemblyVersion>$(MajorMinorProductVersion).0.0</AssemblyVersion>
-        <FileVersion>$(Version)</FileVersion>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include=""Microsoft.NETCore.Targets"" Version=""3.0.0"" PrivateAssets=""all"" />
         <PackageReference Include=""Microsoft.NET.Sdk.Functions"" Version=""3.1.2"" />
         <PackageReference Include=""Microsoft.Azure.WebJobs.Extensions.Storage"" Version=""4.0.3"" />
-<PackageReference Include=""Microsoft.Azure.WebJobs.Extensions.Http"" Version=""3.0.0"" />
-<PackageReference Include=""Microsoft.Azure.WebJobs.Extensions"" Version=""2.0.0"" />
-
+        <PackageReference Include=""Microsoft.Azure.WebJobs.Extensions.Http"" Version=""3.0.0"" />
+        <PackageReference Include=""Microsoft.Azure.WebJobs.Extensions"" Version=""2.0.0"" />
     </ItemGroup>
 
     <Target Name=""_VerifyTargetFramework"" BeforeTargets=""Build"">
@@ -116,23 +110,17 @@ namespace Microsoft.Azure.Functions.SdkTests
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>preview</LangVersion>
         <Configuration>Release</Configuration>
         <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
-        <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions</RootNamespace>
-        <MajorMinorProductVersion>1.0</MajorMinorProductVersion>
-        <Version>$(MajorMinorProductVersion).0</Version>
-        <AssemblyVersion>$(MajorMinorProductVersion).0.0</AssemblyVersion>
-        <FileVersion>$(Version)</FileVersion>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include=""Microsoft.NETCore.Targets"" Version=""3.0.0"" PrivateAssets=""all"" />
         <PackageReference Include=""Microsoft.NET.Sdk.Functions"" Version=""4.2.0"" />
         <PackageReference Include=""Microsoft.Azure.WebJobs.Extensions.Storage"" Version=""4.0.3"" />
-<PackageReference Include=""Microsoft.Azure.WebJobs.Extensions.Http"" Version=""3.0.0"" />
-<PackageReference Include=""Microsoft.Azure.WebJobs.Extensions"" Version=""2.0.0"" />
-
+        <PackageReference Include=""Microsoft.Azure.WebJobs.Extensions.Http"" Version=""3.0.0"" />
+        <PackageReference Include=""Microsoft.Azure.WebJobs.Extensions"" Version=""2.0.0"" />
     </ItemGroup>
 
     <Target Name=""_VerifyTargetFramework"" BeforeTargets=""Build"">


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1995

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR introduces an explicit failure if the inner-build TFM is overridden. Suppressing global properties was already performed as part of #1946, but this is an extra mile to avoid any future vague issues.
