### PR TITLE
Generator tests: Add transitive dependency for System.Text.Json v8.0.5 & bump extension versions

### DIFF
--- a/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
+++ b/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.6"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">

--- a/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
+++ b/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
@@ -35,7 +35,7 @@
     </PackageReference>
     <!--Transitive packages promoted due to CVEs:-->
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
+++ b/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.6"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
@@ -35,6 +35,7 @@
     </PackageReference>
     <!--Transitive packages promoted due to CVEs:-->
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Sdk.Generator.Tests.csproj:

- Add transative dependency for System.Text.Json v8.0.5 (this is coming from "Azure.Messaging.ServiceBus")
- Bump Extensions.Hosting to v8.0.1
- Bump Extensions.DependencyInjection to v8.0.1