### PR TITLE
Add optional 'name' property to ConversionResult

### DIFF
--- a/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
@@ -63,11 +63,11 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
                         // Don't initialize this list unless we have to
                         errors ??= new List<string>();
 
-                        errors.Add($"Cannot convert input parameter '{parameter.Name}' to type '{parameter.Type.FullName}' from type '{source.GetType().FullName}'. Error:{bindingResult.Error}");
+                        errors.Add($"Converter '{bindingResult.Name}' could not convert input parameter '{parameter.Name}' to type '{parameter.Type.FullName}' from type '{source.GetType().FullName}'. Error:{bindingResult.Error}");
                     }
                     else if (bindingResult.Status == ConversionStatus.Unhandled)
                     {
-                        // If still unhandled after going through all converters,check an explicit default value was provided for the parameter.
+                        // If still unhandled after going through all converters, check an explicit default value was provided for the parameter.
                         if (parameter.HasDefaultValue)
                         {
                             parameterValues[i] = parameter.DefaultValue;

--- a/src/DotNetWorker.Core/Context/Features/DefaultInputConversionFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultInputConversionFeature.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
                 if (conversionResult.Status != ConversionStatus.Unhandled)
                 {
-                    return conversionResult;
+                    return ResultWithConverterName(conversionResult, converterFromContext.GetType().Name);
                 }
             }
 
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
                         if (conversionResult.Status != ConversionStatus.Unhandled)
                         {
-                            return conversionResult;
+                            return ResultWithConverterName(conversionResult, converterType.Key.GetType().Name);
                         }
                     }
                 }
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
                     if (conversionResult.Status != ConversionStatus.Unhandled)
                     {
-                        return conversionResult;
+                        return ResultWithConverterName(conversionResult, converter.GetType().Name);
                     }
 
                     // If "Status" is Unhandled, we move on to the next converter and try to convert with that.
@@ -215,5 +215,12 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
             // If types are explicitly advertised by the converter then we should send only those types for conversion.
             return supportedTypes.Any(a => a.AssemblyQualifiedName == targetType.AssemblyQualifiedName);
         }
+
+        private ConversionResult ResultWithConverterName(ConversionResult result, string converterName) => result.Status switch
+        {
+            ConversionStatus.Succeeded => ConversionResult.Success(result.Value, converterName),
+            ConversionStatus.Failed => ConversionResult.Failed(result.Error!, converterName),
+            _ => result // Return the original result for other status types
+        };
     }
 }

--- a/src/DotNetWorker.Core/Converters/Converter/ConversionResult.cs
+++ b/src/DotNetWorker.Core/Converters/Converter/ConversionResult.cs
@@ -10,26 +10,25 @@ namespace Microsoft.Azure.Functions.Worker.Converters
     /// </summary>
     public readonly struct ConversionResult
     {
-        // A static ConversionResult instance which represents an unhandled conversion.
-        private static readonly ConversionResult _unhandledConversionResult = new(status: ConversionStatus.Unhandled);
-
         /// <summary>
         /// Creates a new <see cref="ConversionResult"/> instance.
         /// </summary>
         /// <param name="status">The status of conversion operation.</param>
         /// <param name="value">The value produced from the successful conversion.</param>
         /// <param name="error">The exception which caused the conversion to fail.</param>
-        private ConversionResult(ConversionStatus status, object? value = null, Exception? error = null)
+        /// <param name="name">The name of the converter.</param>
+        private ConversionResult(ConversionStatus status, object? value = null, Exception? error = null, string? name = null)
         {
             Status = status;
             Value = value;
             Error = error;
+            Name = name ?? string.Empty;
         }
 
         /// <summary>
         /// Gets the status of the conversion.
         /// </summary>
-        public ConversionStatus Status { get; } 
+        public ConversionStatus Status { get; }
 
         /// <summary>
         /// Gets the value produced from the conversion if it was successful.
@@ -42,33 +41,43 @@ namespace Microsoft.Azure.Functions.Worker.Converters
         public Exception? Error { get; }
 
         /// <summary>
+        /// Gets the name of the converter.
+        /// </summary>
+        public string? Name { get; }
+
+        /// <summary>
         /// Creates a new <see cref="ConversionResult"/> instance to represent an unhandled input conversion.
         /// </summary>
+        /// <param name="name">The name of the converter.</param>
         /// <returns>A new instance of <see cref="ConversionResult"/> where the Status property value is set to Unhandled.</returns>
-        public static ConversionResult Unhandled() => _unhandledConversionResult;
+        public static ConversionResult Unhandled(string? name = null) => new(status: ConversionStatus.Unhandled, name: name);
 
         /// <summary>
         /// Creates a new <see cref="ConversionResult"/> instance to represent a successful input conversion.
         /// </summary>
+        /// <param name="value">The value produced from the conversion.</param>
+        /// <param name="name">The name of the converter.</param>
         /// <returns>A new instance of <see cref="ConversionResult"/> to represent a successful conversion.</returns>
-        public static ConversionResult Success(object? value) => new(status: ConversionStatus.Succeeded, value: value);
+        public static ConversionResult Success(object? value, string? name = null) => new(status: ConversionStatus.Succeeded, value: value, name: name);
 
         /// <summary>
         /// Creates a new <see cref="ConversionResult"/> instance to represent a failed input conversion.
         /// </summary>
         /// <param name="exception">The exception representing the cause of the failed conversion.</param>
+        /// <param name="name">The name of the converter.</param>
         /// <exception cref="ArgumentNullException">Throws when the <paramref name="exception"/> argument is null.</exception>
         /// <returns>A new instance of <see cref="ConversionResult"/> to represent a failed input conversion.</returns>
-        public static ConversionResult Failed(Exception exception)
+        public static ConversionResult Failed(Exception exception, string? name = null)
         {
             if (exception is null)
             {
                 throw new ArgumentNullException(nameof(exception));
             }
-            
+
             return new ConversionResult(status: ConversionStatus.Failed,
                                         value: null,
-                                        error: exception);
+                                        error: exception,
+                                        name: name);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #2410

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Introducing an optional "name" parameter to `ConversionResult`, allowing converters to provide their name with the result.
This will give us the name of the converter when we get the conversion result and we can use that to then log the name of converter when there is an error. Optional parameter to avoid breaking changes.

Example log with changes:

> Exception: Microsoft.Azure.Functions.Worker.FunctionInputConverterException: Error converting 1 input parameters for Function 'Echo': **Converter 'JsonPocoConverter'** could not convert input parameter 'type' to type 'FunctionApp.TypeEnum' from type 'System.String'. Error:Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: T. Path '', line 0, position 0.

### Design

There were a couple approaches considered, and I am happy to take feedback on these.

1. (This PR) Modify `DefaultInputConversionFeature` to create a new result with the converter name provided. We have the name of the converter here and don't have to rely on every extension updating their converters with the converter name. This feels like the least effort and least amount of changes approach to me. But, I worry about the cost of creating a new ConversionResult for every invocation result - this seems excessive, but maybe the cost isn't so bad?

2. Instead of setting the converter name for every result ourselves as part of the conversion pipeline, we can update all the converters to include the converter name in the conversion result (see liliankasem/converter-name where is design is implemented).  This means not having to recreate the ConversionResult every time, but we depend on all converters being updated to provide the name. Doable, tedious - probably the cleanest way to go.

3. Not updating `ConversionResult`, we can find a way to bubble up the converter name from `DefaultInputConversionFeature` to `DefaultFunctionInputBindingFeature. BindFunctionInputAsync`.  I like this idea, but I can't find a clean way to do this that makes sense.

4. Not updating `ConversionResult`, we can pull the converter name from the ConversionResult.Error (exception) call stack - I hate this. 