### PR TITLE
Allowing version validation to include qualities for testing purposes

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -63,7 +63,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <!-- Validating some expectations for the function app early on. -->
   <Target Name="_FunctionsPreBuild" BeforeTargets="BeforeBuild">
     <PropertyGroup>
-      <_AzureFunctionsVersionStandardized>$(AzureFunctionsVersion.ToLowerInvariant())</_AzureFunctionsVersionStandardized>
+      <!-- Versions could be of several forms, such as "v4", "V4", or "v4-prerelease". This will normalize those three examples all to "v4". -->
+      <_AzureFunctionsVersionStandardized>$(AzureFunctionsVersion.ToLowerInvariant().Split('-')[0])</_AzureFunctionsVersionStandardized>
       <CheckEolAzureFunctionsVersion Condition="'$(CheckEolAzureFunctionsVersion)' == ''">true</CheckEolAzureFunctionsVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
New version validation introduced in https://github.com/Azure/azure-functions-dotnet-worker/pull/2606 is too strict. It prohibits testing with quality tags, which is a part of the prerelease validation process for components like the tooling feed. The validation check should be for the major version format only.

This change will need to make it into the `feature/2.x` branch as well.

This should also inform changes on https://github.com/Azure/azure-functions-dotnet-worker/pull/2671 to remove a similar change in a later property, though those aren't strictly necessary (the secondary action shouldn't hurt). I think we can just rebase that once this change is in the `feature/2.x` branch.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)