### PR TITLE
Register extension startup hooks only once

### DIFF
--- a/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
@@ -110,10 +110,11 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 builder = new FunctionsWorkerApplicationBuilder(services);
                 services.AddSingleton<IFunctionsWorkerApplicationBuilder>(builder);
-            }
 
-            // Execute startup code from worker extensions if present.
-            RunExtensionStartupCode(builder);
+                // Execute startup code from worker extensions if present
+                // Only run it once when builder is first added.
+                RunExtensionStartupCode(builder);
+            }
 
             return builder;
         }

--- a/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/src/DotNetWorker.Core/Hosting/ServiceCollectionExtensions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddSingleton<IFunctionsWorkerApplicationBuilder>(builder);
 
                 // Execute startup code from worker extensions if present
-                // Only run it once when builder is first added.
+                // Only run this once when builder is first added.
                 RunExtensionStartupCode(builder);
             }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This change improves the idempotence of our service registration. We will now only register extension startup hooks on the first call to this method.

Holding off on adding release notes "`ConfigureFunctionsWorkerDefaults()` is now idempotent and safe to call multiple times" as I believe there is more work before that is accurate.
