### PR TITLE
Add missing attributes for kafka trigger

### DIFF
--- a/extensions/Worker.Extensions.Kafka/src/KafkaDataType.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaDataType.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
-    /// Defines the message type for key or value as enum.
+    /// Defines data types as enum.
     /// </summary>
-    public enum KafkaMessageKeyDataType
+    public enum KafkaDataType
     {
         Int = 0,
         Long,

--- a/extensions/Worker.Extensions.Kafka/src/KafkaMessageDataType.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaMessageDataType.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// Defines the message type for key or value as enum.
+    /// </summary>
+    public enum KafkaMessageKeyDataType
+    {
+        Int = 0,
+        Long,
+        String,
+        Float,
+        Double,
+        Binary
+    }
+}

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Functions.Worker
         /// If KeyAvroSchema is set, this value is ignored and the key will be serialized using Avro.
         /// The default type is System.String.
         /// </summary>
-        public KafkaMessageKeyDataType KeyDataType { get; set; } = KafkaMessageKeyDataType.String;
+        public KafkaDataType KeyDataType { get; set; } = KafkaDataType.String;
 
         /// <summary>
         /// SASL mechanism to use for authentication. 

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
@@ -40,10 +40,24 @@ namespace Microsoft.Azure.Functions.Worker
         public string ConsumerGroup { get; set; }
 
         /// <summary>
-        /// Gets or sets the Avro schema.
+        /// Gets or sets the Avro schema of message value.
         /// Should be used only if a generic record should be generated
         /// </summary>
         public string AvroSchema { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Avro schema of message key.
+        /// Should be used only if a generic record should be generated
+        /// </summary>
+        public string KeyAvroSchema { get; set; }
+
+        /// <summary>
+        /// Specifies the data type of the message key.
+        /// This data type will be used to serialize the key before sending it to the Kafka topic.
+        /// If KeyAvroSchema is set, this value is ignored and the key will be serialized using Avro.
+        /// The default type is System.String.
+        /// </summary>
+        public KafkaMessageKeyDataType KeyDataType { get; set; } = KafkaMessageKeyDataType.String;
 
         /// <summary>
         /// SASL mechanism to use for authentication. 


### PR DESCRIPTION
### Issue describing the changes in this PR
To support changes made to Kafka Extension here - https://github.com/Azure/azure-functions-kafka-extension/pull/534. Currently in draft stage till the changes in Extension are made live.

Adds two attributes 
- `KeyDataType`
- `KeyAvroSchema`

Adds a data model to go with `KeyDataType`:
- `KafkaMessageKeyDataType`