### PR TITLE
Fixed spelling error in a comment within FunctionContext.cs

### DIFF
--- a/src/DotNetWorker.Core/Context/FunctionContext.cs
+++ b/src/DotNetWorker.Core/Context/FunctionContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Functions.Worker
         public abstract BindingContext BindingContext { get; }
 
         /// <summary>
-        /// Gets the retry context containing information about retry acvitity for the event that triggered
+        /// Gets the retry context containing information about retry activity for the event that triggered
         /// the current function invocation.
         /// </summary>
         public abstract RetryContext RetryContext { get; }


### PR DESCRIPTION
### Issue describing the changes in this PR

replaced `acvitity` with `activity`

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

