### PR TITLE
Clear release notes

### DIFF
--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -4,7 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.11.0
+### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB <version>
 
-- Updated `Microsoft.Azure.WebJobs.Extensions.CosmosDB` reference to 4.8.0
-- Updated `Microsoft.Extensions.Azure` dependency to 1.7.5
+- <entry>

--- a/extensions/Worker.Extensions.EventGrid/release_notes.md
+++ b/extensions/Worker.Extensions.EventGrid/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.EventGrid 3.4.2
+### Microsoft.Azure.Functions.Worker.Extensions.EventGrid <version>
 
-- Updated `Microsoft.Azure.WebJobs.Extensions.EventGrid` reference to 3.4.2
+- <entry>

--- a/extensions/Worker.Extensions.EventHubs/release_notes.md
+++ b/extensions/Worker.Extensions.EventHubs/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.EventHubs 6.3.6
+### Microsoft.Azure.Functions.Worker.Extensions.EventHubs <version>
 
-- Updated `Microsoft.Extensions.Azure` reference to 1.7.5
+- <entry>

--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -4,9 +4,10 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 1.3.3
+### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore <version>
 
-- Update `ContextReference` to no longer use a given invocation's cancellation token (#2931)
+- <entry>
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Analyzers  <version>
 
+- <entry>

--- a/extensions/Worker.Extensions.Http/release_notes.md
+++ b/extensions/Worker.Extensions.Http/release_notes.md
@@ -6,5 +6,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http <version>
 
-- The 'FromBody' converter now utilizes `DeserializeAsync` for deserializing JSON content from the request body, enhancing support for asynchronous deserialization. (#2901)
-- Update `DefaultFromBodyConversionFeature` to no longer use a given invocation's cancellation token (#2894)
+- <entry>

--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -4,7 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Kafka 4.0.0
+### Microsoft.Azure.Functions.Worker.Extensions.Kafka <version>
 
-- Add OAuthBearer trigger and output Attributes to the dotnet isolated model(#2799)
-- Update kafka extension version to 4.0.0(#2799)
+- <entry>

--- a/extensions/Worker.Extensions.Rpc/release_notes.md
+++ b/extensions/Worker.Extensions.Rpc/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Rpc 1.0.1
+### Microsoft.Azure.Functions.Worker.Extensions.Rpc <version>
 
-- Set max message send and receive length on gRPC `CallInvoker`.
+- <entry>

--- a/extensions/Worker.Extensions.ServiceBus/release_notes.md
+++ b/extensions/Worker.Extensions.ServiceBus/release_notes.md
@@ -4,7 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.ServiceBus 5.22.0
+### Microsoft.Azure.Functions.Worker.Extensions.ServiceBus <version>
 
-- Updated `Azure.Identity` reference to 1.12.0
-- Updated `Microsoft.Extensions.Azure` to 1.7.5
+- <entry>

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,16 +4,14 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker (metapackage) 1.24.0
+### Microsoft.Azure.Functions.Worker (metapackage) <version>
 
-- Updating `Microsoft.Azure.Functions.Worker.Core` to 1.20.0
-- Updating `Microsoft.Azure.Functions.Worker.Grpc` to 1.18.0
+- <entry>
 
-### Microsoft.Azure.Functions.Worker.Core 1.20.0
+### Microsoft.Azure.Functions.Worker.Core <version>
 
-- Updated service registrations for bootstrapping methods to ensure idempotency. (#2820)
+- <entry>
 
-### Microsoft.Azure.Functions.Worker.Grpc 1.18.0
+### Microsoft.Azure.Functions.Worker.Grpc <version>
 
-- Changed exception handling in function invocation path to ensure fatal exceptions bubble up. (#2789)
-- Updated service registrations for bootstrapping methods to ensure idempotency. (#2820)
+- <entry>

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -8,6 +8,10 @@
 
 - <entry>
 
+### Microsoft.Azure.Functions.Worker.Sdk.Analyzers <version>
+
+- <entry>
+
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 
 - <entry>


### PR DESCRIPTION
Clear release notes for v1.x. This should be a clean slate other than for backports that are necessary.