### PR TITLE
Set IncludeEmptyEntriesInMessagePayload capability to true by default

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,16 +4,28 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker (metapackage) 1.23.0
+### Microsoft.Azure.Functions.Worker (metapackage) 2.0.0
 
-- Updating `Microsoft.Azure.Functions.Worker.Core` to 1.19.0
-- Updating `Microsoft.Azure.Functions.Worker.Grpc` to 1.17.0
-- Updating `Azure.Core` to 1.41.0
+- Updating `Microsoft.Azure.Functions.Worker.Core` to 2.0.0
+- Updating `Microsoft.Azure.Functions.Worker.Grpc` to 2.0.0
 
-### Microsoft.Azure.Functions.Worker.Core 1.19.0
+### Microsoft.Azure.Functions.Worker.Core 2.0.0
 
-- Updating `Azure.Core` to 1.41.0
+- Capability `IncludeEmptyEntriesInMessagePayload` is now enabled by default (#2701)
+  - This means that empty entries will be included in the function trigger message payload by default.
+  - To disable this capability and return to the old behaviour, set `IncludeEmptyEntriesInMessagePayload` to `false` in the worker options.
 
-### Microsoft.Azure.Functions.Worker.Grpc 1.17.0
+    ```csharp
+    var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults(builder =>
+    {
+    }, options =>
+    {
+        options.IncludeEmptyEntriesInMessagePayload = false;
+    })
+    .Build();
+    ```
 
-- Updating `Azure.Core` to 1.41.0
+### Microsoft.Azure.Functions.Worker.Grpc 2.0.0
+
+- <entry>

--- a/src/DotNetWorker.Core/Hosting/WorkerCapabilities.cs
+++ b/src/DotNetWorker.Core/Hosting/WorkerCapabilities.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    internal static class WorkerCapabilities
+    {
+        internal const string EnableUserCodeException = "EnableUserCodeException";
+        internal const string HandlesInvocationCancelMessage = "HandlesInvocationCancelMessage";
+        internal const string HandlesWorkerTerminateMessage = "HandlesWorkerTerminateMessage";
+        internal const string HandlesWorkerWarmupMessage = "HandlesWorkerWarmupMessage";
+        internal const string IncludeEmptyEntriesInMessagePayload = "IncludeEmptyEntriesInMessagePayload";
+        internal const string RawHttpBodyBytes = "RawHttpBodyBytes";
+        internal const string RpcHttpBodyOnly = "RpcHttpBodyOnly";
+        internal const string RpcHttpTriggerMetadataRemoved = "RpcHttpTriggerMetadataRemoved";
+        internal const string TypedDataCollection = "TypedDataCollection";
+        internal const string UseNullableValueDictionaryForHttp = "UseNullableValueDictionaryForHttp";
+        internal const string WorkerStatus = "WorkerStatus";
+    }
+}

--- a/src/DotNetWorker.Core/Hosting/WorkerOptions.cs
+++ b/src/DotNetWorker.Core/Hosting/WorkerOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
     /// An options class for configuring the worker.
-    /// </summary>    
+    /// </summary>
     public class WorkerOptions
     {
         /// <summary>
@@ -30,13 +30,14 @@ namespace Microsoft.Azure.Functions.Worker
         public IDictionary<string, string> Capabilities { get; } = new Dictionary<string, string>()
         {
             // Enable these by default, although they are not strictly required and can be removed
-            { "HandlesWorkerTerminateMessage", bool.TrueString },
-            { "HandlesInvocationCancelMessage", bool.TrueString }
+            { WorkerCapabilities.HandlesWorkerTerminateMessage, bool.TrueString },
+            { WorkerCapabilities.HandlesInvocationCancelMessage, bool.TrueString },
+            { WorkerCapabilities.IncludeEmptyEntriesInMessagePayload, bool.TrueString }
         };
 
         /// <summary>
         /// Gets or sets the flag for opting in to unwrapping user-code-thrown
-        /// exceptions when they are surfaced to the Host. 
+        /// exceptions when they are surfaced to the Host.
         /// </summary>
         public bool EnableUserCodeException
         {
@@ -49,7 +50,7 @@ namespace Microsoft.Azure.Functions.Worker
         /// For example, if a set of entries were sent to a messaging service such as Service Bus or Event Hub and your function
         /// app has a Service bus trigger or Event hub trigger, only the non-empty entries from the payload will be sent to the
         /// function code as trigger data when this setting value is <see langword="false"/>. When it is <see langword="true"/>,
-        /// All entries will be sent to the function code as it is. Default value for this setting is <see langword="false"/>.
+        /// all entries will be sent to the function code as it is. Default value for this setting is <see langword="true"/>.
         /// </summary>
         public bool IncludeEmptyEntriesInMessagePayload
         {

--- a/src/DotNetWorker.Grpc/GrpcWorker.cs
+++ b/src/DotNetWorker.Grpc/GrpcWorker.cs
@@ -320,12 +320,12 @@ namespace Microsoft.Azure.Functions.Worker
             }
 
             // Add required capabilities; these cannot be modified and will override anything from WorkerOptions
-            capabilities["RpcHttpBodyOnly"] = bool.TrueString;
-            capabilities["RawHttpBodyBytes"] = bool.TrueString;
-            capabilities["RpcHttpTriggerMetadataRemoved"] = bool.TrueString;
-            capabilities["UseNullableValueDictionaryForHttp"] = bool.TrueString;
-            capabilities["TypedDataCollection"] = bool.TrueString;
-            capabilities["WorkerStatus"] = bool.TrueString;
+            capabilities[WorkerCapabilities.RpcHttpBodyOnly] = bool.TrueString;
+            capabilities[WorkerCapabilities.RawHttpBodyBytes] = bool.TrueString;
+            capabilities[WorkerCapabilities.RpcHttpTriggerMetadataRemoved] = bool.TrueString;
+            capabilities[WorkerCapabilities.UseNullableValueDictionaryForHttp] = bool.TrueString;
+            capabilities[WorkerCapabilities.TypedDataCollection] = bool.TrueString;
+            capabilities[WorkerCapabilities.WorkerStatus] = bool.TrueString;
 
             return capabilities;
         }

--- a/test/DotNetWorkerTests/GrpcWorkerTests.cs
+++ b/test/DotNetWorkerTests/GrpcWorkerTests.cs
@@ -234,6 +234,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
             Assert.Collection(response.Capabilities.OrderBy(p => p.Key),
                 c => AssertKeyAndValue(c, "HandlesInvocationCancelMessage", bool.TrueString),
+                c => AssertKeyAndValue(c, "IncludeEmptyEntriesInMessagePayload", bool.TrueString),
                 c => AssertKeyAndValue(c, "RawHttpBodyBytes", bool.TrueString),
                 c => AssertKeyAndValue(c, "RpcHttpBodyOnly", bool.TrueString),
                 c => AssertKeyAndValue(c, "RpcHttpTriggerMetadataRemoved", bool.TrueString),
@@ -324,7 +325,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             });
 
             releaseFunctionEvent.Wait(5000);
-            
+
             Assert.True(releaseFunctionEvent.IsSet,
                 "Release function was never called. " +
                 "This indicates the blocking function prevented execution flow.");


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1096

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This makes a change so that the worker will by default send the `IncludeEmptyEntriesInPayload` capability to the host. This means that empty entries will always be included in the message payload. This was initially created as a flag to avoid breaking users but there is no reason not to make this the permanent behaviour now as it's what would normally be expected.

Original bug: https://github.com/Azure/azure-functions-dotnet-worker/issues/876

