### PR TITLE
`skipBuildTagsForGitHubPullRequests` when the PR is a fork for extensions

### DIFF
--- a/extensions/Worker.Extensions.CosmosDB/ci/public-build.yml
+++ b/extensions/Worker.Extensions.CosmosDB/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.EventGrid/ci/public-build.yml
+++ b/extensions/Worker.Extensions.EventGrid/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.EventHubs/ci/public-build.yml
+++ b/extensions/Worker.Extensions.EventHubs/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Http.AspNetCore/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Http.AspNetCore/ci/public-build.yml
@@ -52,6 +52,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Http/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Http/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Kafka/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Kafka/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.RabbitMQ/ci/public-build.yml
+++ b/extensions/Worker.Extensions.RabbitMQ/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Rpc/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Rpc/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.SendGrid/ci/public-build.yml
+++ b/extensions/Worker.Extensions.SendGrid/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.ServiceBus/ci/public-build.yml
+++ b/extensions/Worker.Extensions.ServiceBus/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.SignalRService/ci/public-build.yml
+++ b/extensions/Worker.Extensions.SignalRService/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Storage.Blobs/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Storage.Blobs/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Storage.Queues/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Storage.Queues/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Storage/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Storage/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Tables/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Tables/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Timer/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Timer/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 

--- a/extensions/Worker.Extensions.Warmup/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Warmup/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Test
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Add `skipBuildTagsForGitHubPullRequests` for forks for extensions.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
