### PR TITLE
OpenTelemetry Support

### DIFF
--- a/DotNetWorker.sln
+++ b/DotNetWorker.sln
@@ -136,13 +136,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DependentAssemblyWithFuncti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Http.AspNetCore.Tests", "test\extensions\Worker.Extensions.Http.AspNetCore.Tests\Worker.Extensions.Http.AspNetCore.Tests.csproj", "{D8E79B53-9A44-46CC-9D7A-E9494FC8CAF4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worker.Extensions.Shared.Tests", "test\Worker.Extensions.Shared.Tests\Worker.Extensions.Shared.Tests.csproj", "{B6342174-5436-4846-B43C-39D8E34AE5CF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Shared.Tests", "test\Worker.Extensions.Shared.Tests\Worker.Extensions.Shared.Tests.csproj", "{B6342174-5436-4846-B43C-39D8E34AE5CF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.Http.AspNetCore.Analyzers", "extensions\Worker.Extensions.Http.AspNetCore.Analyzers\Worker.Extensions.Http.AspNetCore.Analyzers.csproj", "{7B6C2920-7A02-43B2-8DA0-7B76B9FAFC6B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Net7Worker", "samples\Net7Worker\Net7Worker.csproj", "{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependentAssemblyWithFunctions.NetStandard", "test\DependentAssemblyWithFunctions.NetStandard\DependentAssemblyWithFunctions.NetStandard.csproj", "{198DA072-F94F-4585-A744-97B3DAC21686}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DependentAssemblyWithFunctions.NetStandard", "test\DependentAssemblyWithFunctions.NetStandard\DependentAssemblyWithFunctions.NetStandard.csproj", "{198DA072-F94F-4585-A744-97B3DAC21686}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetWorker.OpenTelemetry", "src\DotNetWorker.OpenTelemetry\DotNetWorker.OpenTelemetry.csproj", "{82157559-DF60-496D-817F-84B34CFF76FD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetWorker.OpenTelemetry.Tests", "test\DotNetWorker.OpenTelemetry.Tests\DotNetWorker.OpenTelemetry.Tests.csproj", "{9AE6E00C-5E6F-4615-9C69-464E9B208E8C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -346,10 +350,6 @@ Global
 		{D8E79B53-9A44-46CC-9D7A-E9494FC8CAF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D8E79B53-9A44-46CC-9D7A-E9494FC8CAF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8E79B53-9A44-46CC-9D7A-E9494FC8CAF4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B6342174-5436-4846-B43C-39D8E34AE5CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B6342174-5436-4846-B43C-39D8E34AE5CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6342174-5436-4846-B43C-39D8E34AE5CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -358,10 +358,22 @@ Global
 		{7B6C2920-7A02-43B2-8DA0-7B76B9FAFC6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7B6C2920-7A02-43B2-8DA0-7B76B9FAFC6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B6C2920-7A02-43B2-8DA0-7B76B9FAFC6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{198DA072-F94F-4585-A744-97B3DAC21686}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{198DA072-F94F-4585-A744-97B3DAC21686}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{198DA072-F94F-4585-A744-97B3DAC21686}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{198DA072-F94F-4585-A744-97B3DAC21686}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82157559-DF60-496D-817F-84B34CFF76FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82157559-DF60-496D-817F-84B34CFF76FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82157559-DF60-496D-817F-84B34CFF76FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82157559-DF60-496D-817F-84B34CFF76FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9AE6E00C-5E6F-4615-9C69-464E9B208E8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9AE6E00C-5E6F-4615-9C69-464E9B208E8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9AE6E00C-5E6F-4615-9C69-464E9B208E8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9AE6E00C-5E6F-4615-9C69-464E9B208E8C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -425,6 +437,8 @@ Global
 		{7B6C2920-7A02-43B2-8DA0-7B76B9FAFC6B} = {A7B4FF1E-3DF7-4F28-9333-D0961CDDF702}
 		{BE1F79C3-24FA-4BC8-BAB2-C1AD321B13FF} = {9D6603BD-7EA2-4D11-A69C-0D9E01317FD6}
 		{198DA072-F94F-4585-A744-97B3DAC21686} = {B5821230-6E0A-4535-88A9-ED31B6F07596}
+		{82157559-DF60-496D-817F-84B34CFF76FD} = {083592CA-7DAB-44CE-8979-44FAFA46AEC3}
+		{9AE6E00C-5E6F-4615-9C69-464E9B208E8C} = {FD7243E4-BF18-43F8-8744-BA1D17ACF378}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {497D2ED4-A13E-4BCA-8D29-F30CA7D0EA4A}

--- a/build/DotNetWorker.Core.slnf
+++ b/build/DotNetWorker.Core.slnf
@@ -8,7 +8,8 @@
       "src\\DotNetWorker.ApplicationInsights\\DotNetWorker.ApplicationInsights.csproj",
       "src\\DotNetWorker.Core\\DotNetWorker.Core.csproj",
       "src\\DotNetWorker.Grpc\\DotNetWorker.Grpc.csproj",
-      "src\\DotNetWorker\\DotNetWorker.csproj"
+      "src\\DotNetWorker\\DotNetWorker.csproj",
+      "src\\DotNetWorker.OpenTelemetry\\DotNetWorker.OpenTelemetry.csproj"
     ]
   }
 }

--- a/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
+++ b/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
@@ -3,11 +3,28 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Microsoft.Azure.Functions.Worker.Diagnostics
 {
     internal static class ActivityExtensions
     {
+
+        private static readonly Action<Activity, string> s_setSpanId;
+        private static readonly Action<Activity, string> s_setId;
+        private static readonly Action<Activity, string> s_setTraceId;
+        private static readonly Action<Activity, string> s_setRootId;
+
+        static ActivityExtensions()
+        {
+            BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+            s_setSpanId = typeof(Activity).GetField("_spanId", flags).CreateSetter<Activity, string>();
+            s_setId = typeof(Activity).GetField("_id", flags).CreateSetter<Activity, string>();
+            s_setRootId = typeof(Activity).GetField("_rootId", flags).CreateSetter<Activity, string>();
+            s_setTraceId = typeof(Activity).GetField("_traceId", flags).CreateSetter<Activity, string>();
+        }
+
         /// <summary>
         /// Records an exception as an ActivityEvent.
         /// </summary>
@@ -40,6 +57,51 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
             }
 
             activity?.AddEvent(new ActivityEvent(TraceConstants.AttributeExceptionEventName, default, tagsCollection));
+        }
+
+        public static void SetId(this Activity activity, string id)
+            => s_setId(activity, id);
+
+        public static void SetSpanId(this Activity activity, string spanId)
+            => s_setSpanId(activity, spanId);
+
+        public static void SetRootId(this Activity activity, string rootId)
+            => s_setRootId(activity, rootId);
+
+        public static void SetTraceId(this Activity activity, string traceId)
+            => s_setTraceId(activity, traceId);
+    }
+
+    internal static class FieldInfoExtensionMethods
+    {
+        /// <summary>
+        /// Create a re-usable setter for a <see cref="FieldInfo"/>.
+        /// When cached and reused, This is quicker than using <see cref="FieldInfo.SetValue(object, object)"/>.
+        /// </summary>
+        /// <typeparam name="TTarget">The target type of the object.</typeparam>
+        /// <typeparam name="TValue">The value type of the field.</typeparam>
+        /// <param name="fieldInfo">The field info.</param>
+        /// <returns>A re-usable action to set the field.</returns>
+        internal static Action<TTarget, TValue> CreateSetter<TTarget, TValue>(this FieldInfo fieldInfo)
+        {
+            if (fieldInfo == null)
+            {
+                throw new ArgumentNullException(nameof(fieldInfo));
+            }
+
+            ParameterExpression targetExp = Expression.Parameter(typeof(TTarget), "target");
+            Expression source = targetExp;
+
+            if (typeof(TTarget) != fieldInfo.DeclaringType)
+            {
+                source = Expression.Convert(targetExp, fieldInfo.DeclaringType);
+            }
+
+            // Creating the setter to set the value to the field
+            ParameterExpression valueExp = Expression.Parameter(typeof(TValue), "value");
+            MemberExpression fieldExp = Expression.Field(source, fieldInfo);
+            BinaryExpression assignExp = Expression.Assign(fieldExp, valueExp);
+            return Expression.Lambda<Action<TTarget, TValue>>(assignExp, targetExp, valueExp).Compile();
         }
     }
 }

--- a/src/DotNetWorker.Core/DotNetWorker.Core.csproj
+++ b/src/DotNetWorker.Core/DotNetWorker.Core.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Core</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Core</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>17</MinorProductVersion>
+    <MinorProductVersion>18</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>

--- a/src/DotNetWorker.Core/FunctionsApplication.cs
+++ b/src/DotNetWorker.Core/FunctionsApplication.cs
@@ -67,6 +67,18 @@ namespace Microsoft.Azure.Functions.Worker
 
         public async Task InvokeFunctionAsync(FunctionContext context)
         {
+            // This will act as an internal activity that represents remote Host activity. This cannot be tracked as this is not associate to an ActivitySource. 
+            using Activity activity = new Activity(nameof(InvokeFunctionAsync));
+            activity.Start();
+
+            if (ActivityContext.TryParse(context.TraceContext.TraceParent, context.TraceContext.TraceState, true, out ActivityContext activityContext))
+            {
+                activity.SetId(context.TraceContext.TraceParent);
+                activity.SetSpanId(activityContext.SpanId.ToString());
+                activity.SetTraceId(activityContext.TraceId.ToString());
+                activity.SetRootId(activityContext.TraceId.ToString());
+            }
+
             var scope = new FunctionInvocationScope(context.FunctionDefinition.Name, context.InvocationId);
 
             using var logScope = _logger.BeginScope(scope);

--- a/src/DotNetWorker.OpenTelemetry/ConfigureFunctionsOpenTelemetry.cs
+++ b/src/DotNetWorker.OpenTelemetry/ConfigureFunctionsOpenTelemetry.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry;
-using OpenTelemetry.Resources;
 
 namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
 {
@@ -24,11 +20,10 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
                 // Lets the host know that the worker is sending logs to App Insights. The host will now ignore these.
                 .Configure<WorkerOptions>(workerOptions => workerOptions.Capabilities["WorkerOpenTelemetryEnabled"] = bool.TrueString);
 
-            builder.ConfigureResource(r =>
+            builder.ConfigureResource((resourceBuilder) =>
             {
-                r.AddDetector(new FunctionsResourceDetector());
+                resourceBuilder.AddDetector(new FunctionsResourceDetector());
             });
-
             return builder;
         }
     }

--- a/src/DotNetWorker.OpenTelemetry/ConfigureFunctionsOpenTelemetry.cs
+++ b/src/DotNetWorker.OpenTelemetry/ConfigureFunctionsOpenTelemetry.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+
+namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
+{
+    public static class ConfigureFunctionsOpenTelemetry
+    {   
+        public static OpenTelemetryBuilder UseFunctionsWorkerDefaults(this OpenTelemetryBuilder builder)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Services
+                // Lets the host know that the worker is sending logs to App Insights. The host will now ignore these.
+                .Configure<WorkerOptions>(workerOptions => workerOptions.Capabilities["WorkerOpenTelemetryEnabled"] = bool.TrueString);
+
+            builder.ConfigureResource(r =>
+            {
+                string version = typeof(ConfigureFunctionsOpenTelemetry).Assembly.GetName().Version.ToString();
+                ConfigureResourceAttributes(r, version);
+            });
+
+            return builder;
+        }
+
+        private static string GetServiceName() => Environment.GetEnvironmentVariable(ResourceAttributeConstants.SiteNameEnvVar) ?? Assembly.GetEntryAssembly()?.GetName().Name ?? ResourceAttributeConstants.SDKPrefix;
+
+        private static void ConfigureResourceAttributes(ResourceBuilder r, string version)
+        {
+            r.AddService(GetServiceName(), serviceVersion: version)
+                .AddDetector(new FunctionsResourceDetector())
+                .AddAttributes(
+                 [
+                    new KeyValuePair<string, object>(ResourceAttributeConstants.AttributeSDKPrefix, $"{ResourceAttributeConstants.SDKPrefix}: {version}"),
+                    new KeyValuePair<string, object>(ResourceAttributeConstants.AttributeProcessId, Process.GetCurrentProcess().Id.ToString())
+                 ]);
+        }
+    }
+}

--- a/src/DotNetWorker.OpenTelemetry/ConfigureFunctionsOpenTelemetry.cs
+++ b/src/DotNetWorker.OpenTelemetry/ConfigureFunctionsOpenTelemetry.cs
@@ -26,24 +26,10 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
 
             builder.ConfigureResource(r =>
             {
-                string version = typeof(ConfigureFunctionsOpenTelemetry).Assembly.GetName().Version.ToString();
-                ConfigureResourceAttributes(r, version);
+                r.AddDetector(new FunctionsResourceDetector());
             });
 
             return builder;
-        }
-
-        private static string GetServiceName() => Environment.GetEnvironmentVariable(ResourceAttributeConstants.SiteNameEnvVar) ?? Assembly.GetEntryAssembly()?.GetName().Name ?? ResourceAttributeConstants.SDKPrefix;
-
-        private static void ConfigureResourceAttributes(ResourceBuilder r, string version)
-        {
-            r.AddService(GetServiceName(), serviceVersion: version)
-                .AddDetector(new FunctionsResourceDetector())
-                .AddAttributes(
-                 [
-                    new KeyValuePair<string, object>(ResourceAttributeConstants.AttributeSDKPrefix, $"{ResourceAttributeConstants.SDKPrefix}: {version}"),
-                    new KeyValuePair<string, object>(ResourceAttributeConstants.AttributeProcessId, Process.GetCurrentProcess().Id.ToString())
-                 ]);
         }
     }
 }

--- a/src/DotNetWorker.OpenTelemetry/DotNetWorker.OpenTelemetry.csproj
+++ b/src/DotNetWorker.OpenTelemetry/DotNetWorker.OpenTelemetry.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <PackageId>Microsoft.Azure.Functions.Worker.OpenTelemetry</PackageId>
+        <AssemblyName>Microsoft.Azure.Functions.Worker.OpenTelemetry</AssemblyName>
+        <RootNamespace>Microsoft.Azure.Functions.Worker.OpenTelemetry</RootNamespace>
+        <MajorProductVersion>0</MajorProductVersion>
+        <MinorProductVersion>1</MinorProductVersion>
+        <PatchProductVersion>0</PatchProductVersion>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <VersionSuffix></VersionSuffix>
+        <BeforePack>$(BeforePack);GetReleaseNotes</BeforePack>
+    </PropertyGroup>
+
+    <Import Project="..\..\build\Common.props" />
+
+    <ItemGroup>
+        <PackageReference Include="OpenTelemetry" Version="1.7.0" />
+        <PackageReference Include="OpenTelemetry.Api" Version="1.7.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\DotNetWorker.Core\DotNetWorker.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="README.md" Pack="true" PackagePath="/" />
+    </ItemGroup>
+
+    <Target Name="GetReleaseNotes">
+        <PropertyGroup>
+            <PackageReleaseNotes>$([System.IO.File]::ReadAllText('release_notes.md'))</PackageReleaseNotes>
+        </PropertyGroup>
+    </Target>
+
+</Project>

--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
                 string version = Assembly.GetEntryAssembly().GetName().Version.ToString();
 
                 attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ServiceVersion, version));
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AISDKPrefix, $@"{OpenTelemetryConstants.SDKPrefix}:{version}"));
+                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AISDKPrefix, $@"{OpenTelemetryConstants.SDKPrefix}:{typeof(FunctionsResourceDetector).Assembly.GetName().Version}"));
                 attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ProcessId, Process.GetCurrentProcess().Id));
 
                 // Add these attributes only if running in Azure.

--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using OpenTelemetry.Resources;
+
+namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
+{
+
+    public sealed class FunctionsResourceDetector : IResourceDetector
+    {  
+        internal static readonly IReadOnlyDictionary<string, string> ResourceAttributes = new Dictionary<string, string>(1)
+        {
+            { ResourceAttributeConstants.AttributeCloudRegion, ResourceAttributeConstants.RegionNameEnvVar },
+        };
+
+        /// <inheritdoc/>
+        public Resource Detect()
+        {
+            List<KeyValuePair<string, object>> attributeList = new(5);
+            try
+            {
+                var siteName = Environment.GetEnvironmentVariable(ResourceAttributeConstants.SiteNameEnvVar);
+                attributeList.Add(new KeyValuePair<string, object>(ResourceAttributeConstants.AttributeCloudProvider, ResourceAttributeConstants.AzureCloudProviderValue));
+                attributeList.Add(new KeyValuePair<string, object>(ResourceAttributeConstants.AttributeCloudPlatform, ResourceAttributeConstants.AzurePlatformValue));
+                
+                var version = Assembly.GetEntryAssembly()?.GetName().Version.ToString() ?? "0:0:0";
+                attributeList.Add(new KeyValuePair<string, object>(ResourceAttributeConstants.AttributeVersion, version)); 
+                if (!string.IsNullOrEmpty(siteName))
+                {
+                    var azureResourceUri = GetAzureResourceURI(siteName);
+                    if (azureResourceUri != null)
+                    {
+                        attributeList.Add(new KeyValuePair<string, object>(ResourceAttributeConstants.AttributeCloudResourceId, azureResourceUri));
+                    }
+
+                    foreach (var kvp in ResourceAttributes)
+                    {
+                        var attributeValue = Environment.GetEnvironmentVariable(kvp.Value);
+                        if (attributeValue != null)
+                        {
+                            attributeList.Add(new KeyValuePair<string, object>(kvp.Key, attributeValue));
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // return empty resource.
+                return Resource.Empty;
+            }
+
+            return new Resource(attributeList);
+        }
+        private static string? GetAzureResourceURI(string websiteSiteName)
+        {
+            string? websiteResourceGroup = Environment.GetEnvironmentVariable(ResourceAttributeConstants.ResourceGroupEnvVar);
+            string? websiteOwnerName = Environment.GetEnvironmentVariable(ResourceAttributeConstants.OwnerNameEnvVar);
+
+            if (string.IsNullOrEmpty(websiteResourceGroup) || string.IsNullOrEmpty(websiteOwnerName))
+            {
+                return null;
+            }
+
+            int idx = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);
+            string subscriptionId = idx > 0 ? websiteOwnerName.Substring(0, idx) : websiteOwnerName;
+
+            if (string.IsNullOrEmpty(subscriptionId))
+            {
+                return null;
+            }
+
+            return $"/subscriptions/{subscriptionId}/resourceGroups/{websiteResourceGroup}/providers/Microsoft.Web/sites/{websiteSiteName}";
+        }
+    }
+}

--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
                 string version = Assembly.GetEntryAssembly().GetName().Version.ToString();
 
                 attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ServiceVersion, version));
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AISDKPrefix, $@"{OpenTelemetryConstants.SDKPrefix}:{typeof(FunctionsResourceDetector).Assembly.GetName().Version}"));
+                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AISDKPrefix, 
+                    $@"{OpenTelemetryConstants.SDKPrefix}:{typeof(FunctionsResourceDetector).Assembly.GetName().Version}"));
                 attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ProcessId, Process.GetCurrentProcess().Id));
 
                 // Add these attributes only if running in Azure.

--- a/src/DotNetWorker.OpenTelemetry/OpenTelemetryConstants.cs
+++ b/src/DotNetWorker.OpenTelemetry/OpenTelemetryConstants.cs
@@ -3,17 +3,10 @@
 
 namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
 {
-    internal class ResourceAttributeConstants
+    internal class OpenTelemetryConstants
     {
-        internal const string AttributeCloudProvider = "cloud.provider";
-        internal const string AttributeCloudPlatform = "cloud.platform";
-        internal const string AttributeCloudRegion = "cloud.region";
-        internal const string AttributeCloudResourceId = "cloud.resource.id";        
         internal const string AzureCloudProviderValue = "azure";
         internal const string AzurePlatformValue = "azure_functions";
-        internal const string AttributeSDKPrefix = "ai.sdk.prefix";
-        internal const string AttributeProcessId = "process.pid";
-        internal const string AttributeVersion = "faas.version";
         internal const string SDKPrefix = "dotnetiso";
         internal const string SiteNameEnvVar = "WEBSITE_SITE_NAME";
         internal const string RegionNameEnvVar = "REGION_NAME";

--- a/src/DotNetWorker.OpenTelemetry/README.md
+++ b/src/DotNetWorker.OpenTelemetry/README.md
@@ -1,0 +1,5 @@
+# Microsoft.Azure.Functions.Worker.ApplicationInsights
+
+This package adds extension methods and services to configure OpenTelemetry for use in Azure Functions .NET isolated applications.
+
+This package does **not** add OpenTelemetry services directly. This must be done directly. Instead, this package only configures isolated application and resource detector.

--- a/src/DotNetWorker.OpenTelemetry/README.md
+++ b/src/DotNetWorker.OpenTelemetry/README.md
@@ -10,7 +10,7 @@ This package does **not** add OpenTelemetry services directly. This must be done
 
 ``` CSharp
 dotnet add package Azure.Monitor.OpenTelemetry.AspNetCore
-dotnet add package Microsoft.Azure.Functions.Worker.OpenTelemetry
+dotnet add package Microsoft.Azure.Functions.Worker.OpenTelemetry --prerelease
 ```
 
 2. Configure ApplicationInsights using Azure Monitor OpenTelemetry Distro

--- a/src/DotNetWorker.OpenTelemetry/README.md
+++ b/src/DotNetWorker.OpenTelemetry/README.md
@@ -1,5 +1,30 @@
-# Microsoft.Azure.Functions.Worker.ApplicationInsights
+# Microsoft.Azure.Functions.Worker.OpenTelemetry
 
 This package adds extension methods and services to configure OpenTelemetry for use in Azure Functions .NET isolated applications.
 
 This package does **not** add OpenTelemetry services directly. This must be done directly. Instead, this package only configures isolated application and resource detector.
+
+## Getting Started
+
+1. Add packages
+
+``` CSharp
+dotnet add package Azure.Monitor.OpenTelemetry.AspNetCore
+dotnet add package Microsoft.Azure.Functions.Worker.OpenTelemetry
+```
+
+2. Configure ApplicationInsights using Azure Monitor OpenTelemetry Distro
+
+``` CSharp
+services.AddOpenTelemetry()
+ .UseFunctionsWorkerDefaults()
+ .UseAzureMonitor();
+```
+
+## UseFunctionsWorkerDefaults
+
+UseFunctionsWorkerDefaults() method will configure the following:
+1. Resource detector for Azure Functions
+2. Adds a capability to avoid duplicate telemetry
+
+

--- a/src/DotNetWorker.OpenTelemetry/ResourceAttributeConstants.cs
+++ b/src/DotNetWorker.OpenTelemetry/ResourceAttributeConstants.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
+{
+    internal class ResourceAttributeConstants
+    {
+        internal const string AttributeCloudProvider = "cloud.provider";
+        internal const string AttributeCloudPlatform = "cloud.platform";
+        internal const string AttributeCloudRegion = "cloud.region";
+        internal const string AttributeCloudResourceId = "cloud.resource.id";        
+        internal const string AzureCloudProviderValue = "azure";
+        internal const string AzurePlatformValue = "azure_functions";
+        internal const string AttributeSDKPrefix = "ai.sdk.prefix";
+        internal const string AttributeProcessId = "process.pid";
+        internal const string AttributeVersion = "faas.version";
+        internal const string SDKPrefix = "dotnetiso";
+        internal const string SiteNameEnvVar = "WEBSITE_SITE_NAME";
+        internal const string RegionNameEnvVar = "REGION_NAME";
+        internal const string ResourceGroupEnvVar = "WEBSITE_RESOURCE_GROUP";
+        internal const string OwnerNameEnvVar = "WEBSITE_OWNER_NAME";
+    }
+}

--- a/src/DotNetWorker.OpenTelemetry/ResourceSemanticConventions.cs
+++ b/src/DotNetWorker.OpenTelemetry/ResourceSemanticConventions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
+{
+    internal static class ResourceSemanticConventions
+    {
+        // Service
+        internal const string ServiceName = "service.name";
+        internal const string ServiceVersion = "service.version";
+
+        // Cloud
+        internal const string CloudProvider = "cloud.provider";
+        internal const string CloudPlatform = "cloud.platform";
+        internal const string CloudRegion = "cloud.region";
+        internal const string CloudResourceId = "cloud.resource.id";
+        
+        // Process
+        internal const string ProcessId = "process.pid";
+
+        // AI
+        internal const string AISDKPrefix = "ai.sdk.prefix";
+    }
+}

--- a/src/DotNetWorker.OpenTelemetry/release_notes.md
+++ b/src/DotNetWorker.OpenTelemetry/release_notes.md
@@ -1,0 +1,3 @@
+## What's Changed
+
+### Microsoft.Azure.Functions.Worker.OpenTelemetry 1.0.0

--- a/src/DotNetWorker.OpenTelemetry/release_notes.md
+++ b/src/DotNetWorker.OpenTelemetry/release_notes.md
@@ -1,3 +1,5 @@
 ## What's Changed
 
-### Microsoft.Azure.Functions.Worker.OpenTelemetry 1.0.0
+### Microsoft.Azure.Functions.Worker.OpenTelemetry 0.1.0 (Preview)
+
+- Initial preview release

--- a/src/DotNetWorker/DotNetWorker.csproj
+++ b/src/DotNetWorker/DotNetWorker.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MinorProductVersion>21</MinorProductVersion>
+    <MinorProductVersion>22</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>

--- a/test/DotNetWorker.OpenTelemetry.Tests/DotNetWorker.OpenTelemetry.Tests.csproj
+++ b/test/DotNetWorker.OpenTelemetry.Tests/DotNetWorker.OpenTelemetry.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+      <IsPackable>false</IsPackable>
+      <AssemblyName>Microsoft.Azure.Functions.Worker.Tests</AssemblyName>
+      <RootNamespace>Microsoft.Azure.Functions.Worker.Tests</RootNamespace>
+      <SignAssembly>true</SignAssembly>
+      <LangVersion>preview</LangVersion>
+      <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
+      <Nullable>disable</Nullable>
+      <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.Abstractions\src\Worker.Extensions.Abstractions.csproj" />
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.Http.AspNetCore\src\Worker.Extensions.Http.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.Http\src\Worker.Extensions.Http.csproj" />
+    <ProjectReference Include="..\..\src\DotNetWorker.OpenTelemetry\DotNetWorker.OpenTelemetry.csproj" />
+    <ProjectReference Include="..\..\src\DotNetWorker\DotNetWorker.csproj" />
+    <ProjectReference Include="..\TestUtility\TestUtility.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/DotNetWorker.OpenTelemetry.Tests/DotNetWorker.OpenTelemetry.Tests.csproj
+++ b/test/DotNetWorker.OpenTelemetry.Tests/DotNetWorker.OpenTelemetry.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
       <IsPackable>false</IsPackable>
       <AssemblyName>Microsoft.Azure.Functions.Worker.Tests</AssemblyName>
       <RootNamespace>Microsoft.Azure.Functions.Worker.Tests</RootNamespace>

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Tests;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Context.Features;
+using Microsoft.Azure.Functions.Worker.Diagnostics;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
+using Microsoft.Azure.Functions.Worker.Tests.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace DotNetWorker.OpenTelemetry.Tests;
+
+public class EndToEndTests
+{
+    private IFunctionsApplication _application;
+    private IInvocationFeaturesFactory _invocationFeaturesFactory;
+    private readonly OtelFunctionDefinition _funcDefinition = new();
+
+    private IHost InitializeHost()
+    {
+        var host = new HostBuilder()
+           .ConfigureServices(services =>
+           {
+               var functionsBuilder = services.AddFunctionsWorkerCore();
+               functionsBuilder.UseDefaultWorkerMiddleware();
+               services.AddDefaultInputConvertersToWorkerOptions();
+               services.AddOpenTelemetry()
+                    .UseFunctionsWorkerDefaults();
+
+               services.AddSingleton(_ => new Mock<IWorkerDiagnostics>().Object);
+           })
+           .Build();
+
+        _application = host.Services.GetService<IFunctionsApplication>();
+        _invocationFeaturesFactory = host.Services.GetService<IInvocationFeaturesFactory>();
+
+        _application.LoadFunction(_funcDefinition);
+
+        return host;
+    }
+
+    private FunctionContext CreateContext(IHost host)
+    {
+        var invocation = new TestFunctionInvocation(functionId: _funcDefinition.Id);
+
+        var features = _invocationFeaturesFactory.Create();
+        features.Set<FunctionInvocation>(invocation);
+        var inputConversionProvider = host.Services.GetRequiredService<IInputConversionFeatureProvider>();
+        inputConversionProvider.TryCreate(typeof(DefaultInputConversionFeature), out var inputConversion);
+        features.Set<IFunctionBindingsFeature>(new TestFunctionBindingsFeature());
+        features.Set<IInputConversionFeature>(inputConversion);
+
+        return _application.CreateContext(features);
+    }
+
+    [Fact]
+    public async Task ContextPropagation()
+    {
+        using var host = InitializeHost();
+        var context = CreateContext(host);
+        await _application.InvokeFunctionAsync(context);
+        var activity = OtelFunctionDefinition.LastActivity;
+
+        Assert.Equal(activity.Id, context.TraceContext.TraceParent);
+        Assert.Equal("InvokeFunctionAsync", activity.OperationName);
+    }
+
+    [Fact]
+    public void ResourceDetectorLocalDevelopment()
+    {
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.Equal(3, resource.Attributes.Count());
+        var attribute = resource.Attributes.FirstOrDefault(a => a.Key == "cloud.provider");
+        Assert.Equal("azure", resource.Attributes.FirstOrDefault(a => a.Key == "cloud.provider").Value);
+        Assert.Equal("azure_functions", resource.Attributes.FirstOrDefault(a => a.Key == "cloud.platform").Value);
+    }
+
+    [Fact]
+    public void ResourceDetectorLocalDevelopment2()
+    {
+        using var _ = SetupDefaultEnvironmentVariables();
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.Equal($"/subscriptions/AAAAA-AAAAA-AAAAA-AAA/resourceGroups/rg/providers/Microsoft.Web/sites/appName"
+            , resource.Attributes.FirstOrDefault(a => a.Key == "cloud.resource.id").Value);
+        Assert.Equal($"EastUS", resource.Attributes.FirstOrDefault(a => a.Key == "cloud.region").Value);
+    }
+
+    private static IDisposable SetupDefaultEnvironmentVariables()
+    {
+        return new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "WEBSITE_RESOURCE_GROUP", "rg" },
+            { "WEBSITE_OWNER_NAME", "AAAAA-AAAAA-AAAAA-AAA+appName-EastUSwebspace" },
+            { "REGION_NAME", "EastUS" }
+        });
+    }
+
+    internal class OtelFunctionDefinition : FunctionDefinition
+    {
+        public static readonly string DefaultPathToAssembly = typeof(OtelFunctionDefinition).Assembly.Location;
+        public static readonly string DefaultEntryPoint = $"{typeof(OtelFunctionDefinition).FullName}.{nameof(TestFunction)}";
+        public static readonly string DefaultId = "TestId";
+        public static readonly string DefaultName = "TestName";
+
+        public OtelFunctionDefinition()
+        {
+            Parameters = (new[] { new FunctionParameter("context", typeof(FunctionContext)) }).ToImmutableArray();
+        }
+
+        public override ImmutableArray<FunctionParameter> Parameters { get; }
+
+        public override string PathToAssembly { get; } = DefaultPathToAssembly;
+
+        public override string EntryPoint { get; } = DefaultEntryPoint;
+
+        public override string Id { get; } = DefaultId;
+
+        public override string Name { get; } = DefaultName;
+
+        public override IImmutableDictionary<string, BindingMetadata> InputBindings { get; } = ImmutableDictionary<string, BindingMetadata>.Empty;
+
+        public override IImmutableDictionary<string, BindingMetadata> OutputBindings { get; } = ImmutableDictionary<string, BindingMetadata>.Empty;
+
+        public static Activity LastActivity;
+
+        public async Task TestFunction(FunctionContext context)
+        {
+            LastActivity = Activity.Current;
+            Activity.Current.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            Activity.Current.AddTag("CustomKey", "CustomValue");
+
+            var logger = context.GetLogger("TestFunction");
+            logger.LogWarning("Test");
+
+            HttpClient httpClient = new HttpClient();
+            await httpClient.GetAsync("https://www.bing.com");
+
+            if (context.Items.ContainsKey("_throw"))
+            {
+                throw new InvalidOperationException("boom!");
+            }
+        }
+    }
+}

--- a/test/DotNetWorker.OpenTelemetry.Tests/TestFunctionBindingsFeature.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/TestFunctionBindingsFeature.cs
@@ -6,7 +6,7 @@ using System.Collections.ObjectModel;
 using Microsoft.Azure.Functions.Worker.Context.Features;
 using Microsoft.Azure.Functions.Worker.OutputBindings;
 
-namespace Microsoft.Azure.Functions.Worker.Tests.Features
+namespace DotNetWorker.OpenTelemetry.Tests
 {
     internal class TestFunctionBindingsFeature : IFunctionBindingsFeature
     {

--- a/test/DotNetWorker.OpenTelemetry.Tests/TestFunctionBindingsFeature.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/TestFunctionBindingsFeature.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.Azure.Functions.Worker.Context.Features;
+using Microsoft.Azure.Functions.Worker.OutputBindings;
+
+namespace Microsoft.Azure.Functions.Worker.Tests.Features
+{
+    internal class TestFunctionBindingsFeature : IFunctionBindingsFeature
+    {
+        public IReadOnlyDictionary<string, object> TriggerMetadata { get; init; } = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+
+        public IReadOnlyDictionary<string, object> InputData { get; init; } = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+
+        public IDictionary<string, object> OutputBindingData { get; } = new Dictionary<string, object>();
+
+        public OutputBindingsInfo OutputBindingsInfo { get; init; } = EmptyOutputBindingsInfo.Instance;
+
+        public object InvocationResult { get; set; }
+    }
+}

--- a/test/DotNetWorker.OpenTelemetry.Tests/TestFunctionInvocation.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/TestFunctionInvocation.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Azure.Functions.Worker;
+
+namespace DotNetWorker.OpenTelemetry.Tests
+{
+    public class TestFunctionInvocation : FunctionInvocation
+    {
+        public TestFunctionInvocation(string id = null, string functionId = null)
+        {
+            if (id is not null)
+            {
+                Id = id;
+            }
+
+            if (functionId is not null)
+            {
+                FunctionId = functionId;
+            }
+
+            // create/dispose activity to pull off it's Id
+            using Activity activity = new Activity(string.Empty).Start();
+            TraceContext = new DefaultTraceContext(activity.Id, Guid.NewGuid().ToString());
+        }
+
+        public override string Id { get; } = Guid.NewGuid().ToString();
+
+        public override string FunctionId { get; } = Guid.NewGuid().ToString();
+
+        public override TraceContext TraceContext { get; }
+    }
+}

--- a/test/Sdk.Generator.Tests/FunctionExecutor/DependentAssemblyTest.cs
+++ b/test/Sdk.Generator.Tests/FunctionExecutor/DependentAssemblyTest.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Functions.SdkGeneratorTests
                                        
                                                private IFunctionExecutor CreateDefaultExecutorInstance(FunctionContext context)
                                                {
-                                                   var defaultExecutorFullName = "Microsoft.Azure.Functions.Worker.Invocation.DefaultFunctionExecutor, Microsoft.Azure.Functions.Worker.Core, Version=1.17.0.0, Culture=neutral, PublicKeyToken=551316b6919f366c";
+                                                   var defaultExecutorFullName = "Microsoft.Azure.Functions.Worker.Invocation.DefaultFunctionExecutor, Microsoft.Azure.Functions.Worker.Core, Version=1.18.0.0, Culture=neutral, PublicKeyToken=551316b6919f366c";
                                                    var defaultExecutorType = Type.GetType(defaultExecutorFullName);
                                        
                                                    return ActivatorUtilities.CreateInstance(context.InstanceServices, defaultExecutorType) as IFunctionExecutor;


### PR DESCRIPTION
Enhancing the DotNet Worker with OpenTelemetry Support involves two key changes aimed at improving telemetry integration and traceability:

**Context Propagation**
Introduced a foundational Activity serving as the precursor to the "Invoke" activity or any customer-generated activity. This foundational activity emulates the remote activity in the Host process, enabling the correlation of all logs and traces with the server/consumer telemetry emitted by the host process.

**OpenTelemetryBuilder extension method for Azure Functions**
a. Functions Resource Detector - This component automatically detects and applies a set of standard attributes defined by the OTel Spec to the telemetry data.
b. Worker Capability - To signal the Host to disregard any logs produced by the worker process.

```
.ConfigureServices(s =>
{
   s.AddOpenTelemetry()
    .UseFunctionsWorkerDefaults()
    .UseAzureMonitor();
})
```

**Reverse Proxy Scenario**

```
Client Telemetry from Console App
-- -> Console App Outgoing Request
-- -- -> Functions Host Incoming Request
-- -- -- -> Functions Host Outgoing Request
-- -- -- -- -> DotNet Worker Incoming Request
-- -- -- -- -- -> Outgoing Request to bing.com from Worker 
```

<img width="1058" alt="image" src="https://github.com/Azure/azure-functions-dotnet-worker/assets/90008725/05a9810f-b157-41e3-a23e-811d0201a65d">

<img width="1059" alt="image" src="https://github.com/Azure/azure-functions-dotnet-worker/assets/90008725/af3bf817-da44-4145-821d-05e33b507fab">

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

