### PR TITLE
Use empty string array in `FunctionsEndpointDataSource.MapHttpFunction` if no HTTP method was defined in `HttpTriggerAttribute`

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs
@@ -105,7 +105,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMidd
                     {
                         DisplayName = functionName
                     };
-                    endpointBuilder.Metadata.Add(new HttpMethodMetadata(functionBinding.Methods));
+
+                    var methods = functionBinding.Methods ?? [];
+                    endpointBuilder.Metadata.Add(new HttpMethodMetadata(methods));
 
                     // no need to look at other bindings for this function
                     return endpointBuilder.Build();

--- a/test/DotNetWorkerTests/AspNetCore/FunctionsEndpointDataSourceTests.cs
+++ b/test/DotNetWorkerTests/AspNetCore/FunctionsEndpointDataSourceTests.cs
@@ -98,6 +98,34 @@ namespace Microsoft.Azure.Functions.Worker.Tests.AspNetCore
         }
 
         [Fact]
+        public void MapHttpFunction_CustomRoute_NoHttpMethodSpecified()
+        {
+            string rawBinding = """
+            {
+                "name": "req",
+                "direction": "In",
+                "type": "httpTrigger",
+                "route": "customRoute/function",
+                "authLevel": "Anonymous",
+                "properties": { }
+            }
+            """;
+
+            var metadata = new DefaultFunctionMetadata
+            {
+                Name = "TestFunction",
+                RawBindings = new List<string> { rawBinding },
+            };
+
+            RouteEndpoint endpoint = FunctionsEndpointDataSource.MapHttpFunction(metadata, "api") as RouteEndpoint;
+
+            Assert.Equal("TestFunction", endpoint.DisplayName);
+            Assert.Equal($"api/customRoute/function", endpoint.RoutePattern.RawText);
+            var endpointMetadata = endpoint.Metadata.Single() as HttpMethodMetadata;
+            Assert.Equal([], endpointMetadata.HttpMethods);
+        }
+
+        [Fact]
         public void GetRoutePrefix()
         {
             string hostJson = """


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Right now if you do not define an HTTP method in the `HttpTriggerAttribute` for a function that uses ASP.NET Core integration and you send a request to it you will get a System.ArgumentNullException and the function hangs. That goes against what the documentation says:

*An array of the HTTP methods to which the function responds. If not specified, the function responds to all HTTP methods.*

https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=python-v2%2Cisolated-process%2Cnodejs-v4%2Cfunctionsv2&pivots=programming-language-csharp#attributes

Not defining an HTTP method works as expected if you use `HttpRequestData` and `HttpResponseData`. This PR basically gets the ASP.NET integration to work as described in the documentation.

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)