### PR TITLE
Update 01-bug-report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Create a report to help us improve
-labels: ["bug"]
+labels: ["potential-bug"]
 body: 
 - id: description
   type: textarea


### PR DESCRIPTION
Changing the label that gets auto-applied so that we can better distinguish between reports that have been opened and items that have been confirmed as bugs through the triage process.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
