### PR TITLE
 Implement `CosmosDBOptions` to allow configuration of the CosmosDB service client via `CosmosClientOptions`

### DIFF
--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -4,8 +4,27 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.8.1
+### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 5.0.0
 
-- Updating `Microsoft.Azure.WebJobs.Extensions.CosmosDB` reference to 4.6.1
-- Updating `Microsoft.Extensions.Azure` reference to 1.7.3
-- Updating `Microsoft.Azure.Cosmos` reference to 3.39.1
+- Expose `CosmosClientOptions` to allow configuration of the CosmosDB client (#2483)
+
+#### Breaking Change
+
+- **Default `ConnectionMode` Change:** The default `ConnectionMode` for `CosmosClientOptions` has been changed from `Gateway` to `Direct`.
+  This change is due to `Direct` being the default value for `ConnectionMode` in the Cosmos SDK; now that we are exposing those options,
+  it is not possible for us to tell whether the user has explicitly set the connection mode to `Direct` or not, so we must default to the
+  SDK's default value
+
+##### How to Maintain Previous Behavior
+
+To continue using `Gateway` mode, configure the `CosmosClientOptions` in your `Program` class as shown below:
+
+```csharp
+.ConfigureFunctionsWorkerDefaults((builder) =>
+{
+    builder.Services.Configure<CosmosClientOptions>((options) =>
+    {
+        options.ConnectionMode = ConnectionMode.Gateway;
+    });
+})
+```

--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 5.0.0
 
-- Implement `CosmosDBOptions` to allow configuration of the CosmosDB service client via `CosmosClientOptions` (#2483)
+- Implement `CosmosDBExtensionOptions` to allow configuration of the CosmosDB service client via `CosmosClientOptions` (#2483)
 
 #### Breaking Change
 

--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 5.0.0
 
-- Expose `CosmosClientOptions` to allow configuration of the CosmosDB client (#2483)
+- Implement `CosmosDBOptions` to allow configuration of the CosmosDB service client via `CosmosClientOptions` (#2483)
 
 #### Breaking Change
 
@@ -22,9 +22,9 @@ To continue using `Gateway` mode, configure the `CosmosClientOptions` in your `P
 ```csharp
 .ConfigureFunctionsWorkerDefaults((builder) =>
 {
-    builder.Services.Configure<CosmosClientOptions>((options) =>
+    builder.ConfigureCosmosDBExtensionOptions((options) =>
     {
-        options.ConnectionMode = ConnectionMode.Gateway;
+        options.ClientOptions.ConnectionMode = ConnectionMode.Gateway;
     });
 })
 ```

--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -4,27 +4,19 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 5.0.0
+### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.9.0
 
 - Implement `CosmosDBExtensionOptions` to allow configuration of the CosmosDB service client via `CosmosClientOptions` (#2483)
 
-#### Breaking Change
-
-- **Default `ConnectionMode` Change:** The default `ConnectionMode` for `CosmosClientOptions` has been changed from `Gateway` to `Direct`.
-  This change is due to `Direct` being the default value for `ConnectionMode` in the Cosmos SDK; now that we are exposing those options,
-  it is not possible for us to tell whether the user has explicitly set the connection mode to `Direct` or not, so we must default to the
-  SDK's default value
-
-##### How to Maintain Previous Behavior
-
-To continue using `Gateway` mode, configure the `CosmosClientOptions` in your `Program` class as shown below:
+#### Example Usage
 
 ```csharp
 .ConfigureFunctionsWorkerDefaults((builder) =>
 {
     builder.ConfigureCosmosDBExtensionOptions((options) =>
     {
-        options.ClientOptions.ConnectionMode = ConnectionMode.Gateway;
+        options.ClientOptions.ConnectionMode = ConnectionMode.Direct;
+        options.ClientOptions.ApplicationName = "MyApp";
     });
 })
 ```

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Azure.Functions.Worker
             // Do not override if preferred locations is configured via CosmosClientOptions
             if (!string.IsNullOrEmpty(preferredLocations) && CosmosExtensionOptions.ClientOptions.ApplicationPreferredRegions is null)
             {
-                // Copy to avoid modifying the original options
-                var cosmosClientOptions = CosmosExtensionOptions.ClientOptions;
+                // Clone to avoid modifying the original options
+                var cosmosClientOptions = CosmosExtensionOptions.Clone().ClientOptions;
                 cosmosClientOptions.ApplicationPreferredRegions = Utilities.ParsePreferredLocations(preferredLocations);
                 return ClientCache.GetOrAdd(cacheKey, (c) => CreateService(cosmosClientOptions));
             }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Functions.Worker
 
             if (CosmosExtensionOptions is null)
             {
-                CosmosExtensionOptions = new CosmosExtensionOptions();
+                CosmosExtensionOptions = new CosmosDBExtensionOptions();
             }
 
             string cacheKey = BuildCacheKey(ConnectionName!, preferredLocations);

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
@@ -9,6 +9,12 @@ using Microsoft.Azure.Functions.Worker.Extensions.CosmosDB;
 
 namespace Microsoft.Azure.Functions.Worker
 {
+     /// <summary>
+    /// Internal options for configuring the CosmosDB binding.
+    /// This class is used internally by the Azure Functions runtime to manage the CosmosDB connection and clients.
+    /// It is not intended to be used directly in user code.
+    /// Any public configuration options should be set on the <see cref="CosmosDBOptions"/> class, which is publicly accessible.
+    /// </summary>
     internal class CosmosDBBindingOptions
     {
         public string? ConnectionName  { get; set; }
@@ -21,7 +27,7 @@ namespace Microsoft.Azure.Functions.Worker
 
         public CosmosSerializer? Serializer { get; set; }
 
-        public CosmosClientOptions? CosmosClientOptions { get; set; }
+        public CosmosDBOptions? CosmosDBOptions { get; set; }
 
         internal string BuildCacheKey(string connection, string region) => $"{connection}|{region}";
 
@@ -34,18 +40,23 @@ namespace Microsoft.Azure.Functions.Worker
                 throw new ArgumentNullException(nameof(ConnectionName));
             }
 
+            if (CosmosDBOptions is null)
+            {
+                CosmosDBOptions = new CosmosDBOptions();
+            }
+
             string cacheKey = BuildCacheKey(ConnectionName!, preferredLocations);
 
             // Do not override if preferred locations is configured via CosmosClientOptions
-            if (!string.IsNullOrEmpty(preferredLocations) && CosmosClientOptions.ApplicationPreferredRegions is null)
+            if (!string.IsNullOrEmpty(preferredLocations) && CosmosDBOptions.ClientOptions.ApplicationPreferredRegions is null)
             {
-                CosmosClientOptions.ApplicationPreferredRegions = Utilities.ParsePreferredLocations(preferredLocations);
+                CosmosDBOptions.ClientOptions.ApplicationPreferredRegions = Utilities.ParsePreferredLocations(preferredLocations);
             }
 
             // Do not override if the serializer is configured via CosmosClientOptions
-            if (Serializer is not null && CosmosClientOptions.Serializer is null)
+            if (Serializer is not null && CosmosDBOptions.ClientOptions.Serializer is null)
             {
-                CosmosClientOptions.Serializer = Serializer;
+                CosmosDBOptions.ClientOptions.Serializer = Serializer;
             }
 
             return ClientCache.GetOrAdd(cacheKey, (c) => CreateService());
@@ -54,8 +65,8 @@ namespace Microsoft.Azure.Functions.Worker
         private CosmosClient CreateService()
         {
             return string.IsNullOrEmpty(ConnectionString)
-                    ? new CosmosClient(AccountEndpoint, Credential, CosmosClientOptions) // AAD auth
-                    : new CosmosClient(ConnectionString, CosmosClientOptions); // Connection string based auth
+                    ? new CosmosClient(AccountEndpoint, Credential, CosmosDBOptions?.ClientOptions) // AAD auth
+                    : new CosmosClient(ConnectionString, CosmosDBOptions?.ClientOptions); // Connection string based auth
         }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Functions.Worker
     /// Internal options for configuring the CosmosDB binding.
     /// This class is used internally by the Azure Functions runtime to manage the CosmosDB connection and clients.
     /// It is not intended to be used directly in user code.
-    /// Any public configuration options should be set on the <see cref="CosmosDBOptions"/> class, which is publicly accessible.
+    /// Any public configuration options should be set on the <see cref="CosmosDBExtensionOptions"/> class, which is publicly accessible.
     /// </summary>
     internal class CosmosDBBindingOptions
     {
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Functions.Worker
 
         public CosmosSerializer? Serializer { get; set; }
 
-        public CosmosDBOptions? CosmosDBOptions { get; set; }
+        public CosmosDBExtensionOptions? CosmosExtensionOptions { get; set; }
 
         internal string BuildCacheKey(string connection, string region) => $"{connection}|{region}";
 
@@ -40,23 +40,23 @@ namespace Microsoft.Azure.Functions.Worker
                 throw new ArgumentNullException(nameof(ConnectionName));
             }
 
-            if (CosmosDBOptions is null)
+            if (CosmosExtensionOptions is null)
             {
-                CosmosDBOptions = new CosmosDBOptions();
+                CosmosExtensionOptions = new CosmosExtensionOptions();
             }
 
             string cacheKey = BuildCacheKey(ConnectionName!, preferredLocations);
 
             // Do not override if preferred locations is configured via CosmosClientOptions
-            if (!string.IsNullOrEmpty(preferredLocations) && CosmosDBOptions.ClientOptions.ApplicationPreferredRegions is null)
+            if (!string.IsNullOrEmpty(preferredLocations) && CosmosExtensionOptions.ClientOptions.ApplicationPreferredRegions is null)
             {
-                CosmosDBOptions.ClientOptions.ApplicationPreferredRegions = Utilities.ParsePreferredLocations(preferredLocations);
+                CosmosExtensionOptions.ClientOptions.ApplicationPreferredRegions = Utilities.ParsePreferredLocations(preferredLocations);
             }
 
             // Do not override if the serializer is configured via CosmosClientOptions
-            if (Serializer is not null && CosmosDBOptions.ClientOptions.Serializer is null)
+            if (Serializer is not null && CosmosExtensionOptions.ClientOptions.Serializer is null)
             {
-                CosmosDBOptions.ClientOptions.Serializer = Serializer;
+                CosmosExtensionOptions.ClientOptions.Serializer = Serializer;
             }
 
             return ClientCache.GetOrAdd(cacheKey, (c) => CreateService());
@@ -65,8 +65,8 @@ namespace Microsoft.Azure.Functions.Worker
         private CosmosClient CreateService()
         {
             return string.IsNullOrEmpty(ConnectionString)
-                    ? new CosmosClient(AccountEndpoint, Credential, CosmosDBOptions?.ClientOptions) // AAD auth
-                    : new CosmosClient(ConnectionString, CosmosDBOptions?.ClientOptions); // Connection string based auth
+                    ? new CosmosClient(AccountEndpoint, Credential, CosmosExtensionOptions?.ClientOptions) // AAD auth
+                    : new CosmosClient(ConnectionString, CosmosExtensionOptions?.ClientOptions); // Connection string based auth
         }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Functions.Worker
             if (!string.IsNullOrEmpty(preferredLocations) && CosmosExtensionOptions.ClientOptions.ApplicationPreferredRegions is null)
             {
                 // Clone to avoid modifying the original options
-                var cosmosClientOptions = CosmosExtensionOptions.Clone().ClientOptions;
+                CosmosClientOptions cosmosClientOptions = CosmosExtensionOptions.ClientOptions.MemberwiseClone<CosmosClientOptions>();
                 cosmosClientOptions.ApplicationPreferredRegions = Utilities.ParsePreferredLocations(preferredLocations);
                 return ClientCache.GetOrAdd(cacheKey, (c) => CreateService(cosmosClientOptions));
             }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Azure.Functions.Worker
         private readonly IConfiguration _configuration;
         private readonly AzureComponentFactory _componentFactory;
         private readonly IOptionsMonitor<WorkerOptions> _workerOptions;
-        private readonly IOptionsMonitor<CosmosClientOptions> _cosmosClientOptions;
+        private readonly IOptionsMonitor<CosmosDBOptions> _cosmosDBOptions;
 
-        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosClientOptions> cosmosClientOptions)
+        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosDBOptions> cosmosClientOptions)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _componentFactory = componentFactory ?? throw new ArgumentNullException(nameof(componentFactory));
             _workerOptions = workerOptions ?? throw new ArgumentNullException(nameof(workerOptions));
-            _cosmosClientOptions = cosmosClientOptions ?? throw new ArgumentNullException(nameof(cosmosClientOptions));
+            _cosmosDBOptions = cosmosClientOptions ?? throw new ArgumentNullException(nameof(cosmosClientOptions));
         }
 
         public void Configure(CosmosDBBindingOptions options)
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Functions.Worker
             }
 
             options.Serializer = new WorkerCosmosSerializer(_workerOptions.CurrentValue.Serializer);
-            options.CosmosClientOptions = _cosmosClientOptions.CurrentValue;
+            options.CosmosDBOptions = _cosmosDBOptions.CurrentValue;
         }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Azure.Functions.Worker
         private readonly IConfiguration _configuration;
         private readonly AzureComponentFactory _componentFactory;
         private readonly IOptionsMonitor<WorkerOptions> _workerOptions;
-        private readonly IOptionsMonitor<CosmosDBOptions> _cosmosDBOptions;
+        private readonly IOptionsMonitor<CosmosDBExtensionOptions> _cosmosExtensionOptions;
 
-        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosDBOptions> cosmosOptions)
+        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosDBExtensionOptions> cosmosExtensionOptions)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _componentFactory = componentFactory ?? throw new ArgumentNullException(nameof(componentFactory));
             _workerOptions = workerOptions ?? throw new ArgumentNullException(nameof(workerOptions));
-            _cosmosDBOptions = cosmosOptions ?? throw new ArgumentNullException(nameof(cosmosOptions));
+            _cosmosExtensionOptions = cosmosExtensionOptions ?? throw new ArgumentNullException(nameof(cosmosExtensionOptions));
         }
 
         public void Configure(CosmosDBBindingOptions options)
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Functions.Worker
             }
 
             options.Serializer = new WorkerCosmosSerializer(_workerOptions.CurrentValue.Serializer);
-            options.CosmosDBOptions = _cosmosDBOptions.CurrentValue;
+            options.CosmosExtensionOptions = _cosmosExtensionOptions.CurrentValue;
         }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Azure.Functions.Worker
                 options.Credential = _componentFactory.CreateTokenCredential(connectionSection);
             }
 
-            options.Serializer = new WorkerCosmosSerializer(_workerOptions.CurrentValue.Serializer);
             options.CosmosExtensionOptions = _cosmosExtensionOptions.CurrentValue;
         }
     }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker.Extensions;
 using Microsoft.Azure.Functions.Worker.Extensions.CosmosDB;
 using Microsoft.Extensions.Azure;
@@ -15,12 +16,14 @@ namespace Microsoft.Azure.Functions.Worker
         private readonly IConfiguration _configuration;
         private readonly AzureComponentFactory _componentFactory;
         private readonly IOptionsMonitor<WorkerOptions> _workerOptions;
+        private readonly IOptionsMonitor<CosmosClientOptions> _cosmosClientOptions;
 
-        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions)
+        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosClientOptions> cosmosClientOptions)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _componentFactory = componentFactory ?? throw new ArgumentNullException(nameof(componentFactory));
             _workerOptions = workerOptions ?? throw new ArgumentNullException(nameof(workerOptions));
+            _cosmosClientOptions = cosmosClientOptions ?? throw new ArgumentNullException(nameof(cosmosClientOptions));
         }
 
         public void Configure(CosmosDBBindingOptions options)
@@ -57,6 +60,7 @@ namespace Microsoft.Azure.Functions.Worker
             }
 
             options.Serializer = new WorkerCosmosSerializer(_workerOptions.CurrentValue.Serializer);
+            options.CosmosClientOptions = _cosmosClientOptions.CurrentValue;
         }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Azure.Functions.Worker
         private readonly IOptionsMonitor<WorkerOptions> _workerOptions;
         private readonly IOptionsMonitor<CosmosDBOptions> _cosmosDBOptions;
 
-        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosDBOptions> cosmosClientOptions)
+        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosDBOptions> cosmosOptions)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _componentFactory = componentFactory ?? throw new ArgumentNullException(nameof(componentFactory));
             _workerOptions = workerOptions ?? throw new ArgumentNullException(nameof(workerOptions));
-            _cosmosDBOptions = cosmosClientOptions ?? throw new ArgumentNullException(nameof(cosmosClientOptions));
+            _cosmosDBOptions = cosmosOptions ?? throw new ArgumentNullException(nameof(cosmosOptions));
         }
 
         public void Configure(CosmosDBBindingOptions options)

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBExtensionOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBExtensionOptions.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Azure.Functions.Worker
         /// <summary>
         /// Gets or sets the CosmosClientOptions.
         /// </summary>
-        public CosmosClientOptions ClientOptions { get; set; } = new CosmosClientOptions();
+        public CosmosClientOptions ClientOptions { get; set; } = new() { ConnectionMode = ConnectionMode.Gateway };
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBExtensionOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBExtensionOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.Azure.Cosmos;
 
 namespace Microsoft.Azure.Functions.Worker
 {
-    public class CosmosDBOptions
+    public class CosmosDBExtensionOptions
     {
         /// <summary>
         /// Gets or sets the CosmosClientOptions.

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBExtensionOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBExtensionOptions.cs
@@ -11,10 +11,5 @@ namespace Microsoft.Azure.Functions.Worker
         /// Gets or sets the CosmosClientOptions.
         /// </summary>
         public CosmosClientOptions ClientOptions { get; set; } = new() { ConnectionMode = ConnectionMode.Gateway };
-
-        internal CosmosDBExtensionOptions Clone()
-        {
-            return (CosmosDBExtensionOptions)this.MemberwiseClone();
-        }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBExtensionOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBExtensionOptions.cs
@@ -11,5 +11,10 @@ namespace Microsoft.Azure.Functions.Worker
         /// Gets or sets the CosmosClientOptions.
         /// </summary>
         public CosmosClientOptions ClientOptions { get; set; } = new() { ConnectionMode = ConnectionMode.Gateway };
+
+        internal CosmosDBExtensionOptions Clone()
+        {
+            return (CosmosDBExtensionOptions)this.MemberwiseClone();
+        }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBOptions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Cosmos;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    public class CosmosDBOptions
+    {
+        /// <summary>
+        /// Gets or sets the CosmosClientOptions.
+        /// </summary>
+        public CosmosClientOptions ClientOptions { get; set; } = new CosmosClientOptions();
+    }
+}

--- a/extensions/Worker.Extensions.CosmosDB/src/Extensions/CloningExtensions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Extensions/CloningExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.Azure.Cosmos;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    internal static class CloningExtensions
+    {
+        public static T MemberwiseClone<T>(this T original)
+        {
+            if (original is null)
+            {
+                throw new ArgumentNullException(nameof(original));
+            }
+
+            // Get the type of the object
+            Type type = original.GetType();
+
+            // Get the internal Clone method
+            MethodInfo cloneMethod = type.GetMethod("MemberwiseClone", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            if (cloneMethod is null)
+            {
+                throw new InvalidOperationException("The MemberwiseClone method could not be found.");
+            }
+
+            // Invoke the Clone method
+            return (T)cloneMethod.Invoke(original, null);
+        }
+    }
+}

--- a/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -29,6 +31,18 @@ namespace Microsoft.Azure.Functions.Worker
             builder.Services.AddOptions<CosmosDBBindingOptions>();
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<CosmosDBBindingOptions>, CosmosDBBindingOptionsSetup>());
 
+            return builder;
+        }
+
+        /// <summary>
+        /// Configures the CosmosDBOptions for the Functions Worker Cosmos extension.
+        /// </summary>
+        /// <param name="builder">The IFunctionsWorkerApplicationBuilder to add the configuration to.</param>
+        /// <param name="options">An Action to configure the CosmosDBOptions.</param>
+        /// <returns>The same instance of the <see cref="IFunctionsWorkerApplicationBuilder"/> for chaining.</returns>
+        public static IFunctionsWorkerApplicationBuilder ConfigureCosmosDBExtensionOptions(this IFunctionsWorkerApplicationBuilder builder, Action<CosmosDBOptions> options)
+        {
+            builder.Services.Configure(options);
             return builder;
         }
     }

--- a/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
@@ -30,7 +30,13 @@ namespace Microsoft.Azure.Functions.Worker
             builder.Services.AddAzureClientsCore(); // Adds AzureComponentFactory
             builder.Services.AddOptions<CosmosDBBindingOptions>();
             builder.Services.AddOptions<CosmosDBExtensionOptions>()
-                            .Configure<IOptions<WorkerOptions>>((cosmos, worker) => cosmos.ClientOptions.Serializer = new WorkerCosmosSerializer(worker.Value.Serializer));
+                            .Configure<IOptions<WorkerOptions>>((cosmos, worker) =>
+                            {
+                                if (cosmos.ClientOptions.Serializer is null)
+                                {
+                                    cosmos.ClientOptions.Serializer = new WorkerCosmosSerializer(worker.Value.Serializer);
+                                }
+                            });
 
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<CosmosDBBindingOptions>, CosmosDBBindingOptionsSetup>());
 

--- a/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Azure.Functions.Worker
         }
 
         /// <summary>
-        /// Configures the CosmosDBOptions for the Functions Worker Cosmos extension.
+        /// Configures the CosmosDBExtensionOptions for the Functions Worker Cosmos extension.
         /// </summary>
         /// <param name="builder">The IFunctionsWorkerApplicationBuilder to add the configuration to.</param>
-        /// <param name="options">An Action to configure the CosmosDBOptions.</param>
+        /// <param name="options">An Action to configure the CosmosDBExtensionOptions.</param>
         /// <returns>The same instance of the <see cref="IFunctionsWorkerApplicationBuilder"/> for chaining.</returns>
-        public static IFunctionsWorkerApplicationBuilder ConfigureCosmosDBExtensionOptions(this IFunctionsWorkerApplicationBuilder builder, Action<CosmosDBOptions> options)
+        public static IFunctionsWorkerApplicationBuilder ConfigureCosmosDBExtensionOptions(this IFunctionsWorkerApplicationBuilder builder, Action<CosmosDBExtensionOptions> options)
         {
             builder.Services.Configure(options);
             return builder;

--- a/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Azure.Functions.Worker
 
             builder.Services.AddAzureClientsCore(); // Adds AzureComponentFactory
             builder.Services.AddOptions<CosmosDBBindingOptions>();
+            builder.Services.AddOptions<CosmosDBExtensionOptions>()
+                            .Configure<IOptions<WorkerOptions>>((cosmos, worker) => cosmos.ClientOptions.Serializer = new WorkerCosmosSerializer(worker.Value.Serializer));
+
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<CosmosDBBindingOptions>, CosmosDBBindingOptionsSetup>());
 
             return builder;

--- a/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
+++ b/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Cosmos DB extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>4.9.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
+++ b/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Cosmos DB extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.8.1</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #2450

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR - TBD: need to check if document the default being Gateway
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) - TODO

<!-- Optional: delete if not applicable  -->
### Additional information

Implement CosmosDBExtensionOptions for the cosmos extension that will expose `CosmosClientOptions` and allow users to configure the CosmosClient.
