### PR TITLE
Update FNH worker config to only start worker in placeholder mode.

### DIFF
--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>

--- a/host/tools/build/worker.config.json
+++ b/host/tools/build/worker.config.json
@@ -2,13 +2,69 @@
   "description": {
     "language": "dotnet-isolated",
     "extensions": [ ".dll" ],
-    "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost.exe",
-    "defaultWorkerPath": "bin/FunctionsNetHost.exe",
     "workerIndexing": "true"
   },
   "profiles": [
     {
-      "profileName": "DotnetIsolatedLinux",
+      "profileName": "DotnetIsolatedLinuxPlaceholder",
+      "conditions": [
+        {
+          "conditionType": "hostProperty",
+          "conditionName": "platform",
+          "conditionExpression": "LINUX"
+        },
+        {
+          "conditionType": "environment",
+          "conditionName": "WEBSITE_CONTAINER_READY",
+          "conditionExpression": "0"
+        },
+        {
+          "conditionType": "environment",
+          "conditionName": "WEBSITE_PLACEHOLDER_MODE",
+          "conditionExpression": "1"
+        }
+      ],
+      "description": {
+        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost",
+        "defaultWorkerPath": "bin/FunctionsNetHost"
+      }
+    },
+    {
+      "profileName": "DotnetIsolatedWindowsPlaceholder",
+      "conditions": [
+        {
+          "conditionType": "hostProperty",
+          "conditionName": "platform",
+          "conditionExpression": "WINDOWS"
+        },
+        {
+          "conditionType": "environment",
+          "conditionName": "WEBSITE_PLACEHOLDER_MODE",
+          "conditionExpression": "1"
+        }
+      ],
+      "description": {
+        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost.exe",
+        "defaultWorkerPath": "bin/FunctionsNetHost.exe"
+      }
+    },
+    {
+      "profileName": "WindowsFallbackDisabledWorker",
+      "conditions": [
+        {
+          "conditionType": "hostProperty",
+          "conditionName": "platform",
+          "conditionExpression": "WINDOWS"
+        }
+      ],
+      "description": {
+        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost.exe",
+        "defaultWorkerPath": "bin/FunctionsNetHost.exe",
+        "isDisabled": true
+      }
+    },
+    {
+      "profileName": "LinuxFallbackDisabledWorker",
       "conditions": [
         {
           "conditionType": "hostProperty",
@@ -18,7 +74,8 @@
       ],
       "description": {
         "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/bin/FunctionsNetHost",
-        "defaultWorkerPath": "bin/FunctionsNetHost"
+        "defaultWorkerPath": "bin/FunctionsNetHost",
+        "isDisabled": true
       }
     }
   ]


### PR DESCRIPTION
Fixes #2501

Changes in this PR leverage the modifications introduced in https://github.com/Azure/azure-functions-host/pull/10231 to disable a worker profile. In this PR, I updated the dotnet isolated worker.config to ensure it starts only in placeholder mode by checking specific environment variable values. If these values are absent, a fallback profile is selected, which disables the worker. This ensures that the dotnet isolated worker does not start after specialization is complete.



### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

