### PR TITLE
Improvements to NetHost logging & worker.config.

### DIFF
--- a/host/src/FunctionsNetHost/Configuration/Configuration.cs
+++ b/host/src/FunctionsNetHost/Configuration/Configuration.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace FunctionsNetHost
+{
+    /// <summary>
+    /// Represents the application configuration.
+    /// </summary>
+    internal static class Configuration
+    {
+        private const string DefaultLogPrefix = "LanguageWorkerConsoleLog";
+
+        static Configuration()
+        {
+            Reload();
+        }
+
+        /// <summary>
+        /// Force the configuration values to be reloaded.
+        /// </summary>
+        internal static void Reload()
+        {
+            IsTraceLogEnabled = string.Equals(EnvironmentUtils.GetValue(EnvironmentVariables.EnableTraceLogs), "1");
+            var disableLogPrefix = string.Equals(EnvironmentUtils.GetValue(EnvironmentVariables.DisableLogPrefix), "1");
+            LogPrefix = disableLogPrefix ? string.Empty : DefaultLogPrefix;
+        }
+
+        /// <summary>
+        /// Gets the log prefix for the log messages.
+        /// </summary>
+        internal static string? LogPrefix { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether trace level logging is enabled.
+        /// </summary>
+        internal static bool IsTraceLogEnabled { get; private set; }
+    }
+}

--- a/host/src/FunctionsNetHost/Environment/EnvironmentVariables.cs
+++ b/host/src/FunctionsNetHost/Environment/EnvironmentVariables.cs
@@ -6,9 +6,15 @@ namespace FunctionsNetHost;
 internal static class EnvironmentVariables
 {
     /// <summary>
-    /// Set value to "1" for enabling extra trace logs in FunctionsNetHost.
+    /// Set value to "1" will prevent the log entries to have the prefix "LanguageWorkerConsoleLog".
+    /// Set this to see logs when you are debugging FunctionsNetHost locally with WebHost.
     /// </summary>
-    internal const string FunctionsNetHostTrace = "AZURE_FUNCTIONS_FUNCTIONSNETHOST_TRACE";
+    internal const string DisableLogPrefix = "AZURE_FUNCTIONS_FUNCTIONSNETHOST_DISABLE_LOGPREFIX";
+
+    /// <summary>
+    /// Set value to "1" for enabling additional trace logs in FunctionsNetHost.
+    /// </summary>
+    internal const string EnableTraceLogs = "AZURE_FUNCTIONS_FUNCTIONSNETHOST_TRACE";
 
     /// <summary>
     /// Application pool Id for the placeholder app. Only available in Windows(when running in IIS).

--- a/host/src/FunctionsNetHost/Grpc/IncomingGrpcMessageHandler.cs
+++ b/host/src/FunctionsNetHost/Grpc/IncomingGrpcMessageHandler.cs
@@ -50,6 +50,7 @@ namespace FunctionsNetHost.Grpc
                     }
                 case StreamingMessage.ContentOneofCase.FunctionEnvironmentReloadRequest:
 
+                    Configuration.Reload();
                     Logger.LogTrace("Specialization request received.");
 
                     var envReloadRequest = msg.FunctionEnvironmentReloadRequest;

--- a/host/src/FunctionsNetHost/Logger.cs
+++ b/host/src/FunctionsNetHost/Logger.cs
@@ -8,22 +8,13 @@ namespace FunctionsNetHost
     internal static class Logger
     {
         private static readonly string LogPrefix;
+        private static readonly bool IsTraceLogEnabled;
 
         static Logger()
         {
-#if !DEBUG
-            LogPrefix = "LanguageWorkerConsoleLog";
-#else
-            LogPrefix = "";
-#endif
-        }
-
-        internal static bool IsTraceLogEnabled
-        {
-            get
-            {
-                return string.Equals(EnvironmentUtils.GetValue(EnvironmentVariables.FunctionsNetHostTrace), "1");
-            }
+            IsTraceLogEnabled = string.Equals(EnvironmentUtils.GetValue(EnvironmentVariables.EnableTraceLogs), "1");
+            var disableLogPrefix = string.Equals(EnvironmentUtils.GetValue(EnvironmentVariables.DisableLogPrefix), "1");
+            LogPrefix = disableLogPrefix ? string.Empty : "LanguageWorkerConsoleLog";
         }
 
         /// <summary>

--- a/host/src/FunctionsNetHost/Logger.cs
+++ b/host/src/FunctionsNetHost/Logger.cs
@@ -7,22 +7,12 @@ namespace FunctionsNetHost
 {
     internal static class Logger
     {
-        private static readonly string LogPrefix;
-        private static readonly bool IsTraceLogEnabled;
-
-        static Logger()
-        {
-            IsTraceLogEnabled = string.Equals(EnvironmentUtils.GetValue(EnvironmentVariables.EnableTraceLogs), "1");
-            var disableLogPrefix = string.Equals(EnvironmentUtils.GetValue(EnvironmentVariables.DisableLogPrefix), "1");
-            LogPrefix = disableLogPrefix ? string.Empty : "LanguageWorkerConsoleLog";
-        }
-
         /// <summary>
-        /// Logs a trace message if "AZURE_FUNCTIONS_FUNCTIONSNETHOST_TRACE" environment variable value is set to "1"
+        /// Logs a trace message if trace level logging is enabled.
         /// </summary>
         internal static void LogTrace(string message)
         {
-            if (IsTraceLogEnabled)
+            if (Configuration.IsTraceLogEnabled)
             {
                 Log(message);
             }
@@ -31,7 +21,7 @@ namespace FunctionsNetHost
         internal static void Log(string message)
         {
             var ts = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
-            Console.WriteLine($"{LogPrefix}[{ts}] [FunctionsNetHost] {message}");
+            Console.WriteLine($"{Configuration.LogPrefix}[{ts}] [FunctionsNetHost] {message}");
         }
     }
 }

--- a/host/tools/build/worker.config.json
+++ b/host/tools/build/worker.config.json
@@ -2,23 +2,45 @@
   "description": {
     "language": "dotnet-isolated",
     "extensions": [ ".dll" ],
-    "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost.exe",
-    "defaultWorkerPath": "bin/FunctionsNetHost.exe",
     "workerIndexing": "true"
   },
   "profiles": [
     {
-      "profileName": "DotnetIsolatedLinux",
+      "profileName": "DotnetIsolatedLinuxPlaceholder",
       "conditions": [
         {
           "conditionType": "hostProperty",
           "conditionName": "platform",
           "conditionExpression": "LINUX"
+        },
+        {
+          "conditionType": "environment",
+          "conditionName": "INITIALIZED_FROM_PLACEHOLDER",
+          "conditionExpression": "(?i)true$"
         }
       ],
       "description": {
         "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost",
         "defaultWorkerPath": "bin/FunctionsNetHost"
+      }
+    },
+    {
+      "profileName": "DotnetIsolatedWindowsPlaceholder",
+      "conditions": [
+        {
+          "conditionType": "hostProperty",
+          "conditionName": "platform",
+          "conditionExpression": "WINDOWS"
+        },
+        {
+          "conditionType": "environment",
+          "conditionName": "INITIALIZED_FROM_PLACEHOLDER",
+          "conditionExpression": "(?i)true$"
+        }
+      ],
+      "description": {
+        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost.exe",
+        "defaultWorkerPath": "bin/FunctionsNetHost.exe"
       }
     }
   ]


### PR DESCRIPTION
#### 1. Logging
Improvements to logging in FNH. Currently we query the env variable for every call to TraceLog method. Based on the usecases I have encountered so far, I do not see a reason for the env value to change after the placeholder started. So I think it makes sense to read that only once during startup.

Also adding some customization to not prepend the special log prefix we add to the messages. This is helpful for local debugging. Previous version did this only for Debug build and this PR is changing it to rely on an env variable.

#### 2. Worker.config

Updated worker config to include one more profile condition which evaluates the environment variable `INITIALIZED_FROM_PLACEHOLDER`. This will ensure that FunctionsNetHost will never be launched in non placeholder mode. During some recent investigations, we found that FNH is being launched in specialization time.  Java worker config [uses this condition](https://github.com/Azure/azure-functions-java-worker/blob/c92d38cdeb867f2f7e2ae9b2515c32c2ecfd1e41/worker.config.json#L34C49-L34C62).

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
