### PR TITLE
ActivityTraceFlags propagation

### DIFF
--- a/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
+++ b/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
             => _setTraceId(activity, traceId);
 
         public static void SetState(this Activity activity, string state)
-            => _setState(activity, arg2: state);
+            => _setState(activity, state);
     }
 
     internal static class FieldInfoExtensionMethods

--- a/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
+++ b/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
         private static readonly Action<Activity, string> _setId;
         private static readonly Action<Activity, string> _setTraceId;
         private static readonly Action<Activity, string> _setRootId;
-        private static readonly Action<Activity, string> _setState;
 
         static ActivityExtensions()
         {
@@ -27,7 +26,6 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
             _setId = activityType.GetField("_id", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
             _setRootId = activityType.GetField("_rootId", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
             _setTraceId = activityType.GetField("_traceId", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
-            _setState = activityType.GetField("_traceState", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
         }
 
         /// <summary>
@@ -75,9 +73,6 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
 
         public static void SetTraceId(this Activity activity, string traceId)
             => _setTraceId(activity, traceId);
-
-        public static void SetState(this Activity activity, string state)
-            => _setState(activity, state);
     }
 
     internal static class FieldInfoExtensionMethods

--- a/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
+++ b/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
@@ -15,15 +15,19 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
         private static readonly Action<Activity, string> _setId;
         private static readonly Action<Activity, string> _setTraceId;
         private static readonly Action<Activity, string> _setRootId;
+        private static readonly Action<Activity, string> _setState;
 
         static ActivityExtensions()
         {
-            BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+             BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
             var activityType = typeof(Activity);
-            _setSpanId = activityType.GetField("_spanId", flags).CreateSetter<Activity, string>();
-            _setId = activityType.GetField("_id", flags).CreateSetter<Activity, string>();
-            _setRootId = activityType.GetField("_rootId", flags).CreateSetter<Activity, string>();
-            _setTraceId = activityType.GetField("_traceId", flags).CreateSetter<Activity, string>();
+
+            // Empty setter serves as a safe fallback mechanism to handle cases where the field is not available.
+            _setSpanId = activityType.GetField("_spanId", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
+            _setId = activityType.GetField("_id", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
+            _setRootId = activityType.GetField("_rootId", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
+            _setTraceId = activityType.GetField("_traceId", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
+            _setState = activityType.GetField("_traceState", flags)?.CreateSetter<Activity, string>() ?? ((_, _) => { /* Ignore */ });
         }
 
         /// <summary>
@@ -71,6 +75,9 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
 
         public static void SetTraceId(this Activity activity, string traceId)
             => _setTraceId(activity, traceId);
+
+        public static void SetState(this Activity activity, string state)
+            => _setState(activity, arg2: state);
     }
 
     internal static class FieldInfoExtensionMethods

--- a/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
+++ b/src/DotNetWorker.Core/Diagnostics/ActivityExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Functions.Worker.Diagnostics
 
         static ActivityExtensions()
         {
-             BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+            BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
             var activityType = typeof(Activity);
 
             // Empty setter serves as a safe fallback mechanism to handle cases where the field is not available.

--- a/src/DotNetWorker.Core/FunctionsApplication.cs
+++ b/src/DotNetWorker.Core/FunctionsApplication.cs
@@ -78,11 +78,7 @@ namespace Microsoft.Azure.Functions.Worker
                 activity.SetTraceId(activityContext.TraceId.ToString());
                 activity.SetRootId(activityContext.TraceId.ToString());
                 activity.ActivityTraceFlags = activityContext.TraceFlags;
-
-                if (activityContext.TraceState is not null)
-                {
-                    activity.SetState(activityContext.TraceState);
-                }
+                activity.TraceStateString = activityContext.TraceState;
             }
 
             var scope = new FunctionInvocationScope(context.FunctionDefinition.Name, context.InvocationId);

--- a/src/DotNetWorker.Core/FunctionsApplication.cs
+++ b/src/DotNetWorker.Core/FunctionsApplication.cs
@@ -77,6 +77,12 @@ namespace Microsoft.Azure.Functions.Worker
                 activity.SetSpanId(activityContext.SpanId.ToString());
                 activity.SetTraceId(activityContext.TraceId.ToString());
                 activity.SetRootId(activityContext.TraceId.ToString());
+                activity.ActivityTraceFlags = activityContext.TraceFlags;
+
+                if (activityContext.TraceState is not null)
+                {
+                    activity.SetState(activityContext.TraceState);
+                }
             }
 
             var scope = new FunctionInvocationScope(context.FunctionDefinition.Name, context.InvocationId);

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -82,6 +82,8 @@ public class EndToEndTests
             Assert.Equal("InvokeFunctionAsync", activity.OperationName);
             Assert.Equal(activity.SpanId, activityContext.SpanId);
             Assert.Equal(activity.TraceId, activityContext.TraceId);
+            Assert.Equal(activity.ActivityTraceFlags, activityContext.TraceFlags);
+            Assert.Equal(activity.TraceStateString, activityContext.TraceState);
         }
         else
         {
@@ -154,7 +156,6 @@ public class EndToEndTests
         public async Task TestFunction(FunctionContext context)
         {
             LastActivity = Activity.Current;
-            Activity.Current.ActivityTraceFlags = ActivityTraceFlags.Recorded;
             Activity.Current.AddTag("CustomKey", "CustomValue");
 
             var response = new HttpResponseMessage(HttpStatusCode.OK);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Adding support for ActivityTraceFlags and TraceState propagation from incoming requests involves ensuring that when a new Activity is created, it correctly inherits the trace context from an incoming request. 

resolves #2543
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
