### PR TITLE
Switch durable for storage in test project

### DIFF
--- a/test/Resources/Projects/FunctionApp01/FunctionApp01.csproj
+++ b/test/Resources/Projects/FunctionApp01/FunctionApp01.csproj
@@ -12,15 +12,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-
-    <!-- DurableTask has an implicit extension, which we want to validate -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.7" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer " Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="$(SdkVersion)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../FunctionLib01/FunctionLib01.csproj" />
+    <ProjectReference Include="../FunctionExt01/FunctionExt01.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Resources/Projects/FunctionExt01/FunctionExt01.csproj
+++ b/test/Resources/Projects/FunctionExt01/FunctionExt01.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Force a WebJobs extension to be included without any usage of it. -->
+    <AssemblyAttribute Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions.ExtensionInformationAttribute">
+      <_Parameter1>Microsoft.Azure.WebJobs.Extensions.Storage</_Parameter1>
+      <_Parameter2>5.3.1</_Parameter2>
+      <_Parameter3>true</_Parameter3>
+      <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/test/SdkE2ETests/InnerBuildTests.cs
+++ b/test/SdkE2ETests/InnerBuildTests.cs
@@ -34,19 +34,19 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
             JToken expectedExtensionsJson = JObject.Parse(@"{
   ""extensions"": [
     {
-      ""name"": ""SqlDurabilityProvider"",
-      ""typeName"": ""DurableTask.SqlServer.AzureFunctions.SqlDurabilityProviderStartup, DurableTask.SqlServer.AzureFunctions, Version=1.4.0.0, Culture=neutral, PublicKeyToken=2ea3c3a96309d850"",
-      ""hintPath"": ""./.azurefunctions/DurableTask.SqlServer.AzureFunctions.dll""
-    },
-    {
-      ""name"": ""DurableTask"",
-      ""typeName"": ""Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.DurableTask, Version=2.0.0.0, Culture=neutral, PublicKeyToken=014045d636e89289"",
-      ""hintPath"": ""./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll""
-    },
-    {
       ""name"": ""Startup"",
       ""typeName"": ""Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.Startup, Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=551316b6919f366c"",
       ""hintPath"": ""./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.FunctionMetadataLoader.dll""
+    },
+    {
+      ""name"": ""AzureStorageBlobs"",
+      ""typeName"": ""Microsoft.Azure.WebJobs.Extensions.Storage.AzureStorageBlobsWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.Storage.Blobs, Version=5.3.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8"",
+      ""hintPath"": ""./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll""
+    },
+    {
+      ""name"": ""AzureStorageQueues"",
+      ""typeName"": ""Microsoft.Azure.WebJobs.Extensions.Storage.AzureStorageQueuesWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.Storage.Queues, Version=5.1.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8"",
+      ""hintPath"": ""./.azurefunctions/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll""
     }
   ]
 }");


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Changes our test resources to use storage webjobs extension instead of durable to avoid some transitive issues.
