### PR TITLE
Fix typo in FromBodyConversionFeature class name

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/FromBodyConversionFeature.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/FromBodyConversionFeature.cs
@@ -13,14 +13,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 {
-    internal sealed class FromBodyConverstionFeature : IFromBodyConversionFeature
+    internal sealed class FromBodyConversionFeature : IFromBodyConversionFeature
     {
-        public static FromBodyConverstionFeature Instance { get; } = new();
+        public static FromBodyConversionFeature Instance { get; } = new();
 
         public async ValueTask<object?> ConvertAsync(FunctionContext context, Type targetType)
         {
             var httpContext = context.GetHttpContext()
-                ?? throw new InvalidOperationException($"The '{nameof(FromBodyConverstionFeature)} expects an '{nameof(HttpContext)}' instance in the current context.");
+                ?? throw new InvalidOperationException($"The '{nameof(FromBodyConversionFeature)} expects an '{nameof(HttpContext)}' instance in the current context.");
 
             var metadata = httpContext.RequestServices
                            .GetService<IModelMetadataProvider>()?
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 
             if (metadata is null)
             {
-                context.GetLogger<FromBodyConverstionFeature>()
+                context.GetLogger<FromBodyConversionFeature>()
                     .LogWarning("Unable to resolve a model metadata provider for the target type ({TargetType}).", targetType);
 
                 return null;
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
                 throw new InvalidOperationException(messageBuilder.ToString());
             }
 
-            context.GetLogger<FromBodyConverstionFeature>()
+            context.GetLogger<FromBodyConversionFeature>()
                 .LogWarning("Unable to bind the request body to the target type ({TargetType}).", targetType);
 
             return null;

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             AddHttpContextToFunctionContext(context, httpContext);
 
             // Register additional context features
-            context.Features.Set<IFromBodyConversionFeature>(FromBodyConverstionFeature.Instance);
+            context.Features.Set<IFromBodyConversionFeature>(FromBodyConversionFeature.Instance);
 
             await next(context);
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Renamed `FromBodyConverstionFeature` class and .cs file to `FromBodyConversionFeature`

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)