### PR TITLE
Fix 'AZURE_FUNCTIONS_' not respected in app builder

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Worker (metapackage) <version>
 
-- <entry>
+- `AZURE_FUNCTIONS_` environment variables are now loaded correctly when using `FunctionsApplicationBuilder`. (#2878)
 
 ### Microsoft.Azure.Functions.Worker.Core <version>
 

--- a/src/DotNetWorker/Builder/FunctionsApplicationBuilder.cs
+++ b/src/DotNetWorker/Builder/FunctionsApplicationBuilder.cs
@@ -30,6 +30,7 @@ public class FunctionsApplicationBuilder : IHostApplicationBuilder, IFunctionsWo
     internal FunctionsApplicationBuilder(string[]? args)
     {
         var configuration = new ConfigurationManager();
+        configuration.AddEnvironmentVariables("AZURE_FUNCTIONS_");
 
         _hostApplicationBuilder = new HostApplicationBuilder(new HostApplicationBuilderSettings
         {

--- a/test/DotNetWorkerTests/Builder/FunctionsApplicationBuilderTests.cs
+++ b/test/DotNetWorkerTests/Builder/FunctionsApplicationBuilderTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests.Builder
+{
+    public class FunctionsApplicationBuilderTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Development")]
+        [InlineData("Staging")]
+        [InlineData("Production")]
+        [InlineData("Other")]
+        public void CreateBuilder_AzureFunctionsEnvironment_IsSet(string value)
+        {
+            // Explicitly set to null to ensure this is not impacted by any existing value.
+            Environment.SetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT", null);
+            Environment.SetEnvironmentVariable("ENVIRONMENT", null);
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", null);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+            if (!string.IsNullOrEmpty(value))
+            {
+                Environment.SetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT", value);
+            }
+
+            var builder = FunctionsApplication.CreateBuilder([]);
+            Assert.Equal(value, builder.Configuration["ENVIRONMENT"]);
+            Assert.Equal(value ?? "Production", builder.Environment.EnvironmentName);
+
+            IHost host = builder.Build();
+            IConfiguration config = host.Services.GetService<IConfiguration>();
+            IHostEnvironment env = host.Services.GetService<IHostEnvironment>();
+            Assert.Equal(value, config["ENVIRONMENT"]);
+            Assert.Equal(value ?? "Production", env.EnvironmentName);
+        }
+    }
+}

--- a/test/DotNetWorkerTests/Builder/FunctionsApplicationBuilderTests.cs
+++ b/test/DotNetWorkerTests/Builder/FunctionsApplicationBuilderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
+using FuncApp = Microsoft.Azure.Functions.Worker.Builder.FunctionsApplication;
 
 namespace Microsoft.Azure.Functions.Worker.Tests.Builder
 {
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests.Builder
                 Environment.SetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT", value);
             }
 
-            var builder = FunctionsApplication.CreateBuilder([]);
+            var builder = FuncApp.CreateBuilder([]);
             Assert.Equal(value, builder.Configuration["ENVIRONMENT"]);
             Assert.Equal(value ?? "Production", builder.Environment.EnvironmentName);
 

--- a/test/DotNetWorkerTests/FunctionMetadata/DefaultFunctionMetadataTests.cs
+++ b/test/DotNetWorkerTests/FunctionMetadata/DefaultFunctionMetadataTests.cs
@@ -1,11 +1,11 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
 using Xunit;
 
-namespace DotNetWorkerTests.FunctionMetadata
+namespace Microsoft.Azure.Functions.Worker.Tests.FunctionMetadata
 {
     public class DefaultFunctionMetadataTests
     {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #2876

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Addresses issue with `AZURE_FUNCTIONS_` environment variables not being bootstrapped when using `IFunctionsApplicationBuilder`.
