### PR TITLE
Adding .NET 9 issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02b-net9-question-or-issue.yml
+++ b/.github/ISSUE_TEMPLATE/02b-net9-question-or-issue.yml
@@ -1,0 +1,15 @@
+name: .NET 9 issue or question
+description: Ask questions or raise issues related to .NET 9
+labels: [".NET 9"]
+body: 
+- type: markdown
+  attributes:
+    value: |
+      Please use this template for any issues you have using .NET 9 or for any questions not answered in our [tracking thread for .NET 9 GA support](https://github.com/Azure/azure-functions-dotnet-worker/issues/2817).
+- id: description
+  type: textarea
+  attributes:
+    label: Description
+    placeholder: Please provide a succinct description of the question or issue. For issue reports, please include the versions of the Azure Functions packages your projects references.
+  validations:
+    required: true


### PR DESCRIPTION
Adding an issue template in advance of the .NET 9 GA release. File naming should make this the third template in our list, after the general bug report and feature request templates.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
