### PR TITLE
explicitly remove ConsoleLogger

### DIFF
--- a/src/DotNetWorker/Builder/FunctionsApplicationBuilder.cs
+++ b/src/DotNetWorker/Builder/FunctionsApplicationBuilder.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 
 namespace Microsoft.Azure.Functions.Worker.Builder;
 
@@ -41,6 +42,19 @@ public class FunctionsApplicationBuilder : IHostApplicationBuilder, IFunctionsWo
 
         _bootstrapHostBuilder
                    .ConfigureDefaults(args)
+                   .ConfigureServices(services =>
+                   {
+                       // The console logger can result in duplicate logging.
+                       foreach (var descriptor in services)
+                       {
+                           if (descriptor.ServiceType == typeof(ILoggerProvider) &&
+                               descriptor.ImplementationType == typeof(ConsoleLoggerProvider))
+                           {
+                               services.Remove(descriptor);
+                               break;
+                           }
+                       }
+                   })
                    .ConfigureFunctionsWorkerDefaults();
 
         _functionsWorkerApplicationBuilder = InitializeHosting(_bootstrapHostBuilder);


### PR DESCRIPTION
ConsoleLogger can result in dupe logging so we'll explicitly remove it by default. This can easily be re-added by customers with `AddConsole()` if they want it.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)