### PR TITLE
Reverting the worker.config change made in #2315 (checking for INITIALIZED_FROM_PLACEHOLDER environment variable)

### DIFF
--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>

--- a/host/tools/build/worker.config.json
+++ b/host/tools/build/worker.config.json
@@ -2,45 +2,23 @@
   "description": {
     "language": "dotnet-isolated",
     "extensions": [ ".dll" ],
+    "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost.exe",
+    "defaultWorkerPath": "bin/FunctionsNetHost.exe",
     "workerIndexing": "true"
   },
   "profiles": [
     {
-      "profileName": "DotnetIsolatedLinuxPlaceholder",
+      "profileName": "DotnetIsolatedLinux",
       "conditions": [
         {
           "conditionType": "hostProperty",
           "conditionName": "platform",
           "conditionExpression": "LINUX"
-        },
-        {
-          "conditionType": "environment",
-          "conditionName": "INITIALIZED_FROM_PLACEHOLDER",
-          "conditionExpression": "(?i)true$"
         }
       ],
       "description": {
         "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost",
         "defaultWorkerPath": "bin/FunctionsNetHost"
-      }
-    },
-    {
-      "profileName": "DotnetIsolatedWindowsPlaceholder",
-      "conditions": [
-        {
-          "conditionType": "hostProperty",
-          "conditionName": "platform",
-          "conditionExpression": "WINDOWS"
-        },
-        {
-          "conditionType": "environment",
-          "conditionName": "INITIALIZED_FROM_PLACEHOLDER",
-          "conditionExpression": "(?i)true$"
-        }
-      ],
-      "description": {
-        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost.exe",
-        "defaultWorkerPath": "bin/FunctionsNetHost.exe"
       }
     }
   ]


### PR DESCRIPTION
Reverting the worker.config change made in #2315 and going back to the [version before that change](https://github.com/Azure/azure-functions-dotnet-worker/blob/2d16152a9c9cad8ed71e8aae1f660d7025a9c498/host/tools/build/worker.config.json).

Revert reason: The host code throws when none of the profile conditions are passing. This means, we have to fix a bunch of E2E tests (even tests which are for other language workers) to specify the env variable which was used in the profile condition evaluation. I [opened a GH issue ](https://github.com/Azure/azure-functions-host/issues/9932)in host to handle this condition gracefully. Once that change is in, we can bring back the worker config version from 2315.


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
