### PR TITLE
Reset release notes

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -4,9 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 1.3.0
+### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore <version>
 
-- Improvements to context coordination/synchronization handling and observability
-  - Failure to receive any of the expected context synchronization calls will now result in a `TimeoutException` thrown with the appropriate exception information. Previously this would block indefinitely and failures here were difficult to diagnose.
-  - Debug logs are now emitted in the context coordination calls, improving observability.
-- Introduces fix to properly handle multiple output binding scenarios (#2322).
+- <entry>

--- a/extensions/Worker.Extensions.Http/release_notes.md
+++ b/extensions/Worker.Extensions.Http/release_notes.md
@@ -4,8 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Http 3.2.0
+### Microsoft.Azure.Functions.Worker.Extensions.Http <version>
 
-- Added ability to bind a POCO parameter to the request body using `FromBodyAttribute`
-  - Special thanks to @njqdev for the contributions and collaboration on this feature
-- Introduces `HttpResultAttribute`, which should be used to label the parameter associated with the HTTP result in multiple output binding scenarios (#2322).
+- <entry>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,35 +4,10 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.17.3-preview2 (meta package)
+### Microsoft.Azure.Functions.Worker.Sdk <version> (meta package)
 
-- Updating to use `Microsoft.NET.Sdk.Functions.Generators` 1.3.0 (#2322)
-- Update legacy generator to handle `HttpResultAttribute` (#2342), which is used on HTTP response properties in [multiple output-binding scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide?tabs=windows#multiple-output-bindings). Example:
+- <entry>
 
-```csharp
-public class MyOutputType
-{
-    [QueueOutput("myQueue")]
-    public string Name { get; set; }
+### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 
-    [HttpResult]
-    public IActionResult HttpResponse { get; set; }
-}
-```
-
-### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.3.0
-
-- Introduces handling for `HttpResultAttribute`, which is used on HTTP response properties in [multiple output-binding scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide?tabs=windows#multiple-output-bindings). Example:
-
-```csharp
-public class MyOutputType
-{
-    [QueueOutput("myQueue")]
-    public string Name { get; set; }
-
-    [HttpResult]
-    public IActionResult HttpResponse { get; set; }
-}
-```
-
-- Fix bug causing compiler error when named arguments in function attributes are array types (#2344).
+- <entry>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Released [sdk](https://github.com/Azure/azure-functions-dotnet-worker/releases/tag/sdk-1.17.3-preview2), [http extension](https://github.com/Azure/azure-functions-dotnet-worker/releases/tag/http-extension-3.2.0), and [asp.net core integration extension](https://github.com/Azure/azure-functions-dotnet-worker/releases/tag/http-aspnetcore-extension-1.3.0) today. Resetting release notes.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
