### PR TITLE
Update FromBody converter to utilize DeserializeAsync

### DIFF
--- a/extensions/Worker.Extensions.Http/release_notes.md
+++ b/extensions/Worker.Extensions.Http/release_notes.md
@@ -6,4 +6,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http <version>
 
-- <entry>
+- The 'FromBody' converter now utilizes `DeserializeAsync` for deserializing JSON content from the request body, enhancing support for asynchronous deserialization. (#<PR>)

--- a/extensions/Worker.Extensions.Http/release_notes.md
+++ b/extensions/Worker.Extensions.Http/release_notes.md
@@ -6,4 +6,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http <version>
 
-- The 'FromBody' converter now utilizes `DeserializeAsync` for deserializing JSON content from the request body, enhancing support for asynchronous deserialization. (#<PR>)
+- The 'FromBody' converter now utilizes `DeserializeAsync` for deserializing JSON content from the request body, enhancing support for asynchronous deserialization. (#2901)

--- a/extensions/Worker.Extensions.Http/src/DefaultFromBodyConversionFeature.cs
+++ b/extensions/Worker.Extensions.Http/src/DefaultFromBodyConversionFeature.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http
             return ConvertBodyAsync(requestData, context, targetType);
         }
 
-        private static ValueTask<object?> ConvertBodyAsync(HttpRequestData requestData, FunctionContext context, Type targetType)
+        private static async ValueTask<object?> ConvertBodyAsync(HttpRequestData requestData, FunctionContext context, Type targetType)
         {
             object? result;
 
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http
                 ObjectSerializer serializer = requestData.FunctionContext.InstanceServices.GetService<IOptions<WorkerOptions>>()?.Value?.Serializer
                  ?? throw new InvalidOperationException("A serializer is not configured for the worker.");
 
-                result = serializer.Deserialize(requestData.Body, targetType, context.CancellationToken);
+                result = await serializer.DeserializeAsync(requestData.Body, targetType, context.CancellationToken);
             }
             else
             {

--- a/extensions/Worker.Extensions.Http/src/DefaultFromBodyConversionFeature.cs
+++ b/extensions/Worker.Extensions.Http/src/DefaultFromBodyConversionFeature.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -46,44 +47,23 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http
             return ConvertBodyAsync(requestData, context, targetType);
         }
 
-        private static async ValueTask<object?> ConvertBodyAsync(HttpRequestData requestData, FunctionContext context, Type targetType)
+        private static async ValueTask<object?> ConvertBodyAsync(HttpRequestData requestData, FunctionContext context, Type targetType) => targetType switch
         {
-            object? result;
+            _ when targetType == typeof(string) => await requestData.ReadAsStringAsync(),
+            _ when targetType == typeof(byte[]) => await ReadBytesAsync(requestData),
+            _ when targetType == typeof(Memory<byte>) => new Memory<byte>(await ReadBytesAsync(requestData)),
+            _ when HasJsonContentType(requestData) =>
+                    await (requestData.FunctionContext.InstanceServices.GetService<IOptions<WorkerOptions>>()?.Value?.Serializer
+                            ?? throw new InvalidOperationException("A serializer is not configured for the worker."))
+                        .DeserializeAsync(requestData.Body, targetType, context.CancellationToken),
+            _ => throw new InvalidOperationException($"The type '{targetType}' is not supported by the '{nameof(DefaultFromBodyConversionFeature)}'.")
+        };
 
-            if (targetType == typeof(string))
-            {
-                result = requestData.ReadAsString();
-            }
-            else if (targetType == typeof(byte[]))
-            {
-                result = ReadBytes(requestData, context.CancellationToken);
-            }
-            else if (targetType == typeof(Memory<byte>))
-            {
-                Memory<byte> bytes = ReadBytes(requestData, context.CancellationToken);
-                result = bytes;
-            }
-            else if (HasJsonContentType(requestData))
-            {
-                ObjectSerializer serializer = requestData.FunctionContext.InstanceServices.GetService<IOptions<WorkerOptions>>()?.Value?.Serializer
-                 ?? throw new InvalidOperationException("A serializer is not configured for the worker.");
-
-                result = await serializer.DeserializeAsync(requestData.Body, targetType, context.CancellationToken);
-            }
-            else
-            {
-                throw new InvalidOperationException($"The type '{targetType}' is not supported by the '{nameof(DefaultFromBodyConversionFeature)}'.");
-            }
-
-            return new ValueTask<object?>(result);
-        }
-
-        private static byte[] ReadBytes(HttpRequestData requestData, CancellationToken cancellationToken)
+        private static async Task<byte[]> ReadBytesAsync(HttpRequestData requestData)
         {
-            var bytes = new byte[requestData.Body.Length];
-            requestData.Body.Read(bytes, 0, bytes.Length);
-
-            return bytes;
+            using var memoryStream = new MemoryStream();
+            await requestData.Body.CopyToAsync(memoryStream);
+            return memoryStream.ToArray();
         }
 
         private static bool HasJsonContentType(HttpRequestData request)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

n/a

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The 'FromBody' converter now utilizes `DeserializeAsync` for deserializing JSON content from the request body, enhancing support for asynchronous deserialization.
