### PR TITLE
adding issue templates for worker repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,18 @@
+name: Bug Report
+description: Create a report to help us improve
+labels: ["bug"]
+body: 
+- id: description
+  type: textarea
+  attributes:
+    label: Description
+    placeholder: Please provide a succinct description of the issue.
+  validations:
+    required: true
+- id: repro
+  type: textarea
+  attributes:
+    label: Steps to reproduce
+    placeholder: Please provide the steps required to reproduce the problem.
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,11 @@
+name: Feature Request
+description: Make a feature request
+labels: ["enhancement"]
+body: 
+- id: description
+  type: textarea
+  attributes:
+    label: Description
+    placeholder: Please provide a succinct description of the feature you would like to see.
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
Adding issue templates, using the new forms feature. We could also just use the standard markdown template as well.

Draft for discussion purposes. I also think the strings need some work, and likely we will want to add other sections. But I think letting that be built up over time is fine. We currently have no template, so just having one big description field is good enough to get started.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)