### PR TITLE
Update Microsoft.AspNetCore.WebUtilities reference in the E2EApps project

### DIFF
--- a/test/E2ETests/E2EApps/E2EApp/E2EApp.csproj
+++ b/test/E2ETests/E2EApps/E2EApp/E2EApp.csproj
@@ -42,7 +42,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.1" />
+     <!-- Use version 2.2.0 for .NET Framework 4.8 -->
+     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" Condition="'$(TargetFramework)' == 'net48'" />
+     <!-- Use version 8.0.1 for .NET Core or other target frameworks -->
+     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.1" Condition="'$(TargetFramework)' != 'net48'" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Condition="$(TestBuild) == 'true'" Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.1" />

--- a/test/E2ETests/E2EApps/E2EApp/E2EApp.csproj
+++ b/test/E2ETests/E2EApps/E2EApp/E2EApp.csproj
@@ -42,10 +42,10 @@
   </ItemGroup>
 
   <ItemGroup>
-     <!-- Use version 2.2.0 for .NET Framework 4.8 -->
-     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" Condition="'$(TargetFramework)' == 'net48'" />
-     <!-- Use version 8.0.1 for .NET Core or other target frameworks -->
-     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.1" Condition="'$(TargetFramework)' != 'net48'" />
+    <!-- Use version 2.2.0 for .NET Framework 4.8 -->
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" Condition="'$(TargetFramework)' == 'net48'" />
+    <!-- Use version 8.0.1 for .NET Core or other target frameworks -->
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.1" Condition="'$(TargetFramework)' != 'net48'" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Condition="$(TestBuild) == 'true'" Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.1" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Add condition to `Microsoft.AspNetCore.WebUtilities` package reference to allow us to run NetFx E2E tests. Without this change, our pipeline fails with the following error:

> ##[error]test\E2ETests\E2EApps\E2EApp\E2EApp.csproj(0,0): Error NU1202: Package Microsoft.AspNetCore.WebUtilities 8.0.1 is not compatible with net48 (.NETFramework,Version=v4.8). Package Microsoft.AspNetCore.WebUtilities 8.0.1 supports: net8.0 (.NETCoreApp,Version=v8.0)
