### PR TITLE
Implement CosmosDBOptions to allow configuration of the CosmosDB service client via CosmosClientOptions 

### DIFF
--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -4,8 +4,27 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.8.1
+### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 5.0.0
 
-- Updating `Microsoft.Azure.WebJobs.Extensions.CosmosDB` reference to 4.6.1
-- Updating `Microsoft.Extensions.Azure` reference to 1.7.3
-- Updating `Microsoft.Azure.Cosmos` reference to 3.39.1
+- Expose `CosmosClientOptions` to allow configuration of the CosmosDB client (#2483)
+
+#### Breaking Change
+
+- **Default `ConnectionMode` Change:** The default `ConnectionMode` for `CosmosClientOptions` has been changed from `Gateway` to `Direct`.
+  This change is due to `Direct` being the default value for `ConnectionMode` in the Cosmos SDK; now that we are exposing those options,
+  it is not possible for us to tell whether the user has explicitly set the connection mode to `Direct` or not, so we must default to the
+  SDK's default value
+
+##### How to Maintain Previous Behavior
+
+To continue using `Gateway` mode, configure the `CosmosClientOptions` in your `Program` class as shown below:
+
+```csharp
+.ConfigureFunctionsWorkerDefaults((builder) =>
+{
+    builder.Services.Configure<CosmosClientOptions>((options) =>
+    {
+        options.ConnectionMode = ConnectionMode.Gateway;
+    });
+})
+```

--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 5.0.0
 
-- Expose `CosmosClientOptions` to allow configuration of the CosmosDB client (#2483)
+- Implement `CosmosDBOptions` to allow configuration of the CosmosDB service client via `CosmosClientOptions` (#2483)
 
 #### Breaking Change
 
@@ -22,9 +22,9 @@ To continue using `Gateway` mode, configure the `CosmosClientOptions` in your `P
 ```csharp
 .ConfigureFunctionsWorkerDefaults((builder) =>
 {
-    builder.Services.Configure<CosmosClientOptions>((options) =>
+    builder.ConfigureCosmosDBExtensionOptions((options) =>
     {
-        options.ConnectionMode = ConnectionMode.Gateway;
+        options.ClientOptions.ConnectionMode = ConnectionMode.Gateway;
     });
 })
 ```

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptions.cs
@@ -9,6 +9,12 @@ using Microsoft.Azure.Functions.Worker.Extensions.CosmosDB;
 
 namespace Microsoft.Azure.Functions.Worker
 {
+     /// <summary>
+    /// Internal options for configuring the CosmosDB binding.
+    /// This class is used internally by the Azure Functions runtime to manage the CosmosDB connection and clients.
+    /// It is not intended to be used directly in user code.
+    /// Any public configuration options should be set on the <see cref="CosmosDBOptions"/> class, which is publicly accessible.
+    /// </summary>
     internal class CosmosDBBindingOptions
     {
         public string? ConnectionName  { get; set; }
@@ -21,7 +27,7 @@ namespace Microsoft.Azure.Functions.Worker
 
         public CosmosSerializer? Serializer { get; set; }
 
-        public CosmosClientOptions? CosmosClientOptions { get; set; }
+        public CosmosDBOptions? CosmosDBOptions { get; set; }
 
         internal string BuildCacheKey(string connection, string region) => $"{connection}|{region}";
 
@@ -34,18 +40,23 @@ namespace Microsoft.Azure.Functions.Worker
                 throw new ArgumentNullException(nameof(ConnectionName));
             }
 
+            if (CosmosDBOptions is null)
+            {
+                CosmosDBOptions = new CosmosDBOptions();
+            }
+
             string cacheKey = BuildCacheKey(ConnectionName!, preferredLocations);
 
             // Do not override if preferred locations is configured via CosmosClientOptions
-            if (!string.IsNullOrEmpty(preferredLocations) && CosmosClientOptions.ApplicationPreferredRegions is null)
+            if (!string.IsNullOrEmpty(preferredLocations) && CosmosDBOptions.ClientOptions.ApplicationPreferredRegions is null)
             {
-                CosmosClientOptions.ApplicationPreferredRegions = Utilities.ParsePreferredLocations(preferredLocations);
+                CosmosDBOptions.ClientOptions.ApplicationPreferredRegions = Utilities.ParsePreferredLocations(preferredLocations);
             }
 
             // Do not override if the serializer is configured via CosmosClientOptions
-            if (Serializer is not null && CosmosClientOptions.Serializer is null)
+            if (Serializer is not null && CosmosDBOptions.ClientOptions.Serializer is null)
             {
-                CosmosClientOptions.Serializer = Serializer;
+                CosmosDBOptions.ClientOptions.Serializer = Serializer;
             }
 
             return ClientCache.GetOrAdd(cacheKey, (c) => CreateService());
@@ -54,8 +65,8 @@ namespace Microsoft.Azure.Functions.Worker
         private CosmosClient CreateService()
         {
             return string.IsNullOrEmpty(ConnectionString)
-                    ? new CosmosClient(AccountEndpoint, Credential, CosmosClientOptions) // AAD auth
-                    : new CosmosClient(ConnectionString, CosmosClientOptions); // Connection string based auth
+                    ? new CosmosClient(AccountEndpoint, Credential, CosmosDBOptions?.ClientOptions) // AAD auth
+                    : new CosmosClient(ConnectionString, CosmosDBOptions?.ClientOptions); // Connection string based auth
         }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Azure.Functions.Worker
         private readonly IConfiguration _configuration;
         private readonly AzureComponentFactory _componentFactory;
         private readonly IOptionsMonitor<WorkerOptions> _workerOptions;
-        private readonly IOptionsMonitor<CosmosClientOptions> _cosmosClientOptions;
+        private readonly IOptionsMonitor<CosmosDBOptions> _cosmosDBOptions;
 
-        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosClientOptions> cosmosClientOptions)
+        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosDBOptions> cosmosClientOptions)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _componentFactory = componentFactory ?? throw new ArgumentNullException(nameof(componentFactory));
             _workerOptions = workerOptions ?? throw new ArgumentNullException(nameof(workerOptions));
-            _cosmosClientOptions = cosmosClientOptions ?? throw new ArgumentNullException(nameof(cosmosClientOptions));
+            _cosmosDBOptions = cosmosClientOptions ?? throw new ArgumentNullException(nameof(cosmosClientOptions));
         }
 
         public void Configure(CosmosDBBindingOptions options)
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Functions.Worker
             }
 
             options.Serializer = new WorkerCosmosSerializer(_workerOptions.CurrentValue.Serializer);
-            options.CosmosClientOptions = _cosmosClientOptions.CurrentValue;
+            options.CosmosDBOptions = _cosmosDBOptions.CurrentValue;
         }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker.Extensions;
 using Microsoft.Azure.Functions.Worker.Extensions.CosmosDB;
 using Microsoft.Extensions.Azure;
@@ -15,12 +16,14 @@ namespace Microsoft.Azure.Functions.Worker
         private readonly IConfiguration _configuration;
         private readonly AzureComponentFactory _componentFactory;
         private readonly IOptionsMonitor<WorkerOptions> _workerOptions;
+        private readonly IOptionsMonitor<CosmosClientOptions> _cosmosClientOptions;
 
-        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions)
+        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosClientOptions> cosmosClientOptions)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _componentFactory = componentFactory ?? throw new ArgumentNullException(nameof(componentFactory));
             _workerOptions = workerOptions ?? throw new ArgumentNullException(nameof(workerOptions));
+            _cosmosClientOptions = cosmosClientOptions ?? throw new ArgumentNullException(nameof(cosmosClientOptions));
         }
 
         public void Configure(CosmosDBBindingOptions options)
@@ -57,6 +60,7 @@ namespace Microsoft.Azure.Functions.Worker
             }
 
             options.Serializer = new WorkerCosmosSerializer(_workerOptions.CurrentValue.Serializer);
+            options.CosmosClientOptions = _cosmosClientOptions.CurrentValue;
         }
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBBindingOptionsSetup.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Azure.Functions.Worker
         private readonly IOptionsMonitor<WorkerOptions> _workerOptions;
         private readonly IOptionsMonitor<CosmosDBOptions> _cosmosDBOptions;
 
-        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosDBOptions> cosmosClientOptions)
+        public CosmosDBBindingOptionsSetup(IConfiguration configuration, AzureComponentFactory componentFactory, IOptionsMonitor<WorkerOptions> workerOptions, IOptionsMonitor<CosmosDBOptions> cosmosOptions)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _componentFactory = componentFactory ?? throw new ArgumentNullException(nameof(componentFactory));
             _workerOptions = workerOptions ?? throw new ArgumentNullException(nameof(workerOptions));
-            _cosmosDBOptions = cosmosClientOptions ?? throw new ArgumentNullException(nameof(cosmosClientOptions));
+            _cosmosDBOptions = cosmosOptions ?? throw new ArgumentNullException(nameof(cosmosOptions));
         }
 
         public void Configure(CosmosDBBindingOptions options)

--- a/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBOptions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Config/CosmosDBOptions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Cosmos;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    public class CosmosDBOptions
+    {
+        /// <summary>
+        /// Gets or sets the CosmosClientOptions.
+        /// </summary>
+        public CosmosClientOptions ClientOptions { get; set; } = new CosmosClientOptions();
+    }
+}

--- a/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/Extensions/FunctionsWorkerApplicationBuilderExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -29,6 +31,18 @@ namespace Microsoft.Azure.Functions.Worker
             builder.Services.AddOptions<CosmosDBBindingOptions>();
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<CosmosDBBindingOptions>, CosmosDBBindingOptionsSetup>());
 
+            return builder;
+        }
+
+        /// <summary>
+        /// Configures the CosmosDBOptions for the Functions Worker Cosmos extension.
+        /// </summary>
+        /// <param name="builder">The IFunctionsWorkerApplicationBuilder to add the configuration to.</param>
+        /// <param name="options">An Action to configure the CosmosDBOptions.</param>
+        /// <returns>The same instance of the <see cref="IFunctionsWorkerApplicationBuilder"/> for chaining.</returns>
+        public static IFunctionsWorkerApplicationBuilder ConfigureCosmosDBExtensionOptions(this IFunctionsWorkerApplicationBuilder builder, Action<CosmosDBOptions> options)
+        {
+            builder.Services.Configure(options);
             return builder;
         }
     }

--- a/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
+++ b/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Cosmos DB extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.8.1</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #2450

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR - TBD: need to check if document the default being Gateway
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) - TODO

<!-- Optional: delete if not applicable  -->
### Additional information

Implement CosmosDBOptions for the cosmos extension that will expose `CosmosClientOptions` and allow users to configure the CosmosClient.

#### Breaking Change

Due to the default value for ConnectionMode in CosmosClientOptions being Direct, this change will introduce a breaking change for users who rely on the implicit default connection mode being Gateway. Currently, this extension has defaulted to using Gateway a the connection mode. Now that we are exposing CosmosClientOptions, we cannot differentiate between a user explicitly setting the connection mode to Direct and the SDK's default value of Direct. Therefore, we have to default to the SDK's default value.

If there are alternative approaches to this, please let me know!
