### PR TITLE
Bringing back .NET 7 sample temporarily

### DIFF
--- a/samples/Net7Worker/EventHubCancellationToken.cs
+++ b/samples/Net7Worker/EventHubCancellationToken.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Net7Worker
+{
+    public class EventHubCancellationToken
+    {
+        private readonly ILogger _logger;
+
+        public EventHubCancellationToken(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<EventHubCancellationToken>();
+        }
+
+        // Sample showing how to handle a cancellation token being received
+        // In this example, the function invocation status will be "Cancelled"
+        //<docsnippet_cancellation_token_throw>
+        [Function(nameof(ThrowOnCancellation))]
+        public async Task ThrowOnCancellation(
+            [EventHubTrigger("sample-workitem-1", Connection = "EventHubConnection")] string[] messages,
+            FunctionContext context,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("C# EventHub {functionName} trigger function processing a request.", nameof(ThrowOnCancellation));
+
+            foreach (var message in messages)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Delay(6000); // task delay to simulate message processing
+                _logger.LogInformation("Message '{msg}' was processed.", message);
+            }
+        }
+        //</docsnippet_cancellation_token_throw>
+
+        // Sample showing how to take precautionary/clean up actions if a cancellation token is received
+        // In this example, the function invocation status will be "Successful"
+        //<docsnippet_cancellation_token_cleanup>
+        [Function(nameof(HandleCancellationCleanup))]
+        public async Task HandleCancellationCleanup(
+            [EventHubTrigger("sample-workitem-2", Connection = "EventHubConnection")] string[] messages,
+            FunctionContext context,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("C# EventHub {functionName} trigger function processing a request.", nameof(HandleCancellationCleanup));
+
+            foreach (var message in messages)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogInformation("A cancellation token was received, taking precautionary actions.");
+                    // Take precautions like noting how far along you are with processing the batch
+                    _logger.LogInformation("Precautionary activities complete.");
+                    break;
+                }
+
+                await Task.Delay(6000); // task delay to simulate message processing
+                _logger.LogInformation("Message '{msg}' was processed.", message);
+            }
+        }
+        //</docsnippet_cancellation_token_cleanup>
+    }
+}

--- a/samples/Net7Worker/README.md
+++ b/samples/Net7Worker/README.md
@@ -1,0 +1,22 @@
+# Former sample for .NET 7 Worker
+
+This sample has been removed, as support for .NET 7 ended on May 14, 2024. The `EventHubCancellationToken.cs` file is being temporarily preserved.
+
+### EventHubCancellationToken.cs
+
+Demonstrates how to use the Cancellation Token parameter binding in the context of an
+EventHub trigger sample where we are processing multiple messages.
+
+- `ThrowOnCancellation`
+  - shows how to throw when a cancellation token is received
+  - the status of the function will be "Cancelled"
+- `HandleCancellationCleanup`
+  - shows how to take precautionary/clean up actions if a cancellation token is received
+  - the status of the function will be "Successful"
+
+Cancellation tokens are signalled by the platform, the use cases supported today are:
+
+1. Sudden host shutdown or host restart
+2. Function timeout (where function execution has exceeded the timeout limit)
+   1. You can try this out by setting function timeout to 5 seconds in
+      the host.json file: `"functionTimeout": "00:00:05"`


### PR DESCRIPTION
This is to fix an issue in docs that cannot be addressed there right now. Please see me directly for details.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)