### PR TITLE
Forwarding command line arguments to app assembly from NetHost

### DIFF
--- a/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
+++ b/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using FunctionsNetHost.Grpc;
 
 namespace FunctionsNetHost
 {
@@ -19,6 +20,12 @@ namespace FunctionsNetHost
         private IntPtr _hostfxrHandle = IntPtr.Zero;
         private IntPtr _hostContextHandle = IntPtr.Zero;
         private bool _disposed;
+        private GrpcWorkerStartupOptions _workerStartupOptions;
+
+        internal AppLoader(GrpcWorkerStartupOptions workerStartupOptions)
+        {
+            _workerStartupOptions = workerStartupOptions;
+        }
 
         internal int RunApplication(string? assemblyPath)
         {
@@ -45,7 +52,7 @@ namespace FunctionsNetHost
 
                 Logger.LogTrace($"hostfxr loaded.");
 
-                var error = HostFxr.Initialize(1, new[] { assemblyPath }, IntPtr.Zero, out _hostContextHandle);
+                var error = HostFxr.Initialize(2, new[] { assemblyPath, _workerStartupOptions.RawCommandLineArgs }, IntPtr.Zero, out _hostContextHandle);
 
                 if (_hostContextHandle == IntPtr.Zero)
                 {

--- a/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
+++ b/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
@@ -52,8 +52,8 @@ namespace FunctionsNetHost
 
                 Logger.LogTrace($"hostfxr loaded.");
 
-                var argv = _workerStartupOptions.CommandLineArgs.Prepend(assemblyPath).ToArray();
-                var error = HostFxr.Initialize(argv.Length, argv, IntPtr.Zero, out _hostContextHandle);
+                var commandLineArguments = _workerStartupOptions.CommandLineArgs.Prepend(assemblyPath).ToArray();
+                var error = HostFxr.Initialize(commandLineArguments.Length, commandLineArguments, IntPtr.Zero, out _hostContextHandle);
 
                 if (_hostContextHandle == IntPtr.Zero)
                 {

--- a/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
+++ b/host/src/FunctionsNetHost/AppLoader/AppLoader.cs
@@ -52,7 +52,8 @@ namespace FunctionsNetHost
 
                 Logger.LogTrace($"hostfxr loaded.");
 
-                var error = HostFxr.Initialize(2, new[] { assemblyPath, _workerStartupOptions.RawCommandLineArgs }, IntPtr.Zero, out _hostContextHandle);
+                var argv = _workerStartupOptions.CommandLineArgs.Prepend(assemblyPath).ToArray();
+                var error = HostFxr.Initialize(argv.Length, argv, IntPtr.Zero, out _hostContextHandle);
 
                 if (_hostContextHandle == IntPtr.Zero)
                 {

--- a/host/src/FunctionsNetHost/Environment/EnvironmentVariables.cs
+++ b/host/src/FunctionsNetHost/Environment/EnvironmentVariables.cs
@@ -14,9 +14,4 @@ internal static class EnvironmentVariables
     /// Application pool Id for the placeholder app. Only available in Windows(when running in IIS).
     /// </summary>
     internal const string AppPoolId  = "APP_POOL_ID";
-
-    /// <summary>
-    /// Environment variable for sending ServerUri to the worker.
-    /// </summary>
-    internal const string HostEndpoint = "Functions:Worker:HostEndpoint";
 }

--- a/host/src/FunctionsNetHost/Grpc/GrpcWorkerStartupOptions.cs
+++ b/host/src/FunctionsNetHost/Grpc/GrpcWorkerStartupOptions.cs
@@ -13,6 +13,6 @@ namespace FunctionsNetHost.Grpc
 
         public int GrpcMaxMessageLength { get; set; }
 
-        public string RawCommandLineArgs { get; set; }
+        public string[] CommandLineArgs { get; set; }
     }
 }

--- a/host/src/FunctionsNetHost/Grpc/GrpcWorkerStartupOptions.cs
+++ b/host/src/FunctionsNetHost/Grpc/GrpcWorkerStartupOptions.cs
@@ -12,5 +12,7 @@ namespace FunctionsNetHost.Grpc
         public string? RequestId { get; set; }
 
         public int GrpcMaxMessageLength { get; set; }
+
+        public string RawCommandLineArgs { get; set; }
     }
 }

--- a/host/src/FunctionsNetHost/Grpc/IncomingGrpcMessageHandler.cs
+++ b/host/src/FunctionsNetHost/Grpc/IncomingGrpcMessageHandler.cs
@@ -80,8 +80,6 @@ namespace FunctionsNetHost.Grpc
                         EnvironmentUtils.SetValue(kv.Key, kv.Value);
                     }
 
-                    EnvironmentUtils.SetValue(EnvironmentVariables.HostEndpoint, _grpcWorkerStartupOptions.ServerUri.ToString());
-
 #pragma warning disable CS4014
                     Task.Run(() =>
 #pragma warning restore CS4014

--- a/host/src/FunctionsNetHost/Program.cs
+++ b/host/src/FunctionsNetHost/Program.cs
@@ -65,7 +65,7 @@ namespace FunctionsNetHost
             var argsWithoutExecutableName = args.Skip(1).ToArray();
             await rootCommand.InvokeAsync(argsWithoutExecutableName);
 
-            workerStartupOptions.RawCommandLineArgs = string.Join(" ", argsWithoutExecutableName);
+            workerStartupOptions.CommandLineArgs = argsWithoutExecutableName;
 
             return workerStartupOptions;
         }

--- a/host/src/FunctionsNetHost/Program.cs
+++ b/host/src/FunctionsNetHost/Program.cs
@@ -16,7 +16,7 @@ namespace FunctionsNetHost
 
                 var workerStartupOptions = await GetStartupOptionsFromCmdLineArgs(args);
 
-                using var appLoader = new AppLoader();
+                using var appLoader = new AppLoader(workerStartupOptions);
                 var grpcClient = new GrpcClient(workerStartupOptions, appLoader);
 
                 await grpcClient.InitAsync();
@@ -64,6 +64,8 @@ namespace FunctionsNetHost
 
             var argsWithoutExecutableName = args.Skip(1).ToArray();
             await rootCommand.InvokeAsync(argsWithoutExecutableName);
+
+            workerStartupOptions.RawCommandLineArgs = string.Join(" ", argsWithoutExecutableName);
 
             return workerStartupOptions;
         }

--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>


### PR DESCRIPTION
resolves #2256 

Forwarding command line arguments to application assembly. 
Removing redundant env variable setting code for functions URL.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
