### PR TITLE
Adding global usings

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Targets/Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.props
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Targets/Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.props
@@ -1,0 +1,27 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+
+  <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+    <!-- Based on https://github.com/dotnet/sdk/blob/main/src/WebSdk/Web/Targets/Sdk.Server.props -->
+    <Using Include="System.Net.Http.Json" />
+    <Using Include="Microsoft.AspNetCore.Builder" />
+    <Using Include="Microsoft.AspNetCore.Hosting" />
+    <Using Include="Microsoft.AspNetCore.Http" />
+    <Using Include="Microsoft.AspNetCore.Routing" />
+    <Using Include="Microsoft.Extensions.Configuration" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Microsoft.Extensions.Hosting" />
+    <Using Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+    
+</Project>

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
@@ -26,4 +26,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="Targets\**">
+        <Pack>true</Pack>
+        <PackagePath>build</PackagePath>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.props
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.props
@@ -36,6 +36,17 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <CompilerVisibleProperty Include="TargetFrameworkIdentifier" />
     <CompilerVisibleProperty Include="FunctionsExecutionModel" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+    <Using Include="Microsoft.Azure.Functions.Worker" />
+    <Using Include="Microsoft.Azure.Functions.Worker.Builder" />
+    <!-- Based on https://github.com/dotnet/sdk/blob/main/src/WebSdk/Worker/Targets/Microsoft.NET.Sdk.Worker.props -->  
+    <Using Include="Microsoft.Extensions.Configuration" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Microsoft.Extensions.Hosting" />
+    <Using Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+       
 <!--
   ***********************************************************************************************
   Import the Publish Props


### PR DESCRIPTION
Adding support for global usings as part of the Functions SDK, based on what we see in the .NET SDK. This would allow users to remove usings from their projects, and we can update the templates to remove them as well.

Creating as a draft, as there are a few questions to resolve, and the PR checklist itself can't be fully completed yet.

### Discussion of PR checklist topics

I think documentation changes would be needed here to at least cover the version requirement and generally set context The change would allow us to trim some usings from code snippets, but I am not sure if we _should_ do that. Due to other versions still being extant, I think it may be appropriate to keep those, at least for some time. Leaving them will create some copy/paste of unnecessary lines, which isn't too big a concern. However, I'm open to making some targeted adjustments where we see fit.

To that end, if we take this forward, we'll want to plan on templates changes which correspond to it. The trick to those is that the item templates can be slightly divorced from the Functions worker SDK reference. That should be manageable (maybe through post-actions), but we would need to evaluate the scenarios there to ensure we don't drop usings in situations where these changes aren't present.

I will update the release notes as part of an update of the PR before it is ready for review.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)