### PR TITLE
Ensuring exception message is used if ModelError.Message is not set

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -6,4 +6,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore <version>
 
-- <entry>
+- Fixed a bug that would lead to an empty exception message in some model binding failures.

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/FromBodyConversionFeature.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/FromBodyConversionFeature.cs
@@ -84,7 +84,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 
                     foreach (var error in dictionary.Errors)
                     {
-                        messageBuilder.AppendLine(error.ErrorMessage);
+                        if (error is null)
+                        {
+                           continue;
+                        }
+
+                        var message = string.IsNullOrEmpty(error.ErrorMessage)
+                            ? error.Exception?.Message
+                            : error.ErrorMessage;
+
+                        messageBuilder.AppendLine(message);
                     }
                 }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

While debugging a different issue, I ran into a bug that would result in an empty error message in cases where the `ModelError.Message` property was not set, but an exception was present.

Updating this code to ensure we use the exception message as a fallback (consistent with ASP.NET behavior) when to ensure the error details are visible.

NOTE: Wanted to add some tests here but our E2E tests are not properly enabled for the extension. Following up with @satvu to track and prioritize that work.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

