### PR TITLE
Removing WEBSITE_CONTAINER_READY=0 env variable check for DotnetIsolatedLinuxPlaceholder profile

### DIFF
--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>

--- a/host/tools/build/worker.config.json
+++ b/host/tools/build/worker.config.json
@@ -15,11 +15,6 @@
         },
         {
           "conditionType": "environment",
-          "conditionName": "WEBSITE_CONTAINER_READY",
-          "conditionExpression": "0"
-        },
-        {
-          "conditionType": "environment",
           "conditionName": "WEBSITE_PLACEHOLDER_MODE",
           "conditionExpression": "1"
         }


### PR DESCRIPTION
In [this PR](https://github.com/Azure/azure-functions-dotnet-worker/pull/2552), we added a profile condition to check if the environment variable `WEBSITE_CONTAINER_READY` is set to `0`, following [our wiki page](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Docs/commit/42e7ab6e7d4771f5d4926d5aa64ec04d6de4e730?refName=refs/heads/master&path=/TeamDocs/FunctionTeamDocs/Design/FlexConsumption/SpecializationCodePath.md&_a=contents&anchor=azure-functions-runtime). However, testing revealed this does not work, as the flex SKU did not set this environment variable. The Linux team conducted an initial investigation to find the impact of adding this environment variable to the container but found that other parts of the system expect this[ value to be not null rather than checking for a specific value (1)](https://github.com/Azure/azure-functions-host/blob/8ba99f7b80e2e7ffbfe32fe6fdc15efb61985d55/src/WebJobs.Script/Environment/EnvironmentExtensions.cs#L499). We have decided to remove this environment variable check, understanding the impact of this change.


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


