### PR TITLE
host.json: Ignore comments and trailing commas

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMidd
 
         private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
-            PropertyNameCaseInsensitive = true
+            AllowTrailingCommas = true,
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
         };
 
 


### PR DESCRIPTION
Because commenting your configuration is a good idea. 

Fixes error stacks similar this:

```
System.Text.Json.JsonException:
   at System.Text.Json.ThrowHelper.ReThrowWithPath (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.JsonSerializer.ReadFromSpan (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.JsonSerializer.ReadFromSpan (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.JsonSerializer.Deserialize (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMiddleware.FunctionsEndpointDataSource.GetRoutePrefix (Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore, Version=1.3.2.0, Culture=neutral, PublicKeyToken=551316b6919f366c: /mnt/vss/_work/1/s/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs:135)
   at Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMiddleware.FunctionsEndpointDataSource.GetRoutePrefixFromHostJson (Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore, Version=1.3.2.0, Culture=neutral, PublicKeyToken=551316b6919f366c: /mnt/vss/_work/1/s/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs:129)
   at Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMiddleware.FunctionsEndpointDataSource.BuildEndpoints (Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore, Version=1.3.2.0, Culture=neutral, PublicKeyToken=551316b6919f366c: /mnt/vss/_work/1/s/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs:61)
   at Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.AspNetMiddleware.FunctionsEndpointDataSource.get_Endpoints (Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore, Version=1.3.2.0, Culture=neutral, PublicKeyToken=551316b6919f366c: /mnt/vss/_work/1/s/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsEndpointDataSource.cs:44)
   at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.CreateEndpointsUnsynchronized (Microsoft.AspNetCore.Routing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.EnsureEndpointsInitialized (Microsoft.AspNetCore.Routing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.get_Endpoints (Microsoft.AspNetCore.Routing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at Microsoft.AspNetCore.Routing.DataSourceDependentCache`1.Initialize (Microsoft.AspNetCore.Routing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at System.Threading.LazyInitializer.EnsureInitializedCore (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Microsoft.AspNetCore.Routing.Matching.DataSourceDependentMatcher..ctor (Microsoft.AspNetCore.Routing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at Microsoft.AspNetCore.Routing.Matching.DfaMatcherFactory.CreateMatcher (Microsoft.AspNetCore.Routing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.InitializeCoreAsync (Microsoft.AspNetCore.Routing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware+<<Invoke>g__AwaitMatcher|10_0>d.MoveNext (Microsoft.AspNetCore.Routing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol+<ProcessRequests>d__238`1.MoveNext (Microsoft.AspNetCore.Server.Kestrel.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
Inner exception System.Text.Json.JsonReaderException handled at System.Text.Json.ThrowHelper.ReThrowWithPath:
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.Utf8JsonReader.ConsumeNextToken (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.Utf8JsonReader.ConsumeNextTokenOrRollback (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.Utf8JsonReader.ReadSingleSegment (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.Utf8JsonReader.Read (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore (System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
```

There are probably other places change, but this is the mentioned above.

see https://github.com/Azure/azure-functions-dotnet-worker/issues/2855
