### PR TITLE
[1ES] Add windows pool and remove extra sign step

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -46,7 +46,6 @@ pr:
     - test/TestUtility
     - tools/
 
-
 resources:
   repositories:
   - repository: 1es

--- a/eng/ci/templates/official/jobs/build-artifacts.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts.yml
@@ -11,6 +11,11 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/NugetPackages
       artifact: NugetPackages
 
+  pool:
+    name: 1es-pool-azfunc
+    image: 1es-windows-2022
+    os: windows
+
   variables:
     ${{ if and( not(contains(variables['Build.SourceBranch'], '/release/')),  not(startsWith(variables['Build.SourceBranch'], 'refs/tags')) ) }}:
       buildNumberTemp: $(Build.BuildNumber)
@@ -62,42 +67,7 @@ jobs:
   - task: DeleteFiles@1
     displayName: Delete CodeSignSummary files
     inputs:
-      contents: '**/CodeSignSummary-*.md'
-
-  - task: EsrpCodeSigning@2
-    displayName: Sign SDK Analyzers assemblies
-    inputs:
-      ConnectedServiceName: ESRP Service-internal
-      FolderPath: sdk/Sdk.Analyzers/bin/Release
-      Pattern: Microsoft.Azure.Functions.Worker.Sdk*.dll
-      signConfigType: inlineSignParams
-      inlineOperation: |
-        [
-          {
-            "KeyCode": "CP-230012",
-            "OperationCode": "SigntoolSign",
-            "Parameters": {
-              "OpusName": "Microsoft",
-              "OpusInfo": "http://www.microsoft.com",
-              "FileDigest": "/fd \"SHA256\"",
-              "PageHash": "/NPH",
-              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-            },
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-          },
-          {
-            "KeyCode": "CP-230012",
-            "OperationCode": "SigntoolVerify",
-            "Parameters": {},
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-          }
-        ]
-
-  - task: DeleteFiles@1
-    displayName: Delete CodeSignSummary files
-    inputs:
+      sourceFolder: sdk
       contents: '**/CodeSignSummary-*.md'
 
   - task: EsrpCodeSigning@2
@@ -134,6 +104,7 @@ jobs:
   - task: DeleteFiles@1
     displayName: Delete CodeSignSummary files
     inputs:
+      sourceFolder: src
       contents: '**/CodeSignSummary-*.md'
 
   - task: DotNetCoreCLI@2
@@ -182,4 +153,5 @@ jobs:
   - task: DeleteFiles@1
     displayName: Delete CodeSignSummary files
     inputs:
+      sourceFolder: $(Build.ArtifactStagingDirectory)/NugetPackages
       contents: '**/CodeSignSummary-*.md'

--- a/eng/ci/templates/official/jobs/build-artifacts.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
     displayName: Sign SDK assemblies
     inputs:
       ConnectedServiceName: ESRP Service-internal
-      FolderPath: sdk/Sdk/bin/Release
+      FolderPath: sdk
       Pattern: Microsoft.Azure.Functions.Worker.Sdk*.dll
       signConfigType: inlineSignParams
       inlineOperation: |


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

`dotnet pack` step leads to issues in linux, everything works in windows as expected to reverting back to windows.

Also removing unnecessary Sdk.Assembly sign step, the generic sdk sign step already covers this.
