### PR TITLE
Remove paths filters for 1es build

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -19,11 +19,6 @@ trigger:
     include:
     - main
     - release/*
-  paths:
-    include:
-    - eng/
-    - sdk/
-    - src/
 
 # CI only, does not trigger on PRs.
 pr: none

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -22,11 +22,6 @@ trigger:
     - main
     - release/*
     - feature/*
-  paths:
-    include:
-    - eng/
-    - sdk/
-    - src/
 
 pr:
   branches:
@@ -34,18 +29,6 @@ pr:
     - main
     - release/*
     - feature/*
-  paths:
-    include:
-    - eng/
-    - extensions/
-    - samples/FunctionApp
-    - sdk/
-    - src/
-    - test/DotNetWorkerTests
-    - test/Worker.Extensions.Tests
-    - test/E2ETests
-    - test/TestUtility
-    - tools/
 
 resources:
   repositories:


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

As `dotnet-worker.public` is a required build for PR, removing path checks so it is always ran regardless of the change. Making a similar change to `dotnet-worker.official` for consistency.
