### PR TITLE
Set extension RPC max message length

### DIFF
--- a/extensions/Worker.Extensions.Rpc/release_notes.md
+++ b/extensions/Worker.Extensions.Rpc/release_notes.md
@@ -4,7 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Rpc 1.0.0
+### Microsoft.Azure.Functions.Worker.Extensions.Rpc 1.0.1
 
-- Initial public release
-- Adds API for getting a `CallInvoker` pre-configured for communication with Functions host. 
+- Set max message send and receive length on gRPC `CallInvoker`.

--- a/extensions/Worker.Extensions.Rpc/src/ConfigurationExtensions.cs
+++ b/extensions/Worker.Extensions.Rpc/src/ConfigurationExtensions.cs
@@ -38,5 +38,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc
 
             return grpcUri;
         }
+
+        /// <summary>
+        /// Gets the maximum message length for the functions host gRPC channel.
+        /// </summary>
+        /// <param name="configuration">The configuration to retrieve values from.</param>
+        /// <returns>The maximum message length if available. </returns>
+        public static int? GetFunctionsHostMaxMessageLength(this IConfiguration configuration)
+        {
+            return configuration.GetValue<int?>("Functions:Worker:GrpcMaxMessageLength", null)
+                ?? configuration.GetValue<int?>("grpcMaxMessageLength", null);
+        }
     }
 }

--- a/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
+++ b/extensions/Worker.Extensions.Rpc/src/GrpcHttpClientBuilderExtensions.cs
@@ -31,7 +31,18 @@ namespace Microsoft.Azure.Functions.Worker
 
             ValidateGrpcClient(builder);
             builder.Services.AddOptions<GrpcClientFactoryOptions>(builder.Name)
-                .Configure<IConfiguration>((options, config) => options.Address = config.GetFunctionsHostGrpcUri());
+                .Configure<IConfiguration>((options, config) =>
+                {
+                    options.Address = config.GetFunctionsHostGrpcUri();
+                    if (config.GetFunctionsHostMaxMessageLength() is int length)
+                    {
+                        options.ChannelOptionsActions.Add(o =>
+                        {
+                            o.MaxReceiveMessageSize = length;
+                            o.MaxSendMessageSize = length;
+                        });
+                    }
+                });
 
             return builder;
         }

--- a/extensions/Worker.Extensions.Rpc/src/RpcServiceCollectionExtensions.NetApp.cs
+++ b/extensions/Worker.Extensions.Rpc/src/RpcServiceCollectionExtensions.NetApp.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 #if !NETSTANDARD
@@ -19,8 +19,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Rpc
         {
             // Instead of building the GrpcChannel/CallInvoker ourselves, we use Grpc.Net.ClientFactory to
             // construct and configure the CallInvoker for us, then we attach that to our options.
-            services.AddGrpcClient<CallInvokerExtractor>(_ => { })
-                .ConfigureForFunctionsHostGrpc();
+            services.AddGrpcClient<CallInvokerExtractor>(_ => { }).ConfigureForFunctionsHostGrpc();
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<FunctionsGrpcOptions>, ConfigureOptions>());
         }

--- a/extensions/Worker.Extensions.Rpc/src/Worker.Extensions.Rpc.csproj
+++ b/extensions/Worker.Extensions.Rpc/src/Worker.Extensions.Rpc.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Rpc</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Rpc</RootNamespace>
     <Description>Contains types to facilitate RPC communication between a worker extension and the functions host.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Configures max message send and receive length for the gRPC `CallInvoker` in the `Microsoft.Azure.Functions.Worker.Extensions.Rpc` package.
