### PR TITLE
Remove redundant project reference in Sdk.Generator.Tests

### DIFF
--- a/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
+++ b/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
@@ -40,7 +40,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\extensions\Worker.Extensions.Http\src\Worker.Extensions.Http.csproj" />
     <ProjectReference Include="..\..\sdk\Sdk.Generators\Sdk.Generators.csproj" />
     <ProjectReference Include="..\DependentAssemblyWithFunctions.NetStandard\DependentAssemblyWithFunctions.NetStandard.csproj" />
     <ProjectReference Include="..\Worker.Extensions.Sample-IncorrectImplementation\Worker.Extensions.Sample-IncorrectImplementation.csproj" />


### PR DESCRIPTION
Sdk.Generator.Tests is referencing Microsoft.Azure.Functions.Worker.Extensions.Http twice, one as a package reference (which is a transitive depedency) and second as a project reference. 


* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
