### PR TITLE
Re-add SDK refactor with referenced assembly scanning fixed.

### DIFF
--- a/DotNetWorker.sln
+++ b/DotNetWorker.sln
@@ -140,6 +140,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worker.Extensions.Shared.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Http.AspNetCore.Analyzers", "extensions\Worker.Extensions.Http.AspNetCore.Analyzers\Worker.Extensions.Http.AspNetCore.Analyzers.csproj", "{7B6C2920-7A02-43B2-8DA0-7B76B9FAFC6B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Net7Worker", "samples\Net7Worker\Net7Worker.csproj", "{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependentAssemblyWithFunctions.NetStandard", "test\DependentAssemblyWithFunctions.NetStandard\DependentAssemblyWithFunctions.NetStandard.csproj", "{198DA072-F94F-4585-A744-97B3DAC21686}"
 EndProject
 Global
@@ -344,6 +346,10 @@ Global
 		{D8E79B53-9A44-46CC-9D7A-E9494FC8CAF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D8E79B53-9A44-46CC-9D7A-E9494FC8CAF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8E79B53-9A44-46CC-9D7A-E9494FC8CAF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B6342174-5436-4846-B43C-39D8E34AE5CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B6342174-5436-4846-B43C-39D8E34AE5CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6342174-5436-4846-B43C-39D8E34AE5CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -417,6 +423,7 @@ Global
 		{D8E79B53-9A44-46CC-9D7A-E9494FC8CAF4} = {AA4D318D-101B-49E7-A4EC-B34165AEDB33}
 		{B6342174-5436-4846-B43C-39D8E34AE5CF} = {FD7243E4-BF18-43F8-8744-BA1D17ACF378}
 		{7B6C2920-7A02-43B2-8DA0-7B76B9FAFC6B} = {A7B4FF1E-3DF7-4F28-9333-D0961CDDF702}
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF} = {9D6603BD-7EA2-4D11-A69C-0D9E01317FD6}
 		{198DA072-F94F-4585-A744-97B3DAC21686} = {B5821230-6E0A-4535-88A9-ED31B6F07596}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/build/Sdk.slnf
+++ b/build/Sdk.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "..\\DotNetWorker.sln",
+    "projects": [
+      "sdk\\Sdk.Analyzers\\Sdk.Analyzers.csproj",
+      "sdk\\Sdk.Generators\\Sdk.Generators.csproj",
+      "sdk\\Sdk\\Sdk.csproj"
+    ]
+  }
+}

--- a/samples/FunctionApp/FunctionApp.csproj
+++ b/samples/FunctionApp/FunctionApp.csproj
@@ -7,6 +7,7 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
+    <SdkVersion>1.17.2</SdkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -14,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="$(SdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>

--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
 {
     internal class ExtensionsCsprojGenerator
     {
-        private const string ExtensionsProjectName = "WorkerExtensions.csproj";
+        internal const string ExtensionsProjectName = "WorkerExtensions.csproj";
 
         private readonly IDictionary<string, string> _extensions;
         private readonly string _outputPath;
@@ -31,9 +31,20 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         {
             var extensionsCsprojFilePath = Path.Combine(_outputPath, ExtensionsProjectName);
 
-            RecreateDirectory(_outputPath);
+            string csproj = GetCsProjContent();
+            if (File.Exists(extensionsCsprojFilePath))
+            {
+                string existing = File.ReadAllText(extensionsCsprojFilePath);
+                if (string.Equals(csproj, existing, StringComparison.Ordinal))
+                {
+                    // If contents are the same, only touch the file to update timestamp.
+                    File.SetLastWriteTimeUtc(extensionsCsprojFilePath, DateTime.UtcNow);
+                    return;
+                }
+            }
 
-            WriteExtensionsCsProj(extensionsCsprojFilePath);
+            RecreateDirectory(_outputPath);
+            File.WriteAllText(extensionsCsprojFilePath, csproj);
         }
 
         private void RecreateDirectory(string directoryPath)
@@ -44,13 +55,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             }
 
             Directory.CreateDirectory(directoryPath);
-        }
-
-        private void WriteExtensionsCsProj(string filePath)
-        {
-            string csprojContent = GetCsProjContent();
-
-            File.WriteAllText(filePath, csprojContent);
         }
 
         internal string GetCsProjContent()

--- a/sdk/Sdk/FunctionMetadataGenerator.cs
+++ b/sdk/Sdk/FunctionMetadataGenerator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
             {
                 using (_logger.Indent())
                 {
-                    _logger.LogMessage($"{Path.GetFileName(path)}");
+                    _logger.LogMessage($"Collecting function metadata from {Path.GetFileName(path)}.");
 
                     using (_logger.Indent())
                     {

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <MinorProductVersion>17</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
+    <PatchProductVersion>3</PatchProductVersion>
+    <VersionSuffix>-preview1</VersionSuffix>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinorProductVersion>17</MinorProductVersion>
-    <PatchProductVersion>2</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -8,437 +8,215 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 ***********************************************************************************************
 -->
-<Project ToolsVersion="14.0"
-         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <_ToolingSuffix></_ToolingSuffix>
-        <_AzureFunctionsNotSet Condition="'$(AzureFunctionsVersion)' == ''">true</_AzureFunctionsNotSet>
-        <AzureFunctionsVersion Condition="'$(AzureFunctionsVersion)' == ''">v3</AzureFunctionsVersion>
-        <_ToolingSuffix Condition="($(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) Or $(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v5.0'">net5-isolated</_ToolingSuffix>
-        <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">net6-isolated</_ToolingSuffix>
-        <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v7.0'">net7-isolated</_ToolingSuffix>
-        <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-isolated</_ToolingSuffix>
-        <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETFramework'">netfx-isolated</_ToolingSuffix>
-        <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
-        <_FunctionsTaskFramework Condition=" '$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</_FunctionsTaskFramework>
-        <_FunctionsTaskFramework Condition=" '$(_FunctionsTaskFramework)' == ''">net472</_FunctionsTaskFramework>
-        <_FunctionsTasksDir Condition=" '$(_FunctionsTasksDir)'=='' ">$(MSBuildThisFileDirectory)..\tools\$(_FunctionsTaskFramework)\</_FunctionsTasksDir>
-        <_FunctionsTaskAssemblyFullPath Condition=" '$(_FunctionsTaskAssemblyFullPath)'=='' ">$(_FunctionsTasksDir)\Microsoft.Azure.Functions.Worker.Sdk.dll</_FunctionsTaskAssemblyFullPath>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_ToolingSuffix></_ToolingSuffix>
+    <_AzureFunctionsNotSet Condition="'$(AzureFunctionsVersion)' == ''">true</_AzureFunctionsNotSet>
+    <AzureFunctionsVersion Condition="'$(AzureFunctionsVersion)' == ''">v4</AzureFunctionsVersion>
+    <_ToolingSuffix Condition="($(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) Or $(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v5.0'">net5-isolated</_ToolingSuffix>
+    <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">net6-isolated</_ToolingSuffix>
+    <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v7.0'">net7-isolated</_ToolingSuffix>
+    <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-isolated</_ToolingSuffix>
+    <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETFramework'">netfx-isolated</_ToolingSuffix>
+    <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
+    <_FunctionsTaskFramework Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</_FunctionsTaskFramework>
+    <_FunctionsTaskFramework Condition="'$(_FunctionsTaskFramework)' == ''">net472</_FunctionsTaskFramework>
+    <_FunctionsTasksDir Condition="'$(_FunctionsTasksDir)'==''">$(MSBuildThisFileDirectory)..\tools\$(_FunctionsTaskFramework)\</_FunctionsTasksDir>
+    <_FunctionsTaskAssemblyFullPath Condition=" '$(_FunctionsTaskAssemblyFullPath)'=='' ">$(_FunctionsTasksDir)\Microsoft.Azure.Functions.Worker.Sdk.dll</_FunctionsTaskAssemblyFullPath>
 
-        <_FunctionsWorkerConfigInputFile>$(MSBuildThisFileDirectory)\..\tools\worker.config.json</_FunctionsWorkerConfigInputFile>
+    <_FunctionsExtensionCommonProps>ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ImportDirectoryPackagesProps=false</_FunctionsExtensionCommonProps>
+    <_FunctionsExtensionRemoveProps>TargetFramework;Platform;RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;UseCurrentRuntimeIdentifier;WebPublishMethod;PublishProfile;DeployOnBuild;PublishDir</_FunctionsExtensionRemoveProps>
+    <_FunctionsWorkerConfigInputFile>$(MSBuildThisFileDirectory)\..\tools\worker.config.json</_FunctionsWorkerConfigInputFile>
 
-        <_FunctionsMetadataLoaderExtensionFile>$(MSBuildThisFileDirectory)\..\tools\netstandard2.0\Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll</_FunctionsMetadataLoaderExtensionFile>
-        <_FunctionsExtensionsDirectory>.azurefunctions</_FunctionsExtensionsDirectory>
-        <_FunctionsExtensionsJsonName>extensions.json</_FunctionsExtensionsJsonName>
-        <_FunctionsExtensionsFullPublish Condition="$(NoBuild) == '' And $(_FunctionsExtensionsFullPublish) == ''">True</_FunctionsExtensionsFullPublish>
-        <_FunctionsExtensionsFullPublish Condition="$(_FunctionsExtensionsFullPublish) == ''">!$(NoBuild)</_FunctionsExtensionsFullPublish>
-        <MSBuildFunctionsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Functions\</MSBuildFunctionsTargetsPath>
-      
-        <FunctionsEnablePlaceholder Condition="$(FunctionsEnablePlaceholder) == ''">false</FunctionsEnablePlaceholder>
-        <FunctionsEnableWorkerIndexing Condition="$(FunctionsEnableWorkerIndexing) == '' Or $(FunctionsEnableWorkerIndexing)">true</FunctionsEnableWorkerIndexing>
-        <FunctionsEnableMetadataSourceGen>$(FunctionsEnableWorkerIndexing)</FunctionsEnableMetadataSourceGen>
-        <FunctionsAutoRegisterGeneratedMetadataProvider>$(FunctionsEnableWorkerIndexing)</FunctionsAutoRegisterGeneratedMetadataProvider>
-        <FunctionsEnableExecutorSourceGen Condition="$(FunctionsEnableExecutorSourceGen) == '' Or $(FunctionsEnableExecutorSourceGen)">true</FunctionsEnableExecutorSourceGen>
-        <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor) == ''">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
-        <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="$(FunctionsAutoRegisterGeneratedFunctionsExecutor)">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
-        <FunctionsGeneratedCodeNamespace Condition="$(FunctionsGeneratedCodeNamespace) == ''">$(RootNamespace.Replace("-", "_"))</FunctionsGeneratedCodeNamespace> 
-    </PropertyGroup>
+    <_FunctionsMetadataLoaderExtensionFile>$(MSBuildThisFileDirectory)\..\tools\netstandard2.0\Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll</_FunctionsMetadataLoaderExtensionFile>
+    <_FunctionsExtensionsDirectory>.azurefunctions</_FunctionsExtensionsDirectory>
+    <_FunctionsExtensionsJsonName>extensions.json</_FunctionsExtensionsJsonName>
+    <MSBuildFunctionsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Functions\</MSBuildFunctionsTargetsPath>
 
-    <UsingTask TaskName="GenerateFunctionMetadata"
-             AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
+    <FunctionsEnablePlaceholder Condition="'$(FunctionsEnablePlaceholder)' == ''">false</FunctionsEnablePlaceholder>
+    <FunctionsEnableWorkerIndexing Condition="'$(FunctionsEnableWorkerIndexing)' == ''">true</FunctionsEnableWorkerIndexing>
+    <FunctionsEnableMetadataSourceGen>$(FunctionsEnableWorkerIndexing)</FunctionsEnableMetadataSourceGen>
+    <FunctionsAutoRegisterGeneratedMetadataProvider>$(FunctionsEnableWorkerIndexing)</FunctionsAutoRegisterGeneratedMetadataProvider> 
 
-    <UsingTask TaskName="CreateZipFileTask"
-             AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
+    <FunctionsEnableExecutorSourceGen Condition="'$(FunctionsEnableExecutorSourceGen)' == ''">true</FunctionsEnableExecutorSourceGen>
+    <FunctionsAutoRegisterGeneratedFunctionsExecutor Condition="'$(FunctionsAutoRegisterGeneratedFunctionsExecutor)' == ''">true</FunctionsAutoRegisterGeneratedFunctionsExecutor>
 
-    <UsingTask TaskName="ZipDeployTask"
-              AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
+    <_FunctionsGenerateExtensionProject Condition="'$(DesignTimeBuild)' != 'true'">true</_FunctionsGenerateExtensionProject>
+    <FunctionsGeneratedCodeNamespace Condition="'$(FunctionsGeneratedCodeNamespace)' == ''">$(RootNamespace.Replace("-", "_"))</FunctionsGeneratedCodeNamespace>
+  </PropertyGroup>
 
-    <Import Project="$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets"
-           Condition="Exists('$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets')" />
+  <UsingTask TaskName="GenerateFunctionMetadata" AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
+  <UsingTask TaskName="CreateZipFileTask" AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
+  <UsingTask TaskName="ZipDeployTask" AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
+  <UsingTask TaskName="EnhanceExtensionsMetadata" AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
 
-    <Target Name="_FunctionsPreBuild" BeforeTargets="BeforeBuild">
-        <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="high" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to v3"/>
-        <Error Condition="$(AzureFunctionsVersion.StartsWith('v1',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v4"/>
-        <Error Condition="$(AzureFunctionsVersion.StartsWith('v2',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v3"/>
-        <Error Condition="!$(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) And !$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version"/>
-        <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set."/>
-        <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps."/>
-    </Target>
+  <Import Project="$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets"
+          Condition="Exists('$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets')" />
 
-    <PropertyGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
-        <_FunctionsWorkerExecutableFileName >$(TargetName)$(TargetExt)</_FunctionsWorkerExecutableFileName>
-    </PropertyGroup>
-  
-    <PropertyGroup Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">
-        <_FunctionsNativeExecutableExtension Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win')))">.exe</_FunctionsNativeExecutableExtension>
-        <_FunctionsWorkerExecutableFileName Condition="'$(PublishAot)' != 'true'">$(TargetName).dll</_FunctionsWorkerExecutableFileName>
-        <_FunctionsWorkerExecutableFileName Condition="'$(PublishAot)' == 'true'">$(TargetName)$(_FunctionsNativeExecutableExtension)</_FunctionsWorkerExecutableFileName>
-    </PropertyGroup>
-
-    <Target Name="_FunctionsPostBuild" AfterTargets="AfterBuild" DependsOnTargets="_FunctionsPostBuildNetFx;_FunctionsPostBuildNetApp"/>
-    <!--.NET Framework post build-->
-    <Target Name="_FunctionsPostBuildNetFx" Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
-        <PropertyGroup>
-            <OutputFile>$(TargetDir)\worker.config.json</OutputFile>
-            <ExtensionsCsProjFilePath>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ExtensionsCsProjFilePath>
-        </PropertyGroup>
-
-        <GenerateFunctionMetadata
-          AssemblyPath="$(TargetDir)$(AssemblyName).exe"
-          ReferencePaths="@(ReferencePath)"
-          ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
-          AzureFunctionsVersion="$(AzureFunctionsVersion)"
-          TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
-          TargetFrameworkVersion="$(TargetFrameworkVersion)"
-          OutputPath="$(TargetDir)"/>
-
-        <!-- Do not copy _FunctionsMetadataLoaderExtensionFile when in placeholder mode, as we don't want the FunctionMetadataLoader entry in extensions.json-->
-        <Copy
-          Condition="!$(FunctionsEnablePlaceholder)"
-          SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
-          DestinationFolder="$(ExtensionsCsProjFilePath)\buildout"
-          OverwriteReadOnlyFiles="true" />
-
-        <WriteLinesToFile
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', '{WorkerRoot}$(TargetName).exe')
-                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-            Overwrite="true" />
-    </Target>
-
-    <!--.NET/.NET Core post build-->
-    <Target Name="_FunctionsPostBuildNetApp" Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">
-        <PropertyGroup>
-            <OutputFile>$(TargetDir)\worker.config.json</OutputFile>
-            <ExtensionsCsProjFilePath>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ExtensionsCsProjFilePath>
-        </PropertyGroup>
-
-        <GenerateFunctionMetadata
-          AssemblyPath="$(TargetDir)$(AssemblyName).dll"
-          ReferencePaths="@(ReferencePath)"
-          ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
-          AzureFunctionsVersion="$(AzureFunctionsVersion)"
-          TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
-          TargetFrameworkVersion="$(TargetFrameworkVersion)"
-          OutputPath="$(TargetDir)"/>
-        <!-- Do not copy _FunctionsMetadataLoaderExtensionFile when in placeholder mode, as we don't want the FunctionMetadataLoader entry in extensions.json--> 
-        <Copy
-          Condition="!$(FunctionsEnablePlaceholder)"
-          SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
-          DestinationFolder="$(ExtensionsCsProjFilePath)\buildout"
-          OverwriteReadOnlyFiles="true" />
-
-        <WriteLinesToFile
-            Condition="$(SelfContained)"
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', '{WorkerRoot}$(TargetName)')
-                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-        Overwrite="true" />
-
-
-        <WriteLinesToFile
-            Condition="!$(SelfContained)"
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', 'dotnet')
-                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-        Overwrite="true" />
-
+  <!-- Validating some expectations for the function app early on. -->
+  <Target Name="_FunctionsPreBuild" BeforeTargets="BeforeBuild">
+    <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="high" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to v3"/>
+    <Error Condition="$(AzureFunctionsVersion.StartsWith('v1',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v4"/>
+    <Error Condition="$(AzureFunctionsVersion.StartsWith('v2',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v3"/>
+    <Error Condition="!$(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) And !$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version"/>
+    <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set."/>
+    <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps."/>
   </Target>
 
+  <!-- These two targets set up the main sequence of targets we want to run and when we want to run them. -->
+  <Target Name="_FunctionsInnerBuild"
+    Condition="'$(_FunctionsGenerateExtensionProject)' == 'true'"
+    AfterTargets="CoreCompile"
+    BeforeTargets="CopyFilesToOutputDirectory"
+    DependsOnTargets="_FunctionsGenerateMetadata;_FunctionsPostBuild;_WorkerExtensionsBuild;_FunctionsExtensionAssignTargetPaths" />
 
-    <!--
-  Build the webjobs extensions in ".azurefunctions"
-  -->
-    <!--
-  We need to copy all files from <build-out>/bin except for "runtimes" directory. The "runtimes" directory inside "bin" doesn't contain the binaries for all platforms.
-  This is due to a bug in Functions SDK. Until that is fixed, we need to copy "runtimes" directly from build output, instead of copying from the "bin".
-  -->
-    <Target Name ="_WorkerExtensionsBuildCopy" AfterTargets="_WorkerExtensionsBuild">
-        <ItemGroup>
-            <ExtensionBinaries Include="$(ExtensionsCsProjFilePath)\buildout\bin\**\*.*"
-                               Exclude="$(ExtensionsCsProjFilePath)\buildout\bin\runtimes\**\*.*" />
-            <ExtensionRuntimeBinaries Include="$(ExtensionsCsProjFilePath)\buildout\runtimes\**\*.*" />
-        </ItemGroup>
+  <!-- For publish we have very little targets. Either:
+    1) It is a publish with build, in which case _FunctionsInnerBuild will already be ran.
+    2) It is publish no-build, in which case we assume everything is as expected in the output directory already. -->
+  <Target Name="_FunctionsInnerPublish" BeforeTargets="GetCopyToPublishDirectoryItems" DependsOnTargets="_FunctionsExtensionAssignTargetPaths" />
 
-        <Copy SourceFiles="@(ExtensionBinaries)" DestinationFolder="$(TargetDir)\.azurefunctions\%(RecursiveDir)" />
-        <Copy SourceFiles="@(ExtensionRuntimeBinaries)" DestinationFolder="$(TargetDir)\.azurefunctions\runtimes\%(RecursiveDir)" />
-    </Target>
+  <!-- This is a no-op target purely for backwards compatibilty. Remove this with a major version rev. -->
+  <Target Name="_FunctionsPostBuild" />
 
-    <Target Name ="_WorkerExtensionsBuild" AfterTargets="_WorkerExtensionsRestore">
-        <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" Targets="Build" RemoveProperties="DeployOnBuild" Properties="Configuration=Release;OutputPath=$(ExtensionsCsProjFilePath)\buildout;CopyLocalLockFileAssemblies=true"/>
-    </Target>
-
-    <Target Name="_WorkerExtensionsRestore" AfterTargets="_FunctionsPostBuild">
-        <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" Targets="Restore" Properties="IsRestoring=true"/>
-    </Target>
-
-    <!--
-  Add HintPath to references in "extensions.json"
-  -->
-    <UsingTask TaskName="EnhanceExtensionsMetadata"
-             AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
-
-    <Target Name="_EnhanceFunctionsExtensionsMetadataPostBuild"
-            AfterTargets="_WorkerExtensionsBuildCopy">
-
-        <EnhanceExtensionsMetadata
-          ExtensionsJsonPath="$(TargetDir)\$(_FunctionsExtensionsDirectory)\$(_FunctionsExtensionsJsonName)"
-          OutputPath="$(TargetDir)\$(_FunctionsExtensionsJsonName)"/>
-
-    </Target>
-
-    <!--
-  ***********************************************************************************************
-  Import the Publish target
-  ***********************************************************************************************
- -->
-    <Import Project="$(MSBuildThisFileDirectory)Microsoft.Azure.Functions.Worker.Sdk.Publish.targets"
-            Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Azure.Functions.Worker.Sdk.Publish.targets')" />
-
-    <Target
-      Name="_CleanFunctions"
-      AfterTargets="Clean">
-
-        <ItemGroup>
-            <_FilesInTargetDir Include="$(TargetDir)**\*" />
-        </ItemGroup>
-
-        <Delete Files="@(_FilesInTargetDir)"
-                ContinueOnError="true" />
-
-        <RemoveDir Directories="$(TargetDir)"
-                   ContinueOnError="true" />
-    </Target>
-
-    <!--
-  Publish targets from Functions SDK
-  -->
-
-    <Target Name="_InitializeDotNetPublishProperties"
-            BeforeTargets="PrepareForPublish"
-            Condition="'$(DeployOnBuild)' != 'true'">
-
-        <ConvertToAbsolutePath Paths="$(PublishDir)">
-            <Output TaskParameter="AbsolutePaths"
-                    PropertyName="FunctionsDir"/>
-        </ConvertToAbsolutePath>
-
-        <PropertyGroup>
-            <PublishDir>$(FunctionsDir)</PublishDir>
-            <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-            <FunctionsTargetPath>$(PublishDir)bin\$(TargetFileName)</FunctionsTargetPath>
-            <FunctionsOutputPath>$(FunctionsDir)</FunctionsOutputPath>
-        </PropertyGroup>
-
-    </Target>
-
-    <Target Name="_InitializeDeployOnBuildProperties" >
-
-        <ConvertToAbsolutePath Paths="$(PublishIntermediateOutputPath)">
-            <Output TaskParameter="AbsolutePaths"
-                    PropertyName="PublishIntermediateOutputPath"/>
-        </ConvertToAbsolutePath>
-
-        <PropertyGroup>
-            <PublishDir>$(PublishIntermediateOutputPath)</PublishDir>
-            <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-            <FunctionsTargetPath>$(PublishDir)bin\$(TargetFileName)</FunctionsTargetPath>
-            <FunctionsOutputPath>$(PublishIntermediateOutputPath)</FunctionsOutputPath>
-        </PropertyGroup>
-
-        <!-- Remove all the files from the temp directory first-->
-        <ItemGroup>
-            <_PublishTempFiles Include="$(PublishIntermediateOutputPath)**\*.*" />
-        </ItemGroup>
-
-        <Delete Files="@(_PublishTempFiles)"
-                ContinueOnError="true" />
-
-        <RemoveDir Directories="$(PublishIntermediateOutputPath)"
-                   ContinueOnError="true"
-                   Condition="Exists('$(PublishIntermediateOutputPath)')" />
-
-        <MakeDir Directories="$(PublishIntermediateOutputPath)"
-                 Condition="!Exists('$(PublishIntermediateOutputPath)')"/>
-
-    </Target>
-
-    <Target Name="_FunctionsPostPublish"
-          AfterTargets="Publish"
-          DependsOnTargets="_GenerateFunctionsAndCopyContentFiles;_WorkerExtensionsPublish"
-          >
-    </Target>
-
-    <!--
-    ============================================================
-
-    This targets gets called when publish is invoked with DeployOnBuild
-    set. This target is responsible for overriding the publish targets
-    from Publish SDK and generating function.json during publish.
-
-    ============================================================
-    -->
-
+  <!-- Setting up some paths we will use for later targets. Broken out into its own as we want to pull it in not just for build (ie: Clean also). -->
+  <Target Name="_FunctionsGetPaths">
     <PropertyGroup>
-        <CorePublishDependsOn>
-            _InitializeDeployOnBuildProperties;
-            Publish;
-            $(_DotNetPublishFiles);
-        </CorePublishDependsOn>
+      <_FunctionsMetadataPath>$(IntermediateOutputPath)functions.metadata</_FunctionsMetadataPath>
+      <_FunctionsWorkerConfigPath>$(IntermediateOutputPath)worker.config.json</_FunctionsWorkerConfigPath>
+      <ExtensionsCsProjDirectory Condition="'$(ExtensionsCsProjDirectory)' == ''">$(IntermediateOutputPath)WorkerExtensions</ExtensionsCsProjDirectory>
+      <ExtensionsCsProjDirectory>$([System.IO.Path]::GetFullPath($(ExtensionsCsProjDirectory)))</ExtensionsCsProjDirectory> <!-- Ensure ExtensionsCsProjDirectory is a full path. -->
+      <ExtensionsCsProj>$([System.IO.Path]::Combine($(ExtensionsCsProjDirectory), WorkerExtensions.csproj))</ExtensionsCsProj>
+      <_FunctionsIntermediateExtensionJsonPath>$(ExtensionsCsProjDirectory)\buildout\bin\$(_FunctionsExtensionsJsonName)</_FunctionsIntermediateExtensionJsonPath>
+      <_FunctionsIntermediateExtensionUpdatedJsonPath>$(IntermediateOutputPath)$(_FunctionsExtensionsJsonName)</_FunctionsIntermediateExtensionUpdatedJsonPath>
+    </PropertyGroup>
+  </Target>
+
+  <!-- We have a few files we can tell the .NET SDK targets to copy for us early on in the build. -->
+  <Target Name="_FunctionsPreBuild" DependsOnTargets="_FunctionsGetPaths" BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <None Include="$(_FunctionsMetadataPath)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" TargetPath="functions.metadata"  />
+      <None Include="$(_FunctionsWorkerConfigPath)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" TargetPath="worker.config.json" />
+      <None Include="$(_FunctionsIntermediateExtensionUpdatedJsonPath)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" TargetPath="$(_FunctionsExtensionsJsonName)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Helper target to granularly order more targets. -->
+  <Target Name="_FunctionsGenerateMetadata"
+    Condition="'$(_FunctionsGenerateExtensionProject)' == 'true'"
+    DependsOnTargets="_FunctionsGenerateCommon;_FunctionsCopyMetadataLoader;_FunctionsGenerateWorkerConfig" />
+
+  <!-- Generates the extension files. Generates functions.metadata and the WorkerExtension.csproj -->
+  <Target Name="_FunctionsGenerateCommon" Inputs="@(IntermediateAssembly);@(ReferencePath)" Outputs="$(_FunctionsMetadataPath);$(ExtensionsCsProj)">
+    <GenerateFunctionMetadata
+      AssemblyPath="$(IntermediateOutputPath)$(TargetName)$(TargetExt)"
+      ReferencePaths="@(ReferencePath)"
+      ExtensionsCsProjFilePath="$(ExtensionsCsProjDirectory)"
+      AzureFunctionsVersion="$(AzureFunctionsVersion)"
+      TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+      TargetFrameworkVersion="$(TargetFrameworkVersion)"
+      OutputPath="$(IntermediateOutputPath)"/>
+  </Target>
+
+  <!-- Copies an assembly over only if we are not a placeholder. -->
+  <Target Name="_FunctionsCopyMetadataLoader" Condition="!$(FunctionsEnablePlaceholder)">
+    <Copy
+      SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
+      DestinationFolder="$(ExtensionsCsProjDirectory)\buildout"
+      SkipUnchangedFiles="true"
+      OverwriteReadOnlyFiles="true" />
+  </Target>
+
+  <!-- Generate worker.config.json. -->
+  <Target Name="_FunctionsGenerateWorkerConfig">
+    <PropertyGroup>
+      <_FunctionsExecutable>dotnet</_FunctionsExecutable>
+
+      <!-- If self-contained, get the name of the .exe to run. This also covers PublishAot scenarios. -->
+      <_FunctionsExecutable Condition="'$(SelfContained)' == 'true' AND '%(Identity)' == '$(AppHostIntermediatePath)'">{WorkerRoot}%(None.Link)</_FunctionsExecutable>
+      <_FunctionsExecutable Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">{WorkerRoot}$(TargetName)$(TargetExt)</_FunctionsExecutable>
     </PropertyGroup>
 
-    <Target Name="_GenerateFunctionsAndCopyContentFiles" DependsOnTargets="_GenerateFunctionsAndCopyContentFilesNetApp;_GenerateFunctionsAndCopyContentFilesNetFx" />
-
-    <Target Name="_GenerateFunctionsAndCopyContentFilesNetFx" Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
-
-        <PropertyGroup>
-            <OutputFile>$(PublishDir)\worker.config.json</OutputFile>
-            <ExtensionsCsProjFilePath>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ExtensionsCsProjFilePath>
-        </PropertyGroup>
-
-        <GenerateFunctionMetadata
-          AssemblyPath="$(PublishDir)\$(AssemblyName).exe"
-          ReferencePaths="@(ReferencePath)"
-          ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
-          AzureFunctionsVersion="$(AzureFunctionsVersion)"
-          TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
-          TargetFrameworkVersion="$(TargetFrameworkVersion)"
-          OutputPath="$(PublishDir)"/>
-
-        <Copy
-          Condition="!$(FunctionsEnablePlaceholder)"
-          SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
-          DestinationFolder="$(ExtensionsCsProjFilePath)\publishout"
-          OverwriteReadOnlyFiles="true" />
-
-        <WriteLinesToFile
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', '{WorkerRoot}$(TargetName).exe')
-                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-            Overwrite="true" />
-    </Target>
-
-    <Target Name="_GenerateFunctionsAndCopyContentFilesNetApp" Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">
-
-        <PropertyGroup>
-            <OutputFile>$(PublishDir)\worker.config.json</OutputFile>
-            <ExtensionsCsProjFilePath>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ExtensionsCsProjFilePath>
-        </PropertyGroup>
-
-        <GenerateFunctionMetadata
-          AssemblyPath="$(PublishDir)\$(AssemblyName).dll"
-          ReferencePaths="@(ReferencePath)"
-          ExtensionsCsProjFilePath="$(ExtensionsCsProjFilePath)"
-          AzureFunctionsVersion="$(AzureFunctionsVersion)"
-          TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
-          TargetFrameworkVersion="$(TargetFrameworkVersion)"
-          OutputPath="$(PublishDir)"/>
-
-        <Copy
-          Condition="!$(FunctionsEnablePlaceholder)"
-          SourceFiles="$(_FunctionsMetadataLoaderExtensionFile)"
-          DestinationFolder="$(ExtensionsCsProjFilePath)\publishout"
-          OverwriteReadOnlyFiles="true" />
-
-        <WriteLinesToFile
-            Condition="$(SelfContained)"
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', '{WorkerRoot}$(TargetName)')
-                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
+    <WriteLinesToFile
+      File="$(_FunctionsWorkerConfigPath)"
+      Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
+        .Replace('$functionExe$', '$(_FunctionsExecutable)')
+        .Replace('$functionWorker$', '$(TargetName)$(TargetExt)')
+        .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
         Overwrite="true" />
+  </Target>
 
-        <WriteLinesToFile
-            Condition="!$(SelfContained)"
-            File="$(OutputFile)"
-            Lines="$([System.IO.File]::ReadAllText($(_FunctionsWorkerConfigInputFile))
-                                  .Replace('$functionExe$', 'dotnet')
-                                  .Replace('$functionWorker$', '$(_FunctionsWorkerExecutableFileName)')
-                                  .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-        Overwrite="true" />
+  <!-- Invoke restore on WorkerExtension.csproj.
+    We depend on _GetRestoreSettings, which is a task from nuget targets that will resolve various nuget restore settings.
+    Namely we want to know what restore sources ($(_OutputSources)) to use. -->
+  <Target Name="_WorkerExtensionsRestore" DependsOnTargets="_GetRestoreSettings">
+    <MSBuild Projects="$(ExtensionsCsProj)" Targets="Restore" RemoveProperties="$(_FunctionsExtensionRemoveProps)" Properties="IsRestoring=true;RestoreSources=$(_OutputSources);$(_FunctionsExtensionCommonProps)" />
+  </Target>
 
-    </Target>
+  <!-- Invoke build on WorkerExtension.csproj -->
+  <Target Name="_WorkerExtensionsBuild" DependsOnTargets="_WorkerExtensionsRestore">
+    <MSbuild Projects="$(ExtensionsCsProj)" Targets="Build" RemoveProperties="$(_FunctionsExtensionRemoveProps)" Properties="Configuration=Release;OutputPath=$(ExtensionsCsProjDirectory)\buildout;$(_FunctionsExtensionCommonProps)" />
+  </Target>
 
-    <!--
-  Publish the webjobs extensions in ".azurefunctions"
-  -->
-    <!--
-  We need to copy all files from <build-out>/bin except for "runtimes" directory. The "runtimes" directory inside "bin" doesn't contain the binaries for all platforms.
-  This is due to a bug in Functions SDK. Until that is fixed, we need to copy "runtimes" directly from build output, instead of copying from the "bin".
-  -->
-    <Target Name ="_WorkerExtensionsPublishCopy">
-        <ItemGroup>
-            <ExtensionBinaries Include="$(ExtensionsCsProjFilePath)\publishout\bin\**\*.*"
-                               Exclude="$(ExtensionsCsProjFilePath)\publishout\bin\runtimes\**\*.*"/>
-            <ExtensionRuntimeBinaries Include="$(ExtensionsCsProjFilePath)\publishout\runtimes\**\*.*" />
-        </ItemGroup>
+  <!-- Touch up the extensions.json file as needed for .NET isolated -->
+  <Target Name="_FunctionsExtensionUpdateMetadata"
+    AfterTargets="_WorkerExtensionsBuild"
+    BeforeTargets="CopyFilesToOutputDirectory"
+    Inputs="$(_FunctionsIntermediateExtensionJsonPath)"
+    Outputs="$(_FunctionsIntermediateExtensionUpdatedJsonPath)">
+    <EnhanceExtensionsMetadata
+      ExtensionsJsonPath="$(_FunctionsIntermediateExtensionJsonPath)"
+      OutputPath="$(_FunctionsIntermediateExtensionUpdatedJsonPath)"/>
+  </Target>
 
-        <Copy SourceFiles="@(ExtensionBinaries)" DestinationFolder="$(PublishDir)\.azurefunctions\%(RecursiveDir)" />
-        <Copy SourceFiles="@(ExtensionRuntimeBinaries)" DestinationFolder="$(PublishDir)\.azurefunctions\runtimes\%(RecursiveDir)" />
-    </Target>
+  <!-- We do not copy files to output or publish directory ourselves. Instead, we are going to leverage existing
+    targets in the .NET SDK to perform the copying for us. All we have to do is append to an item group with
+    appropriate metadata on the items, and now both Build and Publish will know our files are to be copied out. -->
+  <Target Name="_FunctionsExtensionAssignTargetPaths">
+    <ItemGroup>
+      <_ExtensionBinaries Include="$(ExtensionsCsProjDirectory)\buildout\bin\**"
+        Exclude="$(ExtensionsCsProjDirectory)\buildout\bin\runtimes\**;$(_FunctionsIntermediateExtensionJsonPath)"
+        CopyToOutputDirectory="PreserveNewest"
+        CopyToPublishDirectory="PreserveNewest" />
+      <_ExtensionRuntimeBinaries Include="$(ExtensionsCsProjDirectory)\buildout\runtimes\**"
+        CopyToOutputDirectory="PreserveNewest"
+        CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
 
-    <Target Name ="_WorkerExtensionsFullPublish">
-        <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" RemoveProperties="DeployOnBuild" Targets="Publish" Properties="Configuration=Release;PublishDir=$(ExtensionsCsProjFilePath)\publishout;OutputPath=$(ExtensionsCsProjFilePath)\publishout;CopyLocalLockFileAssemblies=true"/>
-    </Target>
+    <!-- This target will assign the 'TargetPath' metadata for us with the correct root. The 'TargetPath' is what
+      the CopyToOutputDirectory and CopyToPublishDirectory will use to determine path to copy to. Setting
+      'RootFolder' as we do tells this task to trim off the root when deciding the final location. -->
+    <AssignTargetPath Files="@(_ExtensionBinaries)" RootFolder="$(ExtensionsCsProjDirectory)\buildout\bin">
+      <Output TaskParameter="AssignedFiles" ItemName="_ExtensionFilesWithTargetPath" />
+    </AssignTargetPath>
 
-    <Target Name="_WorkerExtensionsRestorePublish">
-        <MSBuild Projects="$(ExtensionsCsProjFilePath)\WorkerExtensions.csproj" Targets="Restore" Properties="IsRestoring=true"/>
-    </Target>
+    <AssignTargetPath Files="@(_ExtensionRuntimeBinaries)" RootFolder="$(ExtensionsCsProjDirectory)\buildout">
+      <Output TaskParameter="AssignedFiles" ItemName="_ExtensionFilesWithTargetPath" />
+    </AssignTargetPath>
 
-    <Target Name="_WorkerExtensionsPublish"
-          AfterTargets="_GenerateFunctionsAndCopyContentFiles"
-          DependsOnTargets="$(FunctionsWorkerExtensionsPublishDependsOn)">
-    </Target>
+    <!-- Hook all these files into CopyToOutputDirectory by appending to _NoneWithTargetPath. -->
+    <ItemGroup>
+      <_NoneWithTargetPath Include="@(_ExtensionFilesWithTargetPath)" TargetPath="$(_FunctionsExtensionsDirectory)/%(_ExtensionFilesWithTargetPath.TargetPath)" />
+    </ItemGroup>
+  </Target>
 
-    <PropertyGroup>
-        <FunctionsWorkerExtensionsPublishDependsOn Condition="$(_FunctionsExtensionsFullPublish)">
-            _GenerateFunctionsAndCopyContentFiles;
-            _WorkerExtensionsRestorePublish;
-            _WorkerExtensionsFullPublish;
-            _WorkerExtensionsPublishCopy;
-            _EnhanceFunctionsExtensionsMetadataPostPublish
-        </FunctionsWorkerExtensionsPublishDependsOn>
-        <FunctionsWorkerExtensionsPublishDependsOn Condition="!$(_FunctionsExtensionsFullPublish)">
-            _GenerateFunctionsAndCopyContentFiles;
-            _WorkerExtensionsPublishCopyNoBuild
-        </FunctionsWorkerExtensionsPublishDependsOn>
-    </PropertyGroup>
+  <Target Name="_CleanFunctions" AfterTargets="Clean" DependsOnTargets="_FunctionsGetPaths">
+    <ItemGroup>
+      <_WorkerExtFilesToClean Include="$(ExtensionsCsProjDirectory)\**" Condition="'$(ExtensionsCsProjDirectory)' != ''" />
+      <_WorkerExtFilesToClean Include="$(TargetDir)$(_FunctionsExtensionsDirectory)\**" />
+      <_WorkerExtFilesToClean Include="$(_FunctionsMetadataPath)" />
+      <_WorkerExtFilesToClean Include="$(_FunctionsWorkerConfigPath)" />
+      <_WorkerExtFilesToClean Include="$(TargetDir)worker.config.json" />
+      <_WorkerExtFilesToClean Include="$(TargetDir)extensions.json" />
+      <_WorkerExtFilesToClean Include="$(TargetDir)functions.metadata" />
+      <_WorkerExtFilesToClean Include="$(_FunctionsIntermediateExtensionUpdatedJsonPath)" />
+    </ItemGroup>
 
-    <!--
-  Add HintPath to references in "extensions.json"
-  -->
-    <Target Name="_EnhanceFunctionsExtensionsMetadataPostPublish">
+    <Delete Files="@(_WorkerExtFilesToClean)" ContinueOnError="true" />
+    <RemoveDir Directories="$(TargetDir)$(_FunctionsExtensionsDirectory)" ContinueOnError="true" />
+    <RemoveDir Directories="$(ExtensionsCsProjDirectory)" ContinueOnError="true" Condition="'$(ExtensionsCsProjDirectory)' != ''" />
+  </Target>
 
-        <EnhanceExtensionsMetadata
-          ExtensionsJsonPath="$(PublishDir)\$(_FunctionsExtensionsDirectory)\$(_FunctionsExtensionsJsonName)"
-          OutputPath="$(PublishDir)\$(_FunctionsExtensionsJsonName)" />
-
-    </Target>
-
-    <!--
-  Copies the assemblies from build directory ("bin\...\net5.0\") to the publish directory ("bin\...\net5.0\publish")
-  This task is executed instead of full publish of WorkerExtensions when NoBuild property is set
-  -->
-    <Target Name ="_WorkerExtensionsPublishCopyNoBuild">
-        <ItemGroup>
-            <ExtensionBinaries Include="$(OutDir)\$(_FunctionsExtensionsDirectory)\**\*.*"
-                               Exclude="$(OutDir)\$(_FunctionsExtensionsDirectory)\runtimes\**\*.*"/>
-            <ExtensionRuntimeBinaries Include="$(OutDir)\.azurefunctions\runtimes\**\*.*" />
-            <ExtensionsJson Include="$(OutDir)\$(_FunctionsExtensionsJsonName)" />
-        </ItemGroup>
-
-        <Copy SourceFiles="@(ExtensionBinaries)" DestinationFolder="$(PublishDir)\$(_FunctionsExtensionsDirectory)\%(RecursiveDir)" />
-        <Copy SourceFiles="@(ExtensionRuntimeBinaries)" DestinationFolder="$(PublishDir)\$(_FunctionsExtensionsDirectory)\runtimes\%(RecursiveDir)" />
-        <Copy SourceFiles="@(ExtensionsJson)" DestinationFolder="$(PublishDir)\" />
-    </Target>
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Azure.Functions.Worker.Sdk.Publish.targets"
+    Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Azure.Functions.Worker.Sdk.Publish.targets')" />
 
 </Project>

--- a/sdk/Sdk/Tasks/EnhanceExtensionsMetadata.cs
+++ b/sdk/Sdk/Tasks/EnhanceExtensionsMetadata.cs
@@ -34,8 +34,6 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Tasks
             string newJson = JsonSerializer.Serialize(extensionsMetadata, _serializerOptions);
             File.WriteAllText(OutputPath, newJson);
 
-            File.Delete(ExtensionsJsonPath);
-
             return true;
         }
     }

--- a/sdk/Sdk/Tasks/GenerateFunctionMetadata.cs
+++ b/sdk/Sdk/Tasks/GenerateFunctionMetadata.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Tasks
             {
                 var functionGenerator = new FunctionMetadataGenerator(MSBuildLogger);
 
-                var functions = functionGenerator.GenerateFunctionMetadata(AssemblyPath!, ReferencePaths.Select(p => p.ItemSpec));
+                var functions = functionGenerator.GenerateFunctionMetadata(AssemblyPath!, ReferencePaths ?? Enumerable.Empty<ITaskItem>());
 
                 var extensions = functionGenerator.Extensions;
                 var extensionsCsProjGenerator = new ExtensionsCsprojGenerator(extensions, ExtensionsCsProjFilePath!, AzureFunctionsVersion!, TargetFrameworkIdentifier!, TargetFrameworkVersion!);

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,11 +4,7 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.17.1 (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk 1.17.13-preview1 (meta package)
 
-- Update Microsoft.Azure.Functions.Worker.Sdk.Generators dependency to 1.2.1
-
-### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.2.1
-
-  - Minor refactoring and cleanup (#2208)
-  - Fixed metadata generator not producing metadata when the entry assembly lacked functions but dependent assemblies had them (#2300)
+- Re-add SDK refactors that were reverted in #2313 (#2347)
+- Address assembly scanning regression (#2347)

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,7 +4,11 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.17.2 (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk 1.17.1 (meta package)
 
-- Revert changes from #1946
+- Update Microsoft.Azure.Functions.Worker.Sdk.Generators dependency to 1.2.1
 
+### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.2.1
+
+  - Minor refactoring and cleanup (#2208)
+  - Fixed metadata generator not producing metadata when the entry assembly lacked functions but dependent assemblies had them (#2300)

--- a/test/E2ETests/E2EApps/E2EApp/E2EApp.csproj
+++ b/test/E2ETests/E2EApps/E2EApp/E2EApp.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
-    <PackageReference Condition="$(TestBuild) == 'true'" Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />    
+    <PackageReference Condition="$(TestBuild) == 'true'" Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.1" />
   </ItemGroup>
 </Project>

--- a/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Azure.Functions.Worker.Sdk;
 using Xunit;
 
@@ -9,8 +11,48 @@ namespace Microsoft.Azure.Functions.SdkTests
 {
     public class ExtensionsCsProjGeneratorTests
     {
-        [Fact]
-        public void GetCsProjContent_Succeeds_functions_v3()
+        public enum FuncVersion
+        {
+            V3,
+            V4,
+        }
+
+        [Theory]
+        [InlineData(FuncVersion.V3)]
+        [InlineData(FuncVersion.V4)]
+        public void GetCsProjContent_Succeeds(FuncVersion version)
+        {
+            var generator = GetGenerator(version);
+            string actual = generator.GetCsProjContent().Replace("\r\n", "\n");
+            string expected = ExpectedCsproj(version).Replace("\r\n", "\n");
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(FuncVersion.V3)]
+        [InlineData(FuncVersion.V4)]
+        public void GetCsProjContent_IncrementalSupport(FuncVersion version)
+        {
+            DateTime RunGenerate(string subPath, out string contents)
+            {
+                var generator = GetGenerator(version, subPath);
+                generator.Generate();
+
+                string path = Path.Combine(subPath, ExtensionsCsprojGenerator.ExtensionsProjectName);
+                contents = File.ReadAllText(path);
+                var csproj = new FileInfo(Path.Combine(subPath, ExtensionsCsprojGenerator.ExtensionsProjectName));
+                return csproj.LastWriteTimeUtc;
+            }
+
+            string subPath = Guid.NewGuid().ToString();
+            DateTime firstRun = RunGenerate(subPath, out string first);
+            DateTime secondRun = RunGenerate(subPath, out string second);
+
+            Assert.NotEqual(firstRun, secondRun);
+            Assert.Equal(first, second);
+        }
+
+        static ExtensionsCsprojGenerator GetGenerator(FuncVersion version, string subPath = "")
         {
             IDictionary<string, string> extensions = new Dictionary<string, string>
             {
@@ -19,12 +61,21 @@ namespace Microsoft.Azure.Functions.SdkTests
                 { "Microsoft.Azure.WebJobs.Extensions", "2.0.0" },
             };
 
-            var generator = new ExtensionsCsprojGenerator(extensions, "", "v3", Constants.NetCoreApp, Constants.NetCoreVersion31);
-
-            string actualCsproj = generator.GetCsProjContent().Replace("\r\n", "\n");
-
-            Assert.Equal(ExpectedCsProjV3(), actualCsproj);
+            return version switch
+            {
+                FuncVersion.V3 => new ExtensionsCsprojGenerator(extensions, subPath, "v3", Constants.NetCoreApp, Constants.NetCoreVersion31),
+                FuncVersion.V4 => new ExtensionsCsprojGenerator(extensions, subPath, "v4", Constants.NetCoreApp, Constants.NetCoreVersion6),
+                _ => throw new ArgumentOutOfRangeException(nameof(version)),
+            };
         }
+
+        private static string ExpectedCsproj(FuncVersion version)
+            => version switch
+            {
+                FuncVersion.V3 => ExpectedCsProjV3(),
+                FuncVersion.V4 => ExpectedCsProjV4(),
+                _ => throw new ArgumentOutOfRangeException(nameof(version)),
+            };
 
         private static string ExpectedCsProjV3()
         {
@@ -51,23 +102,6 @@ namespace Microsoft.Azure.Functions.SdkTests
     </Target>
 </Project>
 ";
-        }
-
-        [Fact]
-        public void GetCsProjContent_Succeeds_functions_v4()
-        {
-            IDictionary<string, string> extensions = new Dictionary<string, string>
-            {
-                { "Microsoft.Azure.WebJobs.Extensions.Storage", "4.0.3" },
-                { "Microsoft.Azure.WebJobs.Extensions.Http", "3.0.0" },
-                { "Microsoft.Azure.WebJobs.Extensions", "2.0.0" },
-            };
-
-            var generator = new ExtensionsCsprojGenerator(extensions, "", "v4", Constants.NetCoreApp, Constants.NetCoreVersion6);
-
-            string actualCsproj = generator.GetCsProjContent().Replace("\r\n", "\n");
-
-            Assert.Equal(ExpectedCsProjV4(), actualCsproj);
         }
 
         private static string ExpectedCsProjV4()

--- a/test/Resources/Projects/FunctionApp01/FunctionApp01.csproj
+++ b/test/Resources/Projects/FunctionApp01/FunctionApp01.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
+
+    <!-- DurableTask has an implicit extension, which we want to validate -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer " Version="1.2.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../FunctionLib01/FunctionLib01.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Resources/Projects/FunctionApp01/FunctionApp01.csproj
+++ b/test/Resources/Projects/FunctionApp01/FunctionApp01.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <SdkVersion>1.17.2</SdkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +15,7 @@
     <!-- DurableTask has an implicit extension, which we want to validate -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer " Version="1.2.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="$(SdkVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Resources/Projects/FunctionApp01/HttpFunction.cs
+++ b/test/Resources/Projects/FunctionApp01/HttpFunction.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp01
+{
+    public class HttpFunction
+    {
+        [Function("FunctionApp01_Hello")]
+        public HttpResponseData Hello([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
+        {
+            return req.CreateResponse(HttpStatusCode.OK);
+        }
+    }
+}

--- a/test/Resources/Projects/FunctionApp01/Program.cs
+++ b/test/Resources/Projects/FunctionApp01/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/test/Resources/Projects/FunctionLib01/FunctionLib01.csproj
+++ b/test/Resources/Projects/FunctionLib01/FunctionLib01.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/Resources/Projects/FunctionLib01/HttpFunction.cs
+++ b/test/Resources/Projects/FunctionLib01/HttpFunction.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionLib01
+{
+    public class HttpFunction
+    {
+        [Function("FunctionLib01_Hello")]
+        public HttpResponseData Hello([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
+        {
+            return req.CreateResponse(HttpStatusCode.OK);
+        }
+    }
+}

--- a/test/SdkE2ETests/InnerBuildTests.cs
+++ b/test/SdkE2ETests/InnerBuildTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Functions.SdkE2ETests
+{
+    public class InnerBuildTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public InnerBuildTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async Task Build_ScansReferences()
+        {
+            string outputDir = await TestUtility.InitializeTestAsync(_testOutputHelper, nameof(Build_ScansReferences));
+            string projectFileDirectory = Path.Combine(TestUtility.TestResourcesProjectsRoot, "FunctionApp01", "FunctionApp01.csproj");
+
+            await TestUtility.RestoreAndBuildProjectAsync(projectFileDirectory, outputDir, null, _testOutputHelper);
+
+            // Verify extensions.json contents
+            string extensionsJsonPath = Path.Combine(outputDir, "extensions.json");
+            Assert.True(File.Exists(extensionsJsonPath));
+
+            JToken extensionsJsonContents = JObject.Parse(File.ReadAllText(extensionsJsonPath));
+            JToken expectedExtensionsJson = JObject.Parse(@"{
+  ""extensions"": [
+    {
+      ""name"": ""SqlDurabilityProvider"",
+      ""typeName"": ""DurableTask.SqlServer.AzureFunctions.SqlDurabilityProviderStartup, DurableTask.SqlServer.AzureFunctions, Version=1.2.0.0, Culture=neutral, PublicKeyToken=2ea3c3a96309d850"",
+      ""hintPath"": ""./.azurefunctions/DurableTask.SqlServer.AzureFunctions.dll""
+    },
+    {
+      ""name"": ""DurableTask"",
+      ""typeName"": ""Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.DurableTask, Version=2.0.0.0, Culture=neutral, PublicKeyToken=014045d636e89289"",
+      ""hintPath"": ""./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll""
+    },
+    {
+      ""name"": ""Startup"",
+      ""typeName"": ""Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.Startup, Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=551316b6919f366c"",
+      ""hintPath"": ""./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll""
+    }
+  ]
+}");
+
+            Assert.True(JToken.DeepEquals(expectedExtensionsJson, extensionsJsonContents));
+
+            // Verify functions.metadata contents
+            string functionsMetadataPath = Path.Combine(outputDir, "functions.metadata");
+            Assert.True(File.Exists(functionsMetadataPath));
+
+            JToken functionsMetadataContents = JArray.Parse(File.ReadAllText(functionsMetadataPath));
+            JToken expectedFunctionsMetadata = JArray.Parse(@"[
+  {
+    ""name"": ""FunctionApp01_Hello"",
+    ""scriptFile"": ""FunctionApp01.dll"",
+    ""entryPoint"": ""FunctionApp01.HttpFunction.Hello"",
+    ""language"": ""dotnet-isolated"",
+    ""properties"": {
+      ""IsCodeless"": false
+    },
+    ""bindings"": [
+      {
+        ""name"": ""req"",
+        ""direction"": ""In"",
+        ""type"": ""httpTrigger"",
+        ""authLevel"": ""Anonymous"",
+        ""methods"": [
+          ""get""
+        ],
+        ""properties"": {}
+      },
+      {
+        ""name"": ""$return"",
+        ""type"": ""http"",
+        ""direction"": ""Out""
+      }
+    ]
+  },
+  {
+    ""name"": ""FunctionLib01_Hello"",
+    ""scriptFile"": ""FunctionLib01.dll"",
+    ""entryPoint"": ""FunctionLib01.HttpFunction.Hello"",
+    ""language"": ""dotnet-isolated"",
+    ""properties"": {
+      ""IsCodeless"": false
+    },
+    ""bindings"": [
+      {
+        ""name"": ""req"",
+        ""direction"": ""In"",
+        ""type"": ""httpTrigger"",
+        ""authLevel"": ""Anonymous"",
+        ""methods"": [
+          ""get""
+        ],
+        ""properties"": {}
+      },
+      {
+        ""name"": ""$return"",
+        ""type"": ""http"",
+        ""direction"": ""Out""
+      }
+    ]
+  }
+]");
+
+            Assert.True(JToken.DeepEquals(expectedFunctionsMetadata, functionsMetadataContents));
+        }
+    }
+}

--- a/test/SdkE2ETests/TestUtility.cs
+++ b/test/SdkE2ETests/TestUtility.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
         public static readonly string DevPackPath = Path.Combine(PathToRepoRoot, "tools", "devpack.ps1");
         public static readonly string TestResourcesProjectsRoot = Path.Combine(TestRoot, "Resources", "Projects");
 
+        public static readonly string NuGetOrgPackages = "https://api.nuget.org/v3/index.json";
         public static readonly string NuGetPackageSource = LocalPackages;
 
         private static bool _isInitialized = false;
@@ -94,15 +95,15 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} --source {TestUtility.LocalPackages}";
-            int? exitCode = await new ProcessWrapper().RunProcess(TestUtility.DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
+            string dotnetArgs = $"restore {projectNameToTest} -s {LocalPackages} -s {NuGetOrgPackages}";
+            int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
 
             // Build
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Building...");
-            dotnetArgs = $"build {projectNameToTest} --configuration {TestUtility.Configuration} -o {outputDir} {additionalParams}";
-            exitCode = await new ProcessWrapper().RunProcess(TestUtility.DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
+            dotnetArgs = $"build {projectNameToTest} --configuration {Configuration} -o {outputDir} {additionalParams}";
+            exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
         }
@@ -118,15 +119,15 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} --source {TestUtility.LocalPackages}";
-            int? exitCode = await new ProcessWrapper().RunProcess(TestUtility.DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
+            string dotnetArgs = $"restore {projectNameToTest} -s {LocalPackages} -s {NuGetOrgPackages}";
+            int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
 
             // Publish
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Publishing...");
-            dotnetArgs = $"publish {projectNameToTest} --configuration {TestUtility.Configuration} -o {outputDir} {additionalParams}";
-            exitCode = await new ProcessWrapper().RunProcess(TestUtility.DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
+            dotnetArgs = $"publish {projectNameToTest} --configuration {Configuration} -o {outputDir} {additionalParams}";
+            exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
         }

--- a/test/SdkE2ETests/TestUtility.cs
+++ b/test/SdkE2ETests/TestUtility.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             // Build
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Building...");
-            dotnetArgs = $"build {projectNameToTest} --configuration {Configuration} -o {outputDir} --no-restore -p:SdkVersion={SdkVersion} {additionalParams}";
+            dotnetArgs = $"build {projectNameToTest} --configuration {Configuration} -o {outputDir} -p:SdkVersion={SdkVersion} {additionalParams}";
             exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             // Publish
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Publishing...");
-            dotnetArgs = $"publish {projectNameToTest} --configuration {Configuration} -o {outputDir} --no-restore -p:SdkVersion={SdkVersion} {additionalParams}";
+            dotnetArgs = $"publish {projectNameToTest} --configuration {Configuration} -o {outputDir} -p:SdkVersion={SdkVersion} {additionalParams}";
             exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");

--- a/test/SdkE2ETests/TestUtility.cs
+++ b/test/SdkE2ETests/TestUtility.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} -s {LocalPackages} -s {NuGetOrgPackages}";
+            string dotnetArgs = $"restore {projectNameToTest} -s {NuGetOrgPackages} -s {LocalPackages}";
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} -s {LocalPackages} -s {NuGetOrgPackages}";
+            string dotnetArgs = $"restore {projectNameToTest} -s {NuGetOrgPackages} -s {LocalPackages}";
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, $"remove {projectFile} package {WorkerSdkPackageName}", PathToRepoRoot, testOutputHelper: testOutputHelper);
             // If a previous run failed, this may have a -1 exit code. We'll continue anyway.
 
-            exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, $"add {projectFile} package {WorkerSdkPackageName} -s {LocalPackages} --prerelease", SdkProjectRoot, testOutputHelper: testOutputHelper);
+            exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, $"add {projectFile} package {WorkerSdkPackageName} -s {NuGetOrgPackages} -s {LocalPackages} --prerelease", SdkProjectRoot, testOutputHelper: testOutputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
         }
     }

--- a/test/SdkE2ETests/TestUtility.cs
+++ b/test/SdkE2ETests/TestUtility.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, $"remove {projectFile} package {WorkerSdkPackageName}", PathToRepoRoot, testOutputHelper: testOutputHelper);
             // If a previous run failed, this may have a -1 exit code. We'll continue anyway.
 
-            exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, $"add {projectFile} package {WorkerSdkPackageName} -s {NuGetOrgPackages} -s {LocalPackages} --prerelease", SdkProjectRoot, testOutputHelper: testOutputHelper);
+            exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, $"add {projectFile} package {WorkerSdkPackageName} -s {LocalPackages} --prerelease --no-restore", SdkProjectRoot, testOutputHelper: testOutputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
         }
     }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This re-adds the SDK overhaul that was reverted in #2313. The cause for the reversion has also been addressed. The root issue was that we were identifying what referenced assemblies to scan by looking at all dll's next to the final output assembly of the functions project. With the SDK refactoring this was no longer possible as our targets ran earlier (before being copied to final output location). Instead, we directly use the `ReferencePath` item group from MSBuild to identify all assemblies that will be copied to the final output directory.
