### PR TITLE
Include default values in Sdk.props

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.props
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.props
@@ -24,8 +24,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="host.json" CopyToOutputDirectory="PreserveNewest" CopyToPublisDirectory="PreserveNewest" />
-    <None Include="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublisDirectory="Never" />
+    <None Include="host.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <None Include="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.props
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.props
@@ -14,11 +14,18 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <!--Our source generators rely on the FunctionsExecutionModel property.-->
     <FunctionsExecutionModel>isolated</FunctionsExecutionModel>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);host.json;local.settings.json</DefaultExcludesInProjectFolder>
   </PropertyGroup>
 
   <!--Enable Azure Functions project capability to enable tools-->
   <ItemGroup>
-        <ProjectCapability Include="AzureFunctions"/>
+    <ProjectCapability Include="AzureFunctions"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="host.json" CopyToOutputDirectory="PreserveNewest" CopyToPublisDirectory="PreserveNewest" />
+    <None Include="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublisDirectory="Never" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -5,11 +5,6 @@
 -->
 
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.17.0-preview1 (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk <version>
 
-- Improve incremental build support for worker extension project inner build (https://github.com/Azure/azure-functions-dotnet-worker/pull/1749) 
-  - Now builds to intermediate output path
-- Resolve and pass nuget restore sources as explicit property to inner build (https://github.com/Azure/azure-functions-dotnet-worker/pull/1937)
-- Integrate inner build with existing .NET SDK targets (https://github.com/Azure/azure-functions-dotnet-worker/pull/1861)
-  - Targets have been refactored to participate with `CopyToOutputDirectory` and `CopyToPublishDirectory` instead of manually copying
-  - Incremental build support further improved
+- Set default values for `host.json`, `local.settings.json`, and `AzureFunctionsVersion` in Sdk.props (https://github.com/Azure/azure-functions-dotnet-worker/pull/2223)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR adds default values to our SDK props. This will let us update our templates to be less verbose (but customers can still use old ones)

### Changes

``` diff
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
-    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
    <OutputType>Exe</OutputType>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.1" />
    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0-preview1" />
  </ItemGroup>

-  <ItemGroup>
-    <None Update="host.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-
</Project>
```
