### PR TITLE
Adding a null check before initiating the internal Activity

### DIFF
--- a/src/DotNetWorker.Core/FunctionsApplication.cs
+++ b/src/DotNetWorker.Core/FunctionsApplication.cs
@@ -67,18 +67,23 @@ namespace Microsoft.Azure.Functions.Worker
 
         public async Task InvokeFunctionAsync(FunctionContext context)
         {
-            // This will act as an internal activity that represents remote Host activity. This cannot be tracked as this is not associate to an ActivitySource. 
-            using Activity activity = new Activity(nameof(InvokeFunctionAsync));
-            activity.Start();
+            Activity? activity = null;
 
-            if (ActivityContext.TryParse(context.TraceContext.TraceParent, context.TraceContext.TraceState, true, out ActivityContext activityContext))
+            if (Activity.Current is null)
             {
-                activity.SetId(context.TraceContext.TraceParent);
-                activity.SetSpanId(activityContext.SpanId.ToString());
-                activity.SetTraceId(activityContext.TraceId.ToString());
-                activity.SetRootId(activityContext.TraceId.ToString());
-                activity.ActivityTraceFlags = activityContext.TraceFlags;
-                activity.TraceStateString = activityContext.TraceState;
+                // This will act as an internal activity that represents remote Host activity. This cannot be tracked as this is not associate to an ActivitySource. 
+                activity = new Activity(nameof(InvokeFunctionAsync));
+                activity.Start();
+
+                if (ActivityContext.TryParse(context.TraceContext.TraceParent, context.TraceContext.TraceState, true, out ActivityContext activityContext))
+                {
+                    activity.SetId(context.TraceContext.TraceParent);
+                    activity.SetSpanId(activityContext.SpanId.ToString());
+                    activity.SetTraceId(activityContext.TraceId.ToString());
+                    activity.SetRootId(activityContext.TraceId.ToString());
+                    activity.ActivityTraceFlags = activityContext.TraceFlags;
+                    activity.TraceStateString = activityContext.TraceState;
+                }
             }
 
             var scope = new FunctionInvocationScope(context.FunctionDefinition.Name, context.InvocationId);
@@ -98,6 +103,7 @@ namespace Microsoft.Azure.Functions.Worker
 
                 throw;
             }
+            activity?.Stop();
         }
     }
 }

--- a/src/DotNetWorker.Core/FunctionsApplication.cs
+++ b/src/DotNetWorker.Core/FunctionsApplication.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Azure.Functions.Worker
 
                 throw;
             }
+
+            invokeActivity?.Stop();
             activity?.Stop();
         }
     }

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -92,6 +92,24 @@ public class EndToEndTests
     }
 
     [Fact]
+    public async Task ContextPropagationWithTriggerInstrumentation()
+    {
+        using var host = InitializeHost();
+        var context = CreateContext(host);
+        using Activity testActivity = new Activity("ASPNetCoreMockActivity");
+        testActivity.Start();
+        await _application.InvokeFunctionAsync(context);
+        var activity = OtelFunctionDefinition.LastActivity;
+               
+        Assert.Equal(activity.Id, testActivity.Id);
+        Assert.Equal(activity.OperationName, testActivity.OperationName);
+        Assert.Equal(activity.SpanId, testActivity.SpanId);
+        Assert.Equal(activity.TraceId, testActivity.TraceId);
+        Assert.Equal(activity.ActivityTraceFlags, testActivity.ActivityTraceFlags);
+        Assert.Equal(activity.TraceStateString, testActivity.TraceStateString);
+    }
+
+    [Fact]
     public void ResourceDetectorLocalDevelopment()
     {
         FunctionsResourceDetector detector = new FunctionsResourceDetector();


### PR DESCRIPTION
Adding a null check before starting the internal Activity in the `InvokeFunctionAsync` method. This will help in scenarios where customers want to consume the request telemetry emitted by AspNetCoreInstrumentation. Adding this null check ensures that if a request telemetry already exists (generated by AspNetCoreInstrumentation), the internal Activity won’t be started.


resolves #2733 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)