### PR TITLE
Adding required attribute for query parameter(RequiredQueryParameter)

### DIFF
--- a/extensions/Worker.Extensions.Http/src/RequiredQueryParameterAttribute.cs
+++ b/extensions/Worker.Extensions.Http/src/RequiredQueryParameterAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Extensions.Http.Converters;
+
+namespace Microsoft.Azure.Functions.Worker.Http
+{
+    /// <summary>
+    /// Specifies that a parameter should be bound using the HTTP request body when using the <see cref="HttpTriggerAttribute"/>.
+    /// </summary>
+    public class RequiredQueryParameterAttribute : InputConverterAttribute
+    {
+        /// <summary>
+        /// Creates an instance of the <see cref="RequiredQueryParameterAttribute"/>.
+        /// </summary>
+        public RequiredQueryParameterAttribute() 
+            : base(typeof(RequiredQueryParameterConverter))
+        {
+        }
+    }
+}

--- a/extensions/Worker.Extensions.Http/src/RequiredQueryParameterConverter.cs
+++ b/extensions/Worker.Extensions.Http/src/RequiredQueryParameterConverter.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Converters;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Http.Converters
+{
+    internal class RequiredQueryParameterConverter : IInputConverter
+    {
+        public ValueTask<ConversionResult> ConvertAsync(ConverterContext context)
+        {
+            if (context.TargetType == typeof(string) && string.IsNullOrWhiteSpace(context.Source?.ToString()))
+            {
+                throw new InvalidOperationException("Required query parameter is missing");
+            }
+
+            return new ValueTask<ConversionResult>(ConversionResult.Success(context.Source!));
+        }
+    }
+}

--- a/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Http/BasicHttpFunctions.cs
@@ -149,11 +149,25 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp
             response.WriteString($"{region} {category} {caller.Name}");
             return response;
         }
+        
+        [Function(nameof(RequiredQueryParameter))]
+        public static HttpResponseData RequiredQueryParameter(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = nameof(RequiredQueryParameter))] HttpRequestData req,
+            [RequiredQueryParameter] string region,
+            string category,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger(nameof(RequiredQueryParameter));
+            logger.LogInformation(".NET Worker HTTP trigger function processed a request");
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.WriteString($"{region} {category}");
+            return response;
+        }
 
         public class MyResponse
         {
             public string Name { get; set; }
         }
-
     }
 }

--- a/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
+++ b/test/E2ETests/E2ETests/Fixtures/FunctionAppFixture.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
                     _funcProcess.StartInfo.ArgumentList.Add("PocoWithoutBindingSource");
                     _funcProcess.StartInfo.ArgumentList.Add("HelloPascal");
                     _funcProcess.StartInfo.ArgumentList.Add("HelloAllCaps");
+                    _funcProcess.StartInfo.ArgumentList.Add("RequiredQueryParameter");
                 }
 
                 await CosmosDBHelpers.TryCreateDocumentCollectionsAsync(_logger);

--- a/test/E2ETests/E2ETests/HttpEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/HttpEndToEndTests.cs
@@ -83,6 +83,17 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             Assert.Equal(expectedStatusCode, response.StatusCode);
         }
 
+        [Theory]
+        [InlineData("?region=eu",  HttpStatusCode.OK)]
+        [InlineData("?region=eu&category=caller",  HttpStatusCode.OK)]
+        [InlineData("?category=caller",  HttpStatusCode.InternalServerError)]
+        public async Task HttpTriggerTests_RequiredQueryParameter(string queryString, HttpStatusCode expectedStatusCode)
+        {
+            HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RequiredQueryParameter", queryString);
+
+            Assert.Equal(expectedStatusCode, response.StatusCode);
+        }
+        
         [Fact]
         public async Task HttpTriggerTestsPocoResult()
         {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Changes in this PR:

This PR introduces a new feature in the azure-functions-dotnet-worker library: RequiredQueryParameterAttribute. This attribute enables developers to specify required query parameters for Azure Functions, ensuring that necessary parameters are present in incoming HTTP requests.

Developers can now annotate their Azure Functions with RequiredQueryParameterAttribute, specifying the required query parameters directly within the function signature. 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)
