### PR TITLE
Update Sdk.Generators release notes

### DIFF
--- a/sdk/Sdk.Generators/Sdk.Generators.csproj
+++ b/sdk/Sdk.Generators/Sdk.Generators.csproj
@@ -10,7 +10,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <MinorProductVersion>1</MinorProductVersion>
-    <PatchProductVersion>6</PatchProductVersion>
+    <PatchProductVersion>7</PatchProductVersion>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,7 +4,11 @@
 - My change description (#PR/#issue)
 -->
 
-
 ### Microsoft.Azure.Functions.Worker.Sdk 1.17.0-preview2 (meta package)
 
 - Explicitly error out if inner-builds TFM is altered. (https://github.com/Azure/azure-functions-dotnet-worker/pull/2222)
+
+### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.1.7
+
+- Fix namespace conflict in `ExtensionStartupRunnerGenerator` (#2192).
+  - Thank you to @llJochemll for the contribution!


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Update release notes for [this](https://github.com/Azure/azure-functions-dotnet-worker/pull/2192) community contribution. Bumping generator to version to `1.1.7` as latest out is 1.1.6 (see [here](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Sdk.Generators)).

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

