### PR TITLE
Rename 'ILoggerExtensions' to 'FunctionsLoggerExtensions'

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -27,6 +27,7 @@
     })
     .Build();
     ```
+- Rename `ILoggerExtensions` to `FunctionsLoggerExtensions` to avoid naming conflict issues (#2716)
 
 ### Microsoft.Azure.Functions.Worker.Grpc 2.0.0
 

--- a/src/DotNetWorker.Core/Logging/FunctionsLoggerExtensions.cs
+++ b/src/DotNetWorker.Core/Logging/FunctionsLoggerExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Logging
     /// <summary>
     /// Extensions for <see cref="ILogger"/>.
     /// </summary>
-    public static class ILoggerExtensions
+    public static class FunctionsLoggerExtensions
     {
         /// <summary>
         /// Logs a metric value. Log will be at an information level.


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1215

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Rename 'ILoggerExtensions' to 'FunctionsLoggerExtensions' to avoid conflicts.

E.g.

`Error	CS0121	The call is ambiguous between the following methods or properties: 'Microsoft.Extensions.Logging.LoggerExtensions.LogMetric(Microsoft.Extensions.Logging.ILogger, string, double, System.Collections.Generic.IDictionary<string, object>)' and 'Microsoft.Extensions.Logging.ILoggerExtensions.LogMetric(Microsoft.Extensions.Logging.ILogger, string, double, System.Collections.Generic.IDictionary<string, object>?)`