### PR TITLE
Revert "Patch Http.AspNetCore extension package" & update release notes

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -4,10 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 1.3.3
 
-- Addressing fix for AspNetCoreResponseCookies cookie defaults (#2811)
-- Update `ContextReference` to no longer use a given invocation's cancellation token (#2894)
+- Update `ContextReference` to no longer use a given invocation's cancellation token (#2931)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Analyzers  <version>
 

--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -4,8 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 1.3.4
+### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore <version>
 
+- Addressing fix for AspNetCoreResponseCookies cookie defaults (#2811)
 - Update `ContextReference` to no longer use a given invocation's cancellation token (#2894)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Analyzers  <version>

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <Description>ASP.NET Core extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>1.3.4</VersionPrefix>
+    <VersionPrefix>1.3.3</VersionPrefix>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
Got to the final stage of release only to realize 1.3.3 doesn't exist