### PR TITLE
Update AspNetCoreResponseCookies so that cookie defaults to being secure

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -7,3 +7,4 @@
 ### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore <version>
 
 - Fixed a bug that would lead to an empty exception message in some model binding failures.
+- Cookies will default to `Secure = true` if not set explicitly

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/HttpDataModel/AspNetCoreResponseCookies.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/HttpDataModel/AspNetCoreResponseCookies.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
                 HttpOnly = cookie.HttpOnly ?? false,
                 MaxAge = cookie.MaxAge is null ? null : TimeSpan.FromSeconds(cookie.MaxAge.Value),
                 SameSite = ConvertSameSite(cookie.SameSite),
-                Secure = cookie.Secure ?? false
+                // May still need to diable rule: #pragma warning disable CA5383 as this doesn't ensure that the cookie is secure "always"
+                Secure = cookie.Secure ?? true
             };
 
             _httpResponse.Cookies.Append(cookie.Name, cookie.Value, cookieOptions);


### PR DESCRIPTION
Fix regarding: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5383

However, we might need to still ignore the rule since this does not ensure that the cookie will "always" be secure. 