### PR TITLE
Changing pool image from ubuntu-22.04 to ubuntu-20.04 for FunctionsNetHost Linux artifact

### DIFF
--- a/eng/ci/templates/official/jobs/build-host-artifacts-linux.yml
+++ b/eng/ci/templates/official/jobs/build-host-artifacts-linux.yml
@@ -17,7 +17,7 @@ jobs:
 
   pool:
     name: ${{ parameters.PoolName }}
-    image: 1es-ubuntu-22.04
+    image: 1es-ubuntu-20.04
     os: linux
 
   steps:

--- a/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
+++ b/host/tools/build/Microsoft.Azure.Functions.DotnetIsolatedNativeHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Azure.Functions.DotNetIsolatedNativeHost</id>
     <title>Microsoft Azure Functions dotnet-isolated native host</title>
     <tags>dotnet-isolated azure-functions azure</tags>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/azure-functions-dotnet-worker</projectUrl>


### PR DESCRIPTION
As part of the 1ES pipeline updates, we transitioned to using Ubuntu 22.04 as the build environment for producing the FunctionsNetHost Linux artifact. However, this has resulted in an artifact that is incompatible with some of our images, which still use Debian 11. The following error occurred when attempting to start FunctionsNetHost in a Debian 11 environment:

> ./FunctionsNetHost: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./FunctionsNetHost)

In this pull request, we are reverting to Ubuntu 20.04, which was our previous build environment ([code here](https://github.com/Azure/azure-functions-dotnet-worker/blob/03aa5b4f60c916868b3c1795d0b6a216c80e89bf/host/azure-pipelines.yml#L73)).

Bumped patch version. New version is 1.0.11

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
