### PR TITLE
Remove HttpStatusCode=OK from WriteAsJsonAsync

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -39,5 +39,4 @@ var host = new HostBuilder()
 
 ### Microsoft.Azure.Functions.Worker.Sdk 2.0.0-preview2
 
-- Adding support for SDK container builds with Functions base images.
-- Removed the default value for HttpStatusCode in WriteAsJsonAsync.
+- Adding support for SDK container builds with Functions base images

--- a/release_notes.md
+++ b/release_notes.md
@@ -39,4 +39,5 @@ var host = new HostBuilder()
 
 ### Microsoft.Azure.Functions.Worker.Sdk 2.0.0-preview2
 
-- Adding support for SDK container builds with Functions base images
+- Adding support for SDK container builds with Functions base images.
+- Removed the default value for HttpStatusCode in WriteAsJsonAsync.

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -9,7 +9,7 @@
 - Fix incorrect function version in build message (#2606)
 - Fix inner build failures when central package management is enabled (#2689)
 - Setting _ToolingSuffix for TargetFrameworkVersion v9.0
-- <entry>
+- Adding support for SDK container builds with Functions base images (#2720)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 

--- a/src/DotNetWorker.Core/Http/HttpResponseDataExtensions.cs
+++ b/src/DotNetWorker.Core/Http/HttpResponseDataExtensions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.Worker.Http
 
         /// <summary>
         /// Asynchronously writes the specified value as JSON to the response body using the default <see cref="ObjectSerializer"/> configured for this worker.
-        /// The response content-type will be set to <code>application/json; charset=utf-8</code> and the status code set to 200.
+        /// The response content-type will be set to <code>application/json; charset=utf-8</code>.
         /// </summary>
         /// <typeparam name="T">The type of object to write.</typeparam>
         /// <param name="response">The response to write JSON to.</param>
@@ -90,28 +90,12 @@ namespace Microsoft.Azure.Functions.Worker.Http
         /// <returns>A <see cref="ValueTask"/> that represents the asynchronous operation.</returns>
         public static ValueTask WriteAsJsonAsync<T>(this HttpResponseData response, T instance, CancellationToken cancellationToken = default)
         {
-            return WriteAsJsonAsync(response, instance, "application/json; charset=utf-8", HttpStatusCode.OK, cancellationToken);
+            return WriteAsJsonAsync(response, instance, "application/json; charset=utf-8", cancellationToken);
         }
 
         /// <summary>
         /// Asynchronously writes the specified value as JSON to the response body using the default <see cref="ObjectSerializer"/> configured for this worker.
-        /// The response content-type will be set to <code>application/json; charset=utf-8</code> and the status code set to the provided <paramref name="statusCode"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of object to write.</typeparam>
-        /// <param name="response">The response to write JSON to.</param>
-        /// <param name="instance">The instance to serialize and write as JSON.</param>
-        /// <param name="statusCode">The status code to set on the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
-        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous operation.</returns>
-        public static ValueTask WriteAsJsonAsync<T>(this HttpResponseData response, T instance, HttpStatusCode statusCode,
-            CancellationToken cancellationToken = default)
-        {
-            return WriteAsJsonAsync(response, instance, "application/json; charset=utf-8", statusCode, cancellationToken);
-        }
-
-        /// <summary>
-        /// Asynchronously writes the specified value as JSON to the response body using the default <see cref="ObjectSerializer"/> configured for this worker.
-        /// The response content-type will be set to the provided <paramref name="contentType"/> and the status code set to 200.
+        /// The response content-type will be set to the provided <paramref name="contentType"/>.
         /// </summary>
         /// <typeparam name="T">The type of object to write.</typeparam>
         /// <param name="response">The response to write JSON to.</param>
@@ -128,37 +112,12 @@ namespace Microsoft.Azure.Functions.Worker.Http
 
             ObjectSerializer serializer = GetObjectSerializer(response);
 
-            return WriteAsJsonAsync(response, instance, serializer, contentType, HttpStatusCode.OK, cancellationToken);
+            return WriteAsJsonAsync(response, instance, serializer, contentType, cancellationToken);
         }
-
-        /// <summary>
-        /// Asynchronously writes the specified value as JSON to the response body using the default <see cref="ObjectSerializer"/> configured for this worker.
-        /// The response content-type will be set to the provided <paramref name="contentType"/> and the status code set to the provided <paramref name="statusCode"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of object to write.</typeparam>
-        /// <param name="response">The response to write JSON to.</param>
-        /// <param name="instance">The instance to serialize and write as JSON.</param>
-        /// <param name="contentType">The content-type to set on the response.</param>
-        /// <param name="statusCode">The status code to set on the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
-        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous operation.</returns>
-        public static ValueTask WriteAsJsonAsync<T>(this HttpResponseData response, T instance, string contentType, HttpStatusCode statusCode,
-            CancellationToken cancellationToken = default)
-        {
-            if (response is null)
-            {
-                throw new ArgumentNullException(nameof(response));
-            }
-
-            ObjectSerializer serializer = GetObjectSerializer(response);
-
-            return WriteAsJsonAsync(response, instance, serializer, contentType, statusCode, cancellationToken);
-        }
-
 
         /// <summary>
         /// Asynchronously writes the specified value as JSON to the response body using the provided <see cref="ObjectSerializer"/>.
-        /// The response content-type will be set to <code>application/json; charset=utf-8</code> and the status code set to 200.
+        /// The response content-type will be set to <code>application/json; charset=utf-8</code>.
         /// </summary>
         /// <typeparam name="T">The type of object to write.</typeparam>
         /// <param name="response">The response to write JSON to.</param>
@@ -168,29 +127,12 @@ namespace Microsoft.Azure.Functions.Worker.Http
         /// <returns>A <see cref="ValueTask"/> that represents the asynchronous operation.</returns>
         public static ValueTask WriteAsJsonAsync<T>(this HttpResponseData response, T instance, ObjectSerializer serializer, CancellationToken cancellationToken = default)
         {
-            return WriteAsJsonAsync(response, instance, serializer, "application/json; charset=utf-8", HttpStatusCode.OK, cancellationToken);
+            return WriteAsJsonAsync(response, instance, serializer, "application/json; charset=utf-8", cancellationToken);
         }
-
+                
         /// <summary>
         /// Asynchronously writes the specified value as JSON to the response body using the provided <see cref="ObjectSerializer"/>.
-        /// The response content-type will be set to <code>application/json; charset=utf-8</code> and the status code set to the provided <paramref name="statusCode"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of object to write.</typeparam>
-        /// <param name="response">The response to write JSON to.</param>
-        /// <param name="instance">The instance to serialize and write as JSON.</param>
-        /// <param name="serializer">The serializer used to serialize the instance.</param>
-        /// <param name="statusCode">The status code to set on the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
-        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous operation.</returns>
-        public static ValueTask WriteAsJsonAsync<T>(this HttpResponseData response, T instance, ObjectSerializer serializer, HttpStatusCode statusCode,
-            CancellationToken cancellationToken = default)
-        {
-            return WriteAsJsonAsync(response, instance, serializer, "application/json; charset=utf-8", statusCode, cancellationToken);
-        }
-
-        /// <summary>
-        /// Asynchronously writes the specified value as JSON to the response body using the provided <see cref="ObjectSerializer"/>.
-        /// The response content-type will be set to the provided <paramref name="contentType"/> and the status code set to 200.
+        /// The response content-type will be set to the provided <paramref name="contentType"/>.
         /// </summary>
         /// <typeparam name="T">The type of object to write.</typeparam>
         /// <param name="response">The response to write JSON to.</param>
@@ -199,26 +141,7 @@ namespace Microsoft.Azure.Functions.Worker.Http
         /// <param name="contentType">The content-type to set on the response.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
         /// <returns>A <see cref="ValueTask"/> that represents the asynchronous operation.</returns>
-        public static ValueTask WriteAsJsonAsync<T>(this HttpResponseData response, T instance,
-            ObjectSerializer serializer, string contentType,
-            CancellationToken cancellationToken = default)
-        {
-            return WriteAsJsonAsync(response, instance, serializer, contentType, HttpStatusCode.OK, cancellationToken);
-        }
-
-        /// <summary>
-        /// Asynchronously writes the specified value as JSON to the response body using the provided <see cref="ObjectSerializer"/>.
-        /// The response content-type will be set to the provided <paramref name="contentType"/> and the status code set to the provided <paramref name="statusCode"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of object to write.</typeparam>
-        /// <param name="response">The response to write JSON to.</param>
-        /// <param name="instance">The instance to serialize and write as JSON.</param>
-        /// <param name="serializer">The serializer used to serialize the instance.</param>
-        /// <param name="contentType">The content-type to set on the response.</param>
-        /// <param name="statusCode">The status code to set on the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
-        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous operation.</returns>
-        public static ValueTask WriteAsJsonAsync<T>(this HttpResponseData response, T instance, ObjectSerializer serializer, string contentType, HttpStatusCode statusCode, CancellationToken cancellationToken = default)
+        public static ValueTask WriteAsJsonAsync<T>(this HttpResponseData response, T instance, ObjectSerializer serializer, string contentType, CancellationToken cancellationToken = default)
         {
             if (response is null)
             {
@@ -236,8 +159,6 @@ namespace Microsoft.Azure.Functions.Worker.Http
             }
 
             response.Headers.Add("Content-Type", contentType);
-            response.StatusCode = statusCode;
-
             return serializer.SerializeAsync(response.Body, instance, typeof(T), cancellationToken);
         }
 

--- a/test/DotNetWorkerTests/Http/HttpResponseDataExtensionsTests.cs
+++ b/test/DotNetWorkerTests/Http/HttpResponseDataExtensionsTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         public async Task WriteAsJsonAsync_ContentTypeOverload_AppliesParameters()
         {
             FunctionContext context = CreateContext(new NewtonsoftJsonObjectSerializer());
-            var response = CreateResponse(context);
+            var response = CreateResponse(context, HttpStatusCode.Accepted);
 
             var poco = new ResponsePoco
             {
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             string result = ReadResponseBody(response);
 
             Assert.Equal("application/json", response.Headers.GetValues("content-type").FirstOrDefault());
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("{\"jsonnetname\":\"Test\",\"jsonnetint\":42}", result);
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         public async Task WriteAsJsonAsync_StatusCodeOverload_AppliesParameters()
         {
             FunctionContext context = CreateContext(new NewtonsoftJsonObjectSerializer());
-            var response = CreateResponse(context);
+            var response = CreateResponse(context, HttpStatusCode.BadRequest);
 
             var poco = new ResponsePoco
             {
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
                 SomeInt = 42
             };
 
-            await HttpResponseDataExtensions.WriteAsJsonAsync(response, poco, HttpStatusCode.BadRequest);
+            await HttpResponseDataExtensions.WriteAsJsonAsync(response, poco);
 
             string result = ReadResponseBody(response);
             
@@ -127,9 +127,9 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Equal("{\"jsonnetname\":\"Test\",\"jsonnetint\":42}", result);
         }
 
-        private static TestHttpResponseData CreateResponse(FunctionContext context)
+        private static TestHttpResponseData CreateResponse(FunctionContext context, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
-            var response = new TestHttpResponseData(context, HttpStatusCode.Accepted);
+            var response = new TestHttpResponseData(context, statusCode);
             response.Body = new MemoryStream();
             response.Headers = new HttpHeadersCollection();
             return response;


### PR DESCRIPTION
Eliminated the default value for HttpStatusCode and removed the overloaded methods for setting HttpStatusCode in the response.

Default Behavior - 200 OK
```
var responseData = req.CreateResponse();
await responseData.WriteAsJsonAsync(new { message = "Done" });
return responseData;
```

Return a non-200 response
```
var responseData = req.CreateResponse(HttpStatusCode.BadRequest);
await responseData.WriteAsJsonAsync(new { message = "An error occurred" });
return responseData;
```

resolves #776 

This is a breaking change, targeting feature/2.x branch.
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
