### PR TITLE
initial fix of duplicate registrations if AddFunctionsWorkerCore called twice

### DIFF
--- a/src/DotNetWorker.Core/Hosting/DefaultInputConverterInitializer.cs
+++ b/src/DotNetWorker.Core/Hosting/DefaultInputConverterInitializer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.Core;
+
+internal class DefaultInputConverterInitializer : IConfigureOptions<WorkerOptions>
+{
+    public void Configure(WorkerOptions options)
+    {
+        options.InputConverters.Register<FunctionContextConverter>();
+        options.InputConverters.Register<TypeConverter>();
+        options.InputConverters.Register<GuidConverter>();
+        options.InputConverters.Register<DateTimeConverter>();
+        options.InputConverters.Register<MemoryConverter>();
+        options.InputConverters.Register<StringToByteConverter>();
+        options.InputConverters.Register<JsonPocoConverter>();
+        options.InputConverters.Register<ArrayConverter>();
+        options.InputConverters.Register<CancellationTokenConverter>();
+    }
+}

--- a/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceCollectionExtensions
     {
+        private static bool _defaultConvertersAdded = false;
+
         /// <summary>
         /// Adds the core set of services for the Azure Functions worker.
         /// </summary>
@@ -81,7 +83,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                 });
 
-            services.AddSingleton<ILoggerProvider, WorkerLoggerProvider>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, WorkerLoggerProvider>());
             services.AddSingleton(NullLogWriter.Instance);
             services.AddSingleton<IUserLogWriter>(s => s.GetRequiredService<NullLogWriter>());
             services.AddSingleton<ISystemLogWriter>(s => s.GetRequiredService<NullLogWriter>());
@@ -123,6 +125,13 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         internal static IServiceCollection AddDefaultInputConvertersToWorkerOptions(this IServiceCollection services)
         {
+            if (_defaultConvertersAdded)
+            {
+                return services;
+            }
+
+            _defaultConvertersAdded = true;
+
             return services.Configure<WorkerOptions>((workerOption) =>
             {
                 workerOption.InputConverters.Register<FunctionContextConverter>();

--- a/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceCollectionExtensions
     {
-        private static bool _defaultConvertersAdded = false;
-
         /// <summary>
         /// Adds the core set of services for the Azure Functions worker.
         /// </summary>

--- a/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
@@ -125,25 +125,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         internal static IServiceCollection AddDefaultInputConvertersToWorkerOptions(this IServiceCollection services)
         {
-            if (_defaultConvertersAdded)
-            {
-                return services;
-            }
-
-            _defaultConvertersAdded = true;
-
-            return services.Configure<WorkerOptions>((workerOption) =>
-            {
-                workerOption.InputConverters.Register<FunctionContextConverter>();
-                workerOption.InputConverters.Register<TypeConverter>();
-                workerOption.InputConverters.Register<GuidConverter>();
-                workerOption.InputConverters.Register<DateTimeConverter>();
-                workerOption.InputConverters.Register<MemoryConverter>();
-                workerOption.InputConverters.Register<StringToByteConverter>();
-                workerOption.InputConverters.Register<JsonPocoConverter>();
-                workerOption.InputConverters.Register<ArrayConverter>();
-                workerOption.InputConverters.Register<CancellationTokenConverter>();
-            });
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<WorkerOptions>, DefaultInputConverterInitializer>());
+            return services;
         }
 
         /// <summary>

--- a/test/DotNetWorkerTests/ServiceCollectionExtensionsTests.cs
+++ b/test/DotNetWorkerTests/ServiceCollectionExtensionsTests.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Microsoft.Azure.Functions.Worker.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -25,6 +28,50 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var workerOptions = services.GetService<IOptions<WorkerOptions>>().Value;
 
             Assert.True(configured);
+        }
+
+        [Fact]
+        public void DefaultInputConverters_RegisteredOnce()
+        {
+            var serviceColl = new ServiceCollection();
+            serviceColl.AddFunctionsWorkerDefaults();
+            serviceColl.AddFunctionsWorkerDefaults();
+
+            var services = serviceColl.BuildServiceProvider();
+
+            // request the worker options, which forces their configuration to be called.
+            var workerOptions = services.GetService<IOptions<WorkerOptions>>().Value;
+
+            // Ensure that even though we've called the registration twice, only one
+            // set of default input converters is registered.
+            var count = workerOptions.InputConverters.Count();
+            Assert.Equal(9, count);
+        }
+
+        [Fact]
+        public void LoggerProvider_RegisteredOnce()
+        {
+            var serviceColl = new ServiceCollection();
+            serviceColl.AddFunctionsWorkerDefaults();
+            serviceColl.AddFunctionsWorkerDefaults();
+
+            var services = serviceColl.BuildServiceProvider();
+
+            var loggerProviders = services.GetServices<ILoggerProvider>();
+
+            // Ensure that even though we've called the registration twice, only one
+            // WorkerLoggerProvider is registered.
+            Assert.Single(loggerProviders.Where(p => p is WorkerLoggerProvider));
+        }
+
+        [Fact]
+        public void SameBuilder_Returned()
+        {
+            var serviceColl = new ServiceCollection();
+            var builder1 = serviceColl.AddFunctionsWorkerCore();
+            var builder2 = serviceColl.AddFunctionsWorkerCore();
+
+            Assert.Same(builder1, builder2);
         }
     }
 }


### PR DESCRIPTION
There will be more to improve here, but first crack at making AddFunctionsWorkerCore work if called multiple times.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
