### PR TITLE
Use p2p reference for external ext proj entry point

### DIFF
--- a/samples/ExternalExtensionProject/App/ExternalExtensionProject.App.csproj
+++ b/samples/ExternalExtensionProject/App/ExternalExtensionProject.App.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0-preview.1" /> <!-- TODO: add this to samples sln when this package is published. -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Ext/ExternalExtensionProject.Ext.csproj" ReferenceOutputAssembly="false" WorkerExtensions="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ExternalExtensionProject/App/ExternalExtensionProject.App.csproj
+++ b/samples/ExternalExtensionProject/App/ExternalExtensionProject.App.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Ext/ExternalExtensionProject.Ext.csproj" ReferenceOutputAssembly="false" WorkerExtensions="false" />
+    <ProjectReference Include="../Ext/ExternalExtensionProject.Ext.csproj" ReferenceOutputAssembly="false" WorkerExtensions="true" />
   </ItemGroup>
 
 </Project>

--- a/samples/ExternalExtensionProject/App/Program.cs
+++ b/samples/ExternalExtensionProject/App/Program.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = FunctionsApplication.CreateBuilder(args);
+var host = builder.Build();
+host.Run();

--- a/samples/ExternalExtensionProject/App/QueueFunction.cs
+++ b/samples/ExternalExtensionProject/App/QueueFunction.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Azure.Storage.Queues.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace ExternalExtensionProject.App;
+
+public class QueueFunction(ILogger<QueueFunction> logger)
+{
+    /// <summary>
+    /// This function demonstrates binding to a single <see cref="QueueMessage"/>.
+    /// </summary>
+    [Function(nameof(QueueMessageFunction))]
+    public void QueueMessageFunction([QueueTrigger("input-queue")] QueueMessage message)
+    {
+        logger.LogInformation(message.MessageText);
+    }
+}

--- a/samples/ExternalExtensionProject/Ext/ExternalExtensionProject.Ext.csproj
+++ b/samples/ExternalExtensionProject/Ext/ExternalExtensionProject.Ext.csproj
@@ -1,0 +1,19 @@
+
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
+        <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.3.1" />
+    </ItemGroup>
+
+    <Target Name="_VerifyTargetFramework" BeforeTargets="Build">
+        <!-- It is possible to override our TFM via global properties. This can lead to successful builds, but runtime errors due to incompatible dependencies being brought in. -->
+        <Error Condition="'$(TargetFramework)' != 'net6.0'" Text="The target framework '$(TargetFramework)' must be 'net6.0'. Verify if target framework has been overridden by a global property." />
+    </Target>
+</Project>

--- a/samples/ExternalExtensionProject/README.md
+++ b/samples/ExternalExtensionProject/README.md
@@ -1,0 +1,79 @@
+# External Extension Project
+
+This sample shows how to supply the worker extension project manually.
+
+## What is the worker extension project?
+
+To enable extensions in dotnet-isolated function apps an extension bundle needs to be loaded into the host process (separate from your worker process). For example, if you use `Microsoft.Azure.Functions.Worker.Extensions.ServiceBus`, an host-side extension `Microsoft.Azure.WebJobs.Extensions.ServiceBus` also needs to be loaded into the function host.
+
+Loading of these extensions is accomplished by build steps provided by `Microsoft.Azure.Functions.Worker.Sdk`. These steps will scan for WebJobs extensions indicated by Worker extensions. These extensions are collected and a _new_ csproj is dynamically generated during build called `WorkerExtensions.csproj`. This project is then restored, built, and outputs collected into the `.azurefunctions` folder of your function app build output. This process is often referred to as the "extension inner-build".
+
+## What is this scenario for?
+
+For most customers, this inner-build process is frictionless and requires no customization. However, for some customers this process conflicts with some external factors (no network during build, nuget feed auth issues, among others). To accommodate these conflicts SDK `2.1.0` and on supports the ability to externally supply this extension project, giving full control of the extension project to the customer. This project can now be restored and built alongside the function app. Since the csproj is controlled by the customer, any changes can be made to it.
+
+There is a major drawback though: ensuring the extension project builds a *valid* payload is now the customer's responsibility. Failures to build a valid payload will only be discovered at runtime. Issues may be obscure and varied, from assembly load failures, method missing exceptions, to odd behavior due to mismatching worker & webjobs extensions. Any time the set of extensions for the function app changes, this external project will need to be manually updated. As such, this scenario is only recommended if customization is **absolutely** necessary.
+
+## How
+
+### 1. Prepare the project for external extension
+Add the follow item to your csproj:
+
+``` diff
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
++  <ItemGroup>
++    <ProjectReference Include="{{path-to-extension-csproj}}" ReferenceOutputAssembly="false" WorkerExtensions="false" />
++  </ItemGroup>
+
+  <!-- rest of csproj -->
+</Project>
+```
+
+### 2. First time generation of external extension csproj
+
+Run a target to generate the extension project one-time:
+
+``` shell
+dotnet build -t:GenerateExtensionProject {{path-to-function-app-csproj}}
+```
+
+This will generate the same csproj as the inner-build would. Absent of any external influences by your build process (ie, directory-based imports), this project _should_ produce a valid extension bundle.
+
+> [!NOTE]
+> The target `GenerateExtensionProject` can be ran whenever to regenerate the csproj. **However**, it will overwrite the contents of the csproj indicated by `ExtensionsCsProj` each time. Make sure to re-apply any customizations you have!
+
+> [!TIP]
+> To avoid needing to re-apply customizations, this sample shows putting all custom logic into `Directory.Build.props` and `Directory.Build.targets` and leaving the csproj to always be the generated contents.
+
+### 3. Add the extension project to be built as part of your regular build
+
+If using a solution, make sure to add this new project to the solution file. Failure to do so may cause Visual Studio to skip building this project.
+
+## Things to be aware of
+
+❌ DO NOT change the `TargetFramework` of the extension project
+
+> [!CAUTION]
+> The target framework, and all dependent assemblies of this generated project, must be compatible with the host process. Changing the TFM risks assembly load failures.
+
+⚠️ AVOID changing the packages of the extension project
+
+> [!WARNING]
+> The package closure of the extension project is sensitive to changes. The host process ultimately controls the dependency graph and assembly loads. Depending on a package/assembly not supported by the host process may cause issues. E.G, trying to depend on any `Microsoft.Extensions.*/9x` from the extension project will cause issues.
+
+❌ DO NOT include more than 1 `ProjectReference` with `WorkerExtensions=true`
+
+> [!NOTE]
+> The build will be intentionally failed if there are more than 1 extension projects declared.
+
+✔️ DO set `ReferenceOutputAssembly=false` on the `ProjectReference` with `WorkerExtensions=true`
+
+> [!IMPORTANT]
+> Setting `ReferenceOutputAssembly=false` will exclude this extensions projects package references from being included in your function app. This is not done automatically as it needs to be present for restore phase (and the functions SDK targets are not present until _after_ restore).

--- a/samples/ExternalExtensionProject/README.md
+++ b/samples/ExternalExtensionProject/README.md
@@ -14,7 +14,7 @@ For most customers, this inner-build process is frictionless and requires no cus
 
 There is a major drawback though: ensuring the extension project builds a *valid* payload is now the customer's responsibility. Failures to build a valid payload will only be discovered at runtime. Issues may be obscure and varied, from assembly load failures, method missing exceptions, to odd behavior due to mismatching worker & webjobs extensions. Any time the set of extensions for the function app changes, this external project will need to be manually updated. As such, this scenario is only recommended if customization is **absolutely** necessary.
 
-## How
+## How to use external extension project feature
 
 ### 1. Prepare the project for external extension
 Add the follow item to your csproj:
@@ -29,7 +29,7 @@ Add the follow item to your csproj:
   </PropertyGroup>
 
 +  <ItemGroup>
-+    <ProjectReference Include="{{path-to-extension-csproj}}" ReferenceOutputAssembly="false" WorkerExtensions="false" />
++    <ProjectReference Include="{{path-to-extension-csproj}}" ReferenceOutputAssembly="false" WorkerExtensions="true" />
 +  </ItemGroup>
 
   <!-- rest of csproj -->

--- a/samples/ExternalExtensionProject/README.md
+++ b/samples/ExternalExtensionProject/README.md
@@ -4,9 +4,9 @@ This sample shows how to supply the worker extension project manually.
 
 ## What is the worker extension project?
 
-To enable extensions in dotnet-isolated function apps an extension bundle needs to be loaded into the host process (separate from your worker process). For example, if you use `Microsoft.Azure.Functions.Worker.Extensions.ServiceBus`, an host-side extension `Microsoft.Azure.WebJobs.Extensions.ServiceBus` also needs to be loaded into the function host.
+To support triggers and bindings in dotnet-isolated function apps, an extensions payload needs to be constructed and loaded into the host process (separate from your worker process). For example, if you use `Microsoft.Azure.Functions.Worker.Extensions.ServiceBus`, a host-side extension `Microsoft.Azure.WebJobs.Extensions.ServiceBus` also needs to be loaded into the function host.
 
-Loading of these extensions is accomplished by build steps provided by `Microsoft.Azure.Functions.Worker.Sdk`. These steps will scan for WebJobs extensions indicated by Worker extensions. These extensions are collected and a _new_ csproj is dynamically generated during build called `WorkerExtensions.csproj`. This project is then restored, built, and outputs collected into the `.azurefunctions` folder of your function app build output. This process is often referred to as the "extension inner-build".
+Collecting these extensions to be loaded is accomplished by build steps provided by `Microsoft.Azure.Functions.Worker.Sdk`. These steps will scan for WebJobs extensions indicated by Worker extensions. These extensions are added as `PackageReference`'s to a _new_ `WorkerExtensions.csproj` which is dynamically generated during build. This project is then restored, built, and outputs collected into the `.azurefunctions` folder of your function app build output. This process is often referred to as the "extension inner-build".
 
 ## What is this scenario for?
 
@@ -44,7 +44,7 @@ Run a target to generate the extension project one-time:
 dotnet build -t:GenerateExtensionProject {{path-to-function-app-csproj}}
 ```
 
-This will generate the same csproj as the inner-build would. Absent of any external influences by your build process (ie, directory-based imports), this project _should_ produce a valid extension bundle.
+This will generate the same csproj as the inner-build would. Absent of any external influences by your build process (ie, directory-based imports), this project _should_ produce a valid extension payload.
 
 > [!NOTE]
 > The target `GenerateExtensionProject` can be ran whenever to regenerate the csproj. **However**, it will overwrite the contents of the csproj indicated by `ExtensionsCsProj` each time. Make sure to re-apply any customizations you have!
@@ -55,6 +55,50 @@ This will generate the same csproj as the inner-build would. Absent of any exter
 ### 3. Add the extension project to be built as part of your regular build
 
 If using a solution, make sure to add this new project to the solution file. Failure to do so may cause Visual Studio to skip building this project.
+
+## Example Scenarios
+
+### Scenario 1. No-network build phase
+
+In some cases, a CI's build phase may restrict network access. If this network restriction blocks access to nuget feeds, then the extension inner-build will fail. Using external extension project and ensuring it is part of your existing restore phase will workaround this issue. No project customization is needed by default, unless there are rules enforced by your CI (such as mandating central package versioning). The exact changes needed in those cases will be your responsibility to determine and implement.
+
+### Scenario 2. Authenticated nuget feeds
+
+The extension inner-build inherits the nuget configuration of your function app. If the configured feeds require authentication there are two routes:
+
+1. First, see if you can authenticate using your CI's features. For example, in Azure Devops see [NuGetAuthenticate@1](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/nuget-authenticate-v1?view=azure-pipelines).
+2. If option 1 does not work and there is no feasible way to pass in authentication context into the extension inner-build, then performing same steps as [scenario 1](#scenario-1-no-network-build-phase) may workaround the auth issue.
+
+### Scenario 3. Extension development testing
+
+This feature is useful for extension development itself, as the `PackageReference` for the WebJobs extension can be replaced with a `ProjectReference`.
+
+``` diff
+<ItemGroup>
+  <PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" PrivateAssets="all" />
+  <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
+- <PackageReference Include="Some.WebJobs.Extension.In.Development" Version="1.0.0" />
++ <ProjectReference Include="../Some.WebJobs.Extension.In.Development/Some.WebJobs.Extension.In.Development.csproj" />
+</ItemGroup>
+```
+
+With the above change you can have a function app to locally test your extension without any need for nuget pack and publishing.
+
+### Scenario 4. Pinning a transitive dependency
+
+In the case where an extension brings in a transitive dependency that is not compliant with some CI scans or rules you have, you can manually pin it to an in-compliance version.
+
+``` diff
+<ItemGroup>
+  <PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" PrivateAssets="all" />
+  <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
+  <PackageReference Include="Some.WebJobs.Extension" Version="1.0.0" />
++ <PackageReference Include="Some.Transitive.Dependency" Version="1.1.0" />
+</ItemGroup>
+```
+
+> [!CAUTION]
+> Be very careful with this scenario, as pinning may bring in runtime breaking changes. Especially be careful about pinning across major versions. If the transitive dependency is `vN.x.x`, and you pin to `vN+y.x.x`, this may lead to runtime failures. It is recommended you validate the version you are pinning to is compatible with the originally requested version.
 
 ## Things to be aware of
 

--- a/samples/ExternalExtensionProject/README.md
+++ b/samples/ExternalExtensionProject/README.md
@@ -47,7 +47,7 @@ dotnet build -t:GenerateExtensionProject {{path-to-function-app-csproj}}
 This will generate the same csproj as the inner-build would. Absent of any external influences by your build process (ie, directory-based imports), this project _should_ produce a valid extension payload.
 
 > [!NOTE]
-> The target `GenerateExtensionProject` can be ran whenever to regenerate the csproj. **However**, it will overwrite the contents of the csproj indicated by `ExtensionsCsProj` each time. Make sure to re-apply any customizations you have!
+> The target `GenerateExtensionProject` can be ran whenever to regenerate the csproj. **However**, it will overwrite the contents of the csproj indicated by `ProjectReference` each time. Make sure to re-apply any customizations you have!
 
 > [!TIP]
 > To avoid needing to re-apply customizations, this sample shows putting all custom logic into `Directory.Build.props` and `Directory.Build.targets` and leaving the csproj to always be the generated contents.

--- a/samples/Net9FunctionApp/Net9FunctionApp.csproj
+++ b/samples/Net9FunctionApp/Net9FunctionApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />    
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />

--- a/samples/README.md
+++ b/samples/README.md
@@ -6,10 +6,13 @@ This folder contains a set of samples that demonstrate various scenarios.
 
 | Sample | Description  |
 | ------ | ------------ |
+|[AspNetCore Integration](./AspNetIntegration)| Demonstrates writing `HttpTrigger`s using AspNetCore integration. |
 |[Configuration](./Configuration)| Demonstrates how to configure the worker using Program.cs and WorkerOptions |
 |[Custom Middleware](./CustomMiddleware)| Demonstrates how to create and use custom middleware |
 |[Entity Framework](./EntityFramework)| Demonstrates how to work with entity framework |
+|[External Extension Project](./ExternalExtensionProject)| An advanced scenario. Demonstrates supplying the worker extension project manually. |
 |[Extensions](./Extensions)| Examples of how to work with various extensions |
 |[Function App](./FunctionApp)| Examples of using the HTTP Trigger; default project for debugging the worker SDK |
 |[.NET 7 Worker](./Net7Worker)| Demonstrates how to setup a .NET 7 Function App |
+|[.NET 9 Worker](./Net9FunctionApp)| Demonstrates how to setup a .NET 9 Function App using `HostApplicationBuilder` |
 |[.NET Framework Worker](./NetFxWorker)| Demonstrates how to setup a .NET Framework Function App |

--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -62,10 +62,8 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
         <TargetFramework>{targetFramework}</TargetFramework>
-        <Configuration>Release</Configuration>
         <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <MajorProductVersion>2</MajorProductVersion>    
+    <MajorProductVersion>2</MajorProductVersion>
+    <MinorProductVersion>1</MinorProductVersion>
+    <VersionSuffix>-preview.1</VersionSuffix>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -108,6 +108,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <PropertyGroup>
       <!-- Versions could be of several forms, such as "v4", "V4", or "v4-prerelease". This will normalize those three examples all to "v4". -->
       <_AzureFunctionsVersionStandardized>$(AzureFunctionsVersion.ToLowerInvariant().Split('-')[0])</_AzureFunctionsVersionStandardized>
+      <_FunctionsExtensionRemoveProps Condition="'$(FunctionsGenerateExtensionProject)' == 'true'">$(_FunctionsExtensionRemoveProps)ManagePackageVersionsCentrally;</_FunctionsExtensionRemoveProps>
     </PropertyGroup>
 
     <ItemGroup>
@@ -173,7 +174,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </PropertyGroup>
   </Target>
 
-  <!-- This is a no-op target purely for backwards compatibilty. Remove this with a major version rev. -->
+  <!-- This is a no-op target purely for backwards compatibility. Remove this with a major version rev. -->
   <Target Name="_FunctionsPostBuild" />
 
   <!-- Helper target to granularly order more targets. -->

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -73,6 +73,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Target Name="_FunctionsCollectWorkerExtensions">
     <ItemGroup>
       <_WorkerExtensionProject Include="@(ProjectReference)" Condition="'%(ProjectReference.WorkerExtensions)' == 'true'" />
+      <_WorkerExtensionProjectNonExistent Include="@(_WorkerExtensionProject)" Condition="!Exists('%(Identity)')" />
     </ItemGroup>
   </Target>
 
@@ -85,6 +86,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Message Condition="@(_WorkerExtensionProject->Count()) == 1" Importance="normal" Text="Using WorkerExtensions project: %(_WorkerExtensionProject.Identity)" />
     <Warning Condition="'%(_WorkerExtensionProject.ReferenceOutputAssembly)' != 'false'" Text="WorkerExtensions project should have ReferenceOutputAssembly=false." />
     <Error Condition="@(_WorkerExtensionProject->Count()) &gt; 1" Text="Only one WorkerExtensions project is allowed per function app. Found extensions:@(_WorkerExtensionProject->'%0a    %(Identity)')" />
+    <Error Condition="'@(_WorkerExtensionProjectNonExistent)' != '' AND $(_ForceGenerateExtensionProject) != 'true'" Text="The referenced worker extension project '%(_WorkerExtensionProjectNonExistent.Identity)' does not exist. Run 'dotnet build -t:GenerateExtensionProject' first." />
   </Target>
 
   <Target Name="_FunctionsGetPaths" DependsOnTargets="_FunctionsCollectWorkerExtensions;_FunctionsValidateExternalWorkerExtensions">

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -84,9 +84,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </PropertyGroup>
 
     <Message Condition="@(_WorkerExtensionProject->Count()) == 1" Importance="normal" Text="Using WorkerExtensions project: %(_WorkerExtensionProject.Identity)" />
-    <Warning Condition="'%(_WorkerExtensionProject.ReferenceOutputAssembly)' != 'false'" Text="WorkerExtensions project should have ReferenceOutputAssembly=false." />
+    <Warning Condition="'%(_WorkerExtensionProject.ReferenceOutputAssembly)' != 'false'" Text="The referenced WorkerExtensions project '%(_WorkerExtensionProjectNonExistent.Identity)' is missing ReferenceOutputAssembly=false." />
     <Error Condition="@(_WorkerExtensionProject->Count()) &gt; 1" Text="Only one WorkerExtensions project is allowed per function app. Found extensions:@(_WorkerExtensionProject->'%0a    %(Identity)')" />
-    <Error Condition="'@(_WorkerExtensionProjectNonExistent)' != '' AND $(_ForceGenerateExtensionProject) != 'true'" Text="The referenced worker extension project '%(_WorkerExtensionProjectNonExistent.Identity)' does not exist. Run 'dotnet build -t:GenerateExtensionProject' first." />
+    <Error Condition="'@(_WorkerExtensionProjectNonExistent)' != '' AND $(_ForceGenerateExtensionProject) != 'true'" Text="The referenced WorkerExtensions project '%(_WorkerExtensionProjectNonExistent.Identity)' does not exist. Run 'dotnet build -t:GenerateExtensionProject' first." />
   </Target>
 
   <Target Name="_FunctionsGetPaths" DependsOnTargets="_FunctionsCollectWorkerExtensions;_FunctionsValidateExternalWorkerExtensions">

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -70,7 +70,24 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Import Project="$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets"
           Condition="Exists('$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets')" />
 
-  <Target Name="_FunctionsGetPaths">
+  <Target Name="_FunctionsCollectWorkerExtensions">
+    <ItemGroup>
+      <_WorkerExtensionProject Include="@(ProjectReference)" Condition="'%(ProjectReference.WorkerExtensions)' == 'true'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_FunctionsValidateExternalWorkerExtensions" Condition="'@(_WorkerExtensionProject)' != ''">
+    <PropertyGroup>
+      <FunctionsGenerateExtensionProject Condition="'$(_ForceGenerateExtensionProject)' !='true'">false</FunctionsGenerateExtensionProject>
+      <ExtensionsCsProj>%(_WorkerExtensionProject.Identity)</ExtensionsCsProj>
+    </PropertyGroup>
+
+    <Message Condition="@(_WorkerExtensionProject->Count()) == 1" Importance="normal" Text="Using WorkerExtensions project: %(_WorkerExtensionProject.Identity)" />
+    <Warning Condition="'%(_WorkerExtensionProject.ReferenceOutputAssembly)' != 'false'" Text="WorkerExtensions project should have ReferenceOutputAssembly=false." />
+    <Error Condition="@(_WorkerExtensionProject->Count()) &gt; 1" Text="Only one WorkerExtensions project is allowed per function app. Found extensions:@(_WorkerExtensionProject->'%0a    %(Identity)')" />
+  </Target>
+
+  <Target Name="_FunctionsGetPaths" DependsOnTargets="_FunctionsCollectWorkerExtensions;_FunctionsValidateExternalWorkerExtensions">
     <PropertyGroup Condition="'$(FunctionsGenerateExtensionProject)' == 'true'">
       <ExtensionsCsProjDirectory Condition="'$(ExtensionsCsProjDirectory)' == '' AND '$(ExtensionsCsProj)' != ''">$([System.IO.Path]::GetDirectoryName($(ExtensionsCsProj)))</ExtensionsCsProjDirectory>
       <ExtensionsCsProjDirectory Condition="'$(ExtensionsCsProjDirectory)' == ''">$(IntermediateOutputPath)WorkerExtensions</ExtensionsCsProjDirectory>
@@ -95,17 +112,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <_SelectedFunctionVersion Include="@(_FunctionsVersion)" Condition="'%(_FunctionsVersion.Identity)' == '$(_AzureFunctionsVersionStandardized)'" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(FunctionsGenerateExtensionProject)' == 'false'">
-      <!-- Reference the externaly provided csproj, if any. -->
-      <ProjectReference Include="$(ExtensionsCsProj)" ReferenceOutputAssembly="false" />
-    </ItemGroup>
-
     <Message Condition="'$(_AzureFunctionsVersionNotSet)' == 'true'" Importance="normal" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(_DefaultAzureFunctionsVersion)'." />
     <Warning Condition="'$(CheckEolAzureFunctionsVersion)' == 'true' AND '%(_SelectedFunctionVersion.InSupport)' == 'false'" Text="Azure Functions '%(Identity)' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/azure-functions-retired-versions for more information on the support policy." />
     <Error Condition="'@(_SelectedFunctionVersion)' == ''" Text="The AzureFunctionsVersion value '$(AzureFunctionsVersion)' was not recognized. Allowed values are: @(_FunctionsVersion, ', ')." />
     <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps." />
     <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set." />
-    <Error Condition="'$(FunctionsGenerateExtensionProject)' != 'true' AND '$(ExtensionsCsProj)' == ''" Text="'ExtensionsCsProj' must be set when 'FunctionsGenerateExtensionProject' is 'false'." />
   </Target>
 
   <!-- This target is used to set up the run arguments for the function app, supporting `dotnet run` -->
@@ -168,7 +179,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     DependsOnTargets="_FunctionsGenerateCommon;_FunctionsGenerateWorkerConfig" />
 
   <!-- Generates the extension files. Generates functions.metadata and the WorkerExtension.csproj -->
-  <Target Name="_FunctionsGenerateCommon" Inputs="@(IntermediateAssembly);@(ReferencePath)" Outputs="$(_FunctionsMetadataPath);$(ExtensionsCsProj)">
+  <Target Name="_FunctionsGenerateCommon" DependsOnTargets="_FunctionsGetPaths;ResolveAssemblyReferences">
     <PropertyGroup>
       <!-- We skip generating the WorkerExtension.csproj when it is externally supplied by setting _TargetExtensionsCsProj to null. -->
       <_TargetExtensionsCsProj Condition="'$(FunctionsGenerateExtensionProject)' == 'true'">$(ExtensionsCsProj)</_TargetExtensionsCsProj>
@@ -264,13 +275,19 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <RemoveDir Directories="$(ExtensionsCsProjDirectory)" ContinueOnError="true" Condition="'$(ExtensionsCsProjDirectory)' != '' AND '$(FunctionsGenerateExtensionProject)' == 'true'" />
   </Target>
 
-  <Target Name="GenerateExtensionProject" DependsOnTargets="_ForceExtensionGenerate;Build" />
+  <Target Name="GenerateExtensionProject" DependsOnTargets="_FunctionsCollectWorkerExtensions;_ForceExtensionGenerate;_FunctionsGenerateCommon" />
 
   <Target Name="_ForceExtensionGenerate">
     <PropertyGroup>
       <!-- Forces generation. -->
+      <_ForceGenerateExtensionProject>true</_ForceGenerateExtensionProject>
       <FunctionsGenerateExtensionProject>true</FunctionsGenerateExtensionProject>
     </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Remove these p2p refs to avoid this project being built during ResolveReferenceAssemblies. -->
+      <ProjectReference Remove="@(ProjectReference->WithMetadataValue('WorkerExtensions', 'true'))" />
+    </ItemGroup>
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Azure.Functions.Worker.Sdk.Publish.targets"

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,7 +4,7 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk <version>
+### Microsoft.Azure.Functions.Worker.Sdk 2.1.0-preview.1
 
 - Addresses issue with `dotnet build --no-incremental` failing build (PR #2763, Issue #2601)
 - Addresses issue with setting `OutDir` msbuild property failing build (PR #2763, Issue #2125)

--- a/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
+++ b/test/FunctionMetadataGeneratorTests/ExtensionsCsProjGeneratorTests.cs
@@ -219,10 +219,8 @@ namespace Microsoft.Azure.Functions.SdkTests
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Configuration>Release</Configuration>
         <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
     <ItemGroup>
@@ -247,10 +245,8 @@ namespace Microsoft.Azure.Functions.SdkTests
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Configuration>Release</Configuration>
         <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

- Refactor the method for enabling external ext proj
   - This change was needed to include the ext proj in restore phase. It also is slightly more elegant.
- `GenerateExtensionProject` target no longer builds, only generates the extension project
- Adds more errors and warnings around correct configuration of external ext proj
   - Error if more than one external ext proj is referenced
   - Error if external ext proj does not exist (but is referenced)
   - Warning if external ext proj does not have `ReferenceOutputAssemblies=false`.
- Removes `Configuration=Release` and `ManagePackageVersionsCentrally=false` from generated csproj
   - Configuration is passed in via global property for non-external scenarios
   - ManagePackageVersionsCentrally was moved to the list of remove-props
- Add sample with docs around external ext proj
    - this will eventually be polished and included in official microsoft docs.
- Update SDK version to 2.1.0-preview.1
