### PR TITLE
Add warning for v3 out of support. Fix incorrect build message.

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -61,13 +61,16 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <!-- Validating some expectations for the function app early on. -->
   <Target Name="_FunctionsPreBuild" BeforeTargets="BeforeBuild">
     <PropertyGroup>
-      <_ValidAzureFunctionsVersion Condition="'%(_SupportedFunctionsVersion.Identity)' == '$(AzureFunctionsVersion.ToLowerInvariant())'">true</_ValidAzureFunctionsVersion>
+      <_AzureFunctionsVersionStandardized>$(AzureFunctionsVersion.ToLowerInvariant())</_AzureFunctionsVersionStandardized>
+      <_ValidAzureFunctionsVersion Condition="'%(_SupportedFunctionsVersion.Identity)' == '$(_AzureFunctionsVersionStandardized)'">true</_ValidAzureFunctionsVersion>
+      <WarnOnDeprecatedFunctionsVersion Condition="'$(WarnOnDeprecatedFunctionsVersion)' == ''">true</WarnOnDeprecatedFunctionsVersion>
     </PropertyGroup>
 
-    <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="normal" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(_DefaultAzureFunctionsVersion)'"/>
-    <Error Condition="'$(_ValidAzureFunctionsVersion)' != 'true'" Text="AzureFunctionsVersion is set to an unsupported value '$(AzureFunctionsVersion)'. Allowed values are: @(_SupportedFunctionsVersions, ', ')"/>
-    <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set."/>
-    <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps."/>
+    <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="normal" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(_DefaultAzureFunctionsVersion)'" />
+    <Error Condition="'$(_ValidAzureFunctionsVersion)' != 'true'" Text="AzureFunctionsVersion is set to an unsupported value '$(AzureFunctionsVersion)'. Allowed values are: @(_SupportedFunctionsVersions, ', ')" />
+    <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set." />
+    <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps." />
+    <Warning Condition="'$(WarnOnDeprecatedFunctionsVersion)' == 'true' AND '$(_AzureFunctionsVersionStandardized)' == 'v3'" Text="AzureFunctionsVersion v3 is out of support. Please consider upgrading to v4. https://aka.ms/azure-functions-retired-versions. Suppress this warning by adding '&lt;WarnOnDeprecatedFunctionsVersion&gt;false&lt;/WarnOnDeprecatedFunctionsVersion&gt;' to the project.'" />
   </Target>
 
   <!-- These two targets set up the main sequence of targets we want to run and when we want to run them. -->

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -55,7 +55,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   <!-- Validating some expectations for the function app early on. -->
   <Target Name="_FunctionsPreBuild" BeforeTargets="BeforeBuild">
-    <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="high" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to v3"/>
+    <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="high" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(AzureFunctionsVersion)'"/>
     <Error Condition="$(AzureFunctionsVersion.StartsWith('v1',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v4"/>
     <Error Condition="$(AzureFunctionsVersion.StartsWith('v2',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v3"/>
     <Error Condition="!$(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) And !$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version"/>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -11,8 +11,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_ToolingSuffix></_ToolingSuffix>
+    <_DefaultAzureFunctionsVersion>v4</_DefaultAzureFunctionsVersion>
     <_AzureFunctionsNotSet Condition="'$(AzureFunctionsVersion)' == ''">true</_AzureFunctionsNotSet>
-    <AzureFunctionsVersion Condition="'$(AzureFunctionsVersion)' == ''">v4</AzureFunctionsVersion>
+    <AzureFunctionsVersion Condition="'$(AzureFunctionsVersion)' == ''">$(_DefaultAzureFunctionsVersion)</AzureFunctionsVersion>
     <_ToolingSuffix Condition="($(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) Or $(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v5.0'">net5-isolated</_ToolingSuffix>
     <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">net6-isolated</_ToolingSuffix>
     <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v7.0'">net7-isolated</_ToolingSuffix>
@@ -45,6 +46,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <FunctionsGeneratedCodeNamespace Condition="'$(FunctionsGeneratedCodeNamespace)' == ''">$(RootNamespace.Replace("-", "_"))</FunctionsGeneratedCodeNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <_SupportedFunctionsVersion Include="v3;v4" />
+  </ItemGroup>
+
   <UsingTask TaskName="GenerateFunctionMetadata" AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
   <UsingTask TaskName="CreateZipFileTask" AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
   <UsingTask TaskName="ZipDeployTask" AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
@@ -55,10 +60,12 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   <!-- Validating some expectations for the function app early on. -->
   <Target Name="_FunctionsPreBuild" BeforeTargets="BeforeBuild">
-    <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="high" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(AzureFunctionsVersion)'"/>
-    <Error Condition="$(AzureFunctionsVersion.StartsWith('v1',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v4"/>
-    <Error Condition="$(AzureFunctionsVersion.StartsWith('v2',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version, Please set it to v3"/>
-    <Error Condition="!$(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) And !$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))" Text="AzureFunctionsVersion is set to an incompatible version"/>
+    <PropertyGroup>
+      <_ValidAzureFunctionsVersion Condition="'%(_SupportedFunctionsVersion.Identity)' == '$(AzureFunctionsVersion.ToLowerInvariant())'">true</_ValidAzureFunctionsVersion>
+    </PropertyGroup>
+
+    <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="normal" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(_DefaultAzureFunctionsVersion)'"/>
+    <Error Condition="'$(_ValidAzureFunctionsVersion)' != 'true'" Text="AzureFunctionsVersion is set to an unsupported value '$(AzureFunctionsVersion)'. Allowed values are: @(_SupportedFunctionsVersions, ', ')"/>
     <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set."/>
     <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps."/>
   </Target>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -9,10 +9,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <_ToolingSuffix></_ToolingSuffix>
     <_DefaultAzureFunctionsVersion>v4</_DefaultAzureFunctionsVersion>
-    <_AzureFunctionsNotSet Condition="'$(AzureFunctionsVersion)' == ''">true</_AzureFunctionsNotSet>
+    <_AzureFunctionsVersionNotSet Condition="'$(AzureFunctionsVersion)' == ''">true</_AzureFunctionsVersionNotSet>
     <AzureFunctionsVersion Condition="'$(AzureFunctionsVersion)' == ''">$(_DefaultAzureFunctionsVersion)</AzureFunctionsVersion>
     <_ToolingSuffix Condition="($(AzureFunctionsVersion.StartsWith('v3',StringComparison.OrdinalIgnoreCase)) Or $(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase))) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v5.0'">net5-isolated</_ToolingSuffix>
     <_ToolingSuffix Condition="$(AzureFunctionsVersion.StartsWith('v4',StringComparison.OrdinalIgnoreCase)) And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">net6-isolated</_ToolingSuffix>
@@ -47,7 +48,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </PropertyGroup>
 
   <ItemGroup>
-    <_SupportedFunctionsVersion Include="v3;v4" />
+    <_FunctionsVersion Include="v3" InSupport="false" />
+    <_FunctionsVersion Include="$(_DefaultAzureFunctionsVersion)" InSupport="true" />
   </ItemGroup>
 
   <UsingTask TaskName="GenerateFunctionMetadata" AssemblyFile="$(_FunctionsTaskAssemblyFullPath)"/>
@@ -62,15 +64,18 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Target Name="_FunctionsPreBuild" BeforeTargets="BeforeBuild">
     <PropertyGroup>
       <_AzureFunctionsVersionStandardized>$(AzureFunctionsVersion.ToLowerInvariant())</_AzureFunctionsVersionStandardized>
-      <_ValidAzureFunctionsVersion Condition="'%(_SupportedFunctionsVersion.Identity)' == '$(_AzureFunctionsVersionStandardized)'">true</_ValidAzureFunctionsVersion>
-      <WarnOnDeprecatedFunctionsVersion Condition="'$(WarnOnDeprecatedFunctionsVersion)' == ''">true</WarnOnDeprecatedFunctionsVersion>
+      <CheckEolAzureFunctionsVersion Condition="'$(CheckEolAzureFunctionsVersion)' == ''">true</CheckEolAzureFunctionsVersion>
     </PropertyGroup>
 
-    <Message Condition="'$(_AzureFunctionsNotSet)' == 'true'" Importance="normal" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(_DefaultAzureFunctionsVersion)'" />
-    <Error Condition="'$(_ValidAzureFunctionsVersion)' != 'true'" Text="AzureFunctionsVersion is set to an unsupported value '$(AzureFunctionsVersion)'. Allowed values are: @(_SupportedFunctionsVersions, ', ')" />
+    <ItemGroup>
+      <_SelectedFunctionVersion Include="@(_FunctionsVersion)" Condition="'%(_FunctionsVersion.Identity)' == '$(_AzureFunctionsVersionStandardized)'" />
+    </ItemGroup>
+
+    <Message Condition="'$(_AzureFunctionsVersionNotSet)' == 'true'" Importance="normal" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(_DefaultAzureFunctionsVersion)'." />
+    <Error Condition="'@(_SelectedFunctionVersion)' == ''" Text="The AzureFunctionsVersion value '$(AzureFunctionsVersion)' was not recognized. Allowed values are: @(_FunctionsVersion, ', ')." />
     <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set." />
     <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps." />
-    <Warning Condition="'$(WarnOnDeprecatedFunctionsVersion)' == 'true' AND '$(_AzureFunctionsVersionStandardized)' == 'v3'" Text="AzureFunctionsVersion v3 is out of support. Please consider upgrading to v4. https://aka.ms/azure-functions-retired-versions. Suppress this warning by adding '&lt;WarnOnDeprecatedFunctionsVersion&gt;false&lt;/WarnOnDeprecatedFunctionsVersion&gt;' to the project.'" />
+    <Warning Condition="'$(CheckEolAzureFunctionsVersion)' == 'true' AND '%(_SelectedFunctionVersion.InSupport)' == 'false'" Text="Azure Functions '%(Identity)' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/azure-functions-retired-versions for more information on the support policy." />
   </Target>
 
   <!-- These two targets set up the main sequence of targets we want to run and when we want to run them. -->

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,11 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk 1.17.4
+### Microsoft.Azure.Functions.Worker.Sdk <version>
 
-- Upgrade Microsoft.Azure.Functions.Worker.Sdk.Generators to 1.3.2
-
-### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.3.2
-
-- Enhanced function metadata generation to include `$return` binding for HTTP trigger functions. (#1619)
-- Updating generators to fix the namespace conflict with customer code (#2582)
+- Fix incorrect function version in build message (#2606)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Fixes the function version printed when defaulting during build. This also adds a warning for functions v3 being out of support.
