### PR TITLE
Make HttpContext injectable into HTTP trigger Azure Functions

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -6,4 +6,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore <version>
 
-- <entry>
+- The `HttpContext` instance is directly injectable into an HTTP trigger. (#2259)

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/HttpContextConverter.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/HttpContextConverter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker.Converters;
@@ -10,7 +9,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 {
     /// <summary>
-    /// Converter to bind HttpRequest type parameters.
+    /// Converter to bind <see cref="HttpContext"/>, <see cref="HttpRequest"/> and <see cref="HttpRequestData"/> type parameters.
     /// </summary>
     internal class HttpContextConverter : IInputConverter
     {
@@ -18,7 +17,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
         {
             object? target = null;
 
-            if (context.TargetType == typeof(HttpRequest)
+            if (context.TargetType == typeof(HttpContext))
+            {
+                target = context.FunctionContext.GetHttpContext();
+            }
+            else if (context.TargetType == typeof(HttpRequest)
                 && context.FunctionContext.TryGetRequest(out var request))
             {
                 target = request;

--- a/samples/AspNetIntegration/SimpleHttpTrigger/SimpleHttpTrigger.cs
+++ b/samples/AspNetIntegration/SimpleHttpTrigger/SimpleHttpTrigger.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Net.Mime;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Net.Http.Headers;
 
 namespace AspNetIntegration
 {
@@ -17,6 +21,27 @@ namespace AspNetIntegration
             return new OkObjectResult("Welcome to Azure Functions!");
         }
         //</docsnippet_aspnet_http_trigger>
+    }
+
+    public class SimpleHttpTriggerHttpContext
+    {
+        //<docsnippet_aspnet_http_trigger_http_context>
+        [Function("SimpleHttpTriggerHttpContext")]
+        public async Task RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpContext httpContext)
+        {
+            static int WriteBody(PipeWriter writer)
+            {
+                ReadOnlySpan<byte> body = "Welcome to Azure Functions!"u8;
+                writer.Write(body);
+                return body.Length;
+            }
+
+            var responseHeaders = httpContext.Response.GetTypedHeaders();
+            responseHeaders.ContentLength = WriteBody(httpContext.Response.BodyWriter);
+            responseHeaders.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Text.Plain);
+            await httpContext.Response.BodyWriter.FlushAsync();
+        }
+        //</docsnippet_aspnet_http_trigger_http_context>
     }
 
     public class SimpleHttpTriggerHttpData

--- a/test/DotNetWorkerTests/Converters/HttpContextConverterTests.cs
+++ b/test/DotNetWorkerTests/Converters/HttpContextConverterTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore;
+using Microsoft.Azure.Functions.Worker.Http;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests.Converters
+{
+    public class HttpContextConverterTests
+    {
+        private readonly HttpContextConverter _converter = new();
+
+        [Fact]
+        public async Task ConversionSuccessfulForHttpContextAsync()
+        {
+            var httpContext = new DefaultHttpContext();
+            var context = new TestConverterContext(typeof(HttpContext), null)
+            {
+                FunctionContext = { Items = new Dictionary<object, object>{ [Constants.HttpContextKey] = httpContext } }
+            };
+
+            var conversionResult = await _converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, conversionResult.Status);
+            var convertedHttpContext = TestUtility.AssertIsTypeAndConvert<HttpContext>(conversionResult.Value);
+            Assert.Same(httpContext, convertedHttpContext);
+        }
+
+        [Fact]
+        public async Task ConversionSuccessfulForHttpRequestAsync()
+        {
+            var httpContext = new DefaultHttpContext();
+            var context = new TestConverterContext(typeof(HttpRequest), null)
+            {
+                FunctionContext = { Items = new Dictionary<object, object>{ [Constants.HttpContextKey] = httpContext } }
+            };
+
+            var conversionResult = await _converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, conversionResult.Status);
+            var convertedRequest = TestUtility.AssertIsTypeAndConvert<HttpRequest>(conversionResult.Value);
+            Assert.Same(httpContext.Request, convertedRequest);
+        }
+
+        [Fact]
+        public async Task ConversionSuccessfulForHttpRequestDataAsync()
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Scheme = "http",
+                    Host = new HostString("localhost", 8080),
+                    QueryString = QueryString.Create("key", "value"),
+                }
+            };
+            var context = new TestConverterContext(typeof(HttpRequestData), null)
+            {
+                FunctionContext = { Items = new Dictionary<object, object>{ [Constants.HttpContextKey] = httpContext } }
+            };
+
+            var conversionResult = await _converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, conversionResult.Status);
+            var convertedRequestData = TestUtility.AssertIsTypeAndConvert<HttpRequestData>(conversionResult.Value);
+            Assert.Equal(new Uri("http://localhost:8080?key=value"), convertedRequestData.Url);
+        }
+    }
+}


### PR DESCRIPTION
Just like ASP.NET Core `HttpRequest` is injectable into an HTTP trigger Azure Function, make the `HttpContext` also injectable.

### Issue describing the changes in this PR

resolves #2259

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation PR opened at https://github.com/MicrosoftDocs/azure-docs/pull/122815
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
