### PR TITLE
DefaultHttpCoordinator SetHttpContextAsync should use async/await to make the catch/rethrow effective

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             _logger = extensionTrace;
         }
 
-        public Task<FunctionContext> SetHttpContextAsync(string invocationId, HttpContext context)
+        public async Task<FunctionContext> SetHttpContextAsync(string invocationId, HttpContext context)
         {
             var contextRef = _contextReferenceList.GetOrAdd(invocationId, static id => new ContextReference(id));
             contextRef.HttpContextValueSource.SetResult(context);
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 
             try
             {
-                return contextRef.FunctionContextValueSource.Task.WaitAsync(TimeSpan.FromSeconds(FunctionContextTimeoutInSeconds));
+                return await contextRef.FunctionContextValueSource.Task.WaitAsync(TimeSpan.FromSeconds(FunctionContextTimeoutInSeconds));
             }
             catch (TimeoutException e)
             {

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <Description>ASP.NET Core extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>1.3.2</VersionPrefix>
+    <VersionPrefix>1.3.3</VersionPrefix>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
Awaiting on the call to `FunctionContextValueSource` in `SetHttpContextAsync` to ensure potential exceptions are correctly caught.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


