### PR TITLE
Updating Service Bus sample with auto-completion property

### DIFF
--- a/samples/Extensions/Extensions.csproj
+++ b/samples/Extensions/Extensions.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Kafka" Version="3.10.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.RabbitMQ" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.16.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.SignalRService" Version="1.13.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.3.0" />
@@ -32,9 +32,4 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
-  <!--  TEMP Remove and update package version once ServiceBusMessageActions is shipped-->
-  <ItemGroup>
-    <ProjectReference Include="..\..\extensions\Worker.Extensions.ServiceBus\src\Worker.Extensions.ServiceBus.csproj" />
-  </ItemGroup>
-  <!--  End TEMP-->
 </Project>

--- a/samples/Extensions/ServiceBus/ServiceBusReceivedMessageFunctions.cs
+++ b/samples/Extensions/ServiceBus/ServiceBusReceivedMessageFunctions.cs
@@ -78,7 +78,7 @@ namespace SampleApp
         //<docsnippet_servicebus_message_actions>
         [Function(nameof(ServiceBusMessageActionsFunction))]
         public async Task ServiceBusMessageActionsFunction(
-            [ServiceBusTrigger("queue", Connection = "ServiceBusConnection")]
+            [ServiceBusTrigger("queue", Connection = "ServiceBusConnection", AutoCompleteMessages = false)]
             ServiceBusReceivedMessage message,
             ServiceBusMessageActions messageActions)
         {


### PR DESCRIPTION
Updating the sample to use the `AutoCompleteMessages` attribute property when the function code is handling settlement.

### Issue describing the changes in this PR

This does not resolve the issue, but this is a necessary change to provide documentation for the mitigation described in #2142.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] I have added all required tests (Unit tests, E2E tests)

This PR is initially being opened as a draft and should not be merged prior to docs on learn.microsoft.com being updated to describe the property.