### PR TITLE
Adding default settings to support SDK container builds

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -15,3 +15,7 @@
 ### Microsoft.Azure.Functions.Worker.Grpc <version>
 
 - Removed fallback command line argument reading code for grpc worker startup options. (#1908)
+
+### Microsoft.Azure.Functions.Worker.Sdk 2.0.0-preview2
+
+- Adding support for SDK container builds with Functions base images

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.Publish.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.Publish.targets
@@ -21,4 +21,30 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Azure.Functions.Worker.Sdk.Publish.$(PublishProtocol).targets"  
           Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Azure.Functions.Worker.Sdk.Publish.$(PublishProtocol).targets')" />
 
+    <Target
+          Name="AssignFunctionsBaseImage"
+          BeforeTargets="ComputeContainerBaseImage"
+          DependsOnTargets="_FunctionsPreBuild" >
+        <PropertyGroup>
+            <_FunctionsRuntimeMajorVersion>$(_AzureFunctionsVersionStandardized.TrimStart('vV'))</_FunctionsRuntimeMajorVersion>
+            <ContainerBaseImage Condition="'$(ContainerBaseImage)' == ''">mcr.microsoft.com/azure-functions/dotnet-isolated:$(_FunctionsRuntimeMajorVersion)-dotnet-isolated$(TargetFrameworkVersion.TrimStart('vV'))</ContainerBaseImage>
+            <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/home/site/wwwroot</ContainerWorkingDirectory>
+            <!-- Functions base images only support amd64 runtimes -->
+            <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == ''">linux-x64</ContainerRuntimeIdentifier>
+        </PropertyGroup>
+        <ItemGroup>
+            <ContainerEnvironmentVariable
+                    Condition="@(ContainerEnvironmentVariable->AnyHaveMetadataValue('Identity', 'AzureWebJobsScriptRoot')) == false"
+                    Include="AzureWebJobsScriptRoot"
+                    Value="$(ContainerWorkingDirectory)" />
+            <ContainerEnvironmentVariable
+                    Condition="@(ContainerEnvironmentVariable->AnyHaveMetadataValue('Identity', 'AzureFunctionsJobHost__Logging__Console__IsEnabled')) == false"
+                    Include="AzureFunctionsJobHost__Logging__Console__IsEnabled"
+                    Value="true" />
+        </ItemGroup>
+        <ItemGroup>
+            <ContainerAppCommand Include="/opt/startup/start_nonappservice.sh" />
+        </ItemGroup>
+    </Target>
+
 </Project>

--- a/test/SdkE2ETests/SdkE2ETests.csproj
+++ b/test/SdkE2ETests/SdkE2ETests.csproj
@@ -8,6 +8,10 @@
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\SdkE2ETests_default.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+    
   <ItemGroup>
     <None Remove="Contents\functions.metadata" />
   </ItemGroup>

--- a/test/SdkE2ETests/SdkE2ETests_default.runsettings
+++ b/test/SdkE2ETests/SdkE2ETests_default.runsettings
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <TestCaseFilter>(Requirement != Docker)</TestCaseFilter>
+  </RunConfiguration>
+</RunSettings>

--- a/test/SdkE2ETests/SdkE2ETests_dockertests.runsettings
+++ b/test/SdkE2ETests/SdkE2ETests_dockertests.runsettings
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <TestCaseFilter>(Requirement = Docker)</TestCaseFilter>
+  </RunConfiguration>
+</RunSettings>

--- a/test/SdkE2ETests/TestUtility.cs
+++ b/test/SdkE2ETests/TestUtility.cs
@@ -135,5 +135,12 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             return outputDir;
         }
+
+        public static async Task RemoveDockerTestImage(string repository, string imageTag, ITestOutputHelper outputHelper)
+        {
+            outputHelper.WriteLine($"Removing image {repository}:{imageTag} from local registry");
+            int? rmiExitCode = await new ProcessWrapper().RunProcess("docker", $"rmi -f {repository}:{imageTag}", TestOutputDir, outputHelper);
+            Assert.True(rmiExitCode.HasValue && rmiExitCode.Value == 0); // daemon may still error if the image doesn't exist, but it will still return 0
+        }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #2617 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional PR information

Because the tests associated with these changes require a docker daemon, I've moved them out of the default test set by setting a trait and applying a default filter which removes it. The relevant test can still be run by explicitly specifying the other runtime settings file included in the PR. Discussion may be needed around running this test within CI.

In addition to passes for the newly added tests, I have also manually tested the resulting output in both Windows and Linux, using .NET SDK 8.0.4 as per the discussion in #2641. The resulting images have no differences in included packages.

~~I would like to discuss the impact of these changes, as they would modify the default base image and some other settings for apps that are already using SDK container builds. Those would likely be unsuccessful today, so it is likely safe to do so. However, this still could be a change that warrants a major version revision.~~ Edit: This now targets a new major version. See comment below.

If someone is setting the properties explicitly, those would continue to be honored. I also defined a new property (`FunctionsContainerOmitDefaultEnvsVars`) which can be used to suppress the environment variables being added should someone be customizing the other properties or have some other reason to modify them. It was not clear to me how I could otherwise conditionally avoid overwriting values that someone else had supplied for these.