### PR TITLE
fixing whitespace in asignment automation

### DIFF
--- a/.github/policies/issue.flag-for-triage.yml
+++ b/.github/policies/issue.flag-for-triage.yml
@@ -42,10 +42,10 @@ configuration:
         - labelAdded:
             label: 'Needs: Attention :wave:'
       then:
-        - assignIcmUsers:
-            teamId: 114785
-            primary: true
-            secondary: false
+      - assignIcmUsers:
+          teamId: 114785
+          primary: true
+          secondary: false
       triggerOnOwnActions: true
 
 onFailure: 


### PR DESCRIPTION
My hope is that this fixes the problem we've been having where the bot is no longer assigning. This may have made the task invalid / a no-op.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
