### PR TITLE
Write metadata and worker.config only if content has changed

### DIFF
--- a/sdk/Sdk/FunctionMetadataJsonWriter.cs
+++ b/sdk/Sdk/FunctionMetadataJsonWriter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         {
             string metadataFile = Path.Combine(metadataFileDirectory, FileName);
             string newContent = JsonSerializer.Serialize(functions, s_serializerOptions);
-            if (TryReadFile(metadataFile, out string? current) && !string.Equals(current, newContent, StringComparison.Ordinal))
+            if (TryReadFile(metadataFile, out string? current) && string.Equals(current, newContent, StringComparison.Ordinal))
             {
                 // Incremental build support. Skip writing if the content is the same.
                 return;

--- a/sdk/Sdk/FunctionMetadataJsonWriter.cs
+++ b/sdk/Sdk/FunctionMetadataJsonWriter.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Functions.Worker.Sdk
 {
@@ -34,9 +36,26 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         public static void WriteMetadata(IEnumerable<SdkFunctionMetadata> functions, string metadataFileDirectory)
         {
             string metadataFile = Path.Combine(metadataFileDirectory, FileName);
-            using var fs = new FileStream(metadataFile, FileMode.Create, FileAccess.Write);
-            using var writer = new Utf8JsonWriter(fs, new JsonWriterOptions { Indented = true });
-            JsonSerializer.Serialize(writer, functions, s_serializerOptions);
+            string newContent = JsonSerializer.Serialize(functions, s_serializerOptions);
+            if (TryReadFile(metadataFile, out string? current) && !string.Equals(current, newContent, StringComparison.Ordinal))
+            {
+                // Incremental build support. Skip writing if the content is the same.
+                return;
+            }
+
+            File.WriteAllText(metadataFile, newContent);
+        }
+
+        private static bool TryReadFile(string filePath, out string? content)
+        {
+            if (File.Exists(filePath))
+            {
+                content = File.ReadAllText(filePath);
+                return true;
+            }
+
+            content = null;
+            return false;
         }
     }
 }

--- a/sdk/Sdk/FunctionMetadataJsonWriter.cs
+++ b/sdk/Sdk/FunctionMetadataJsonWriter.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Functions.Worker.Sdk
 {

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -214,7 +214,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         .Replace('$functionExe$', '$(_FunctionsExecutable)')
         .Replace('$functionWorker$', '$(TargetName)$(TargetExt)')
         .Replace('$enableWorkerIndexing$', '$(FunctionsEnableWorkerIndexing)'))"
-        Overwrite="true" />
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
   </Target>
 
   <!-- Touch up the extensions.json file as needed for .NET isolated -->

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -10,6 +10,7 @@
 - Addresses issue with setting `OutDir` msbuild property failing build (PR #2763, Issue #2125)
 - Adds support for externally supplied worker extensions project. (PR #2763, Issues #1252, #1888)
     - This mode is opt-in only. Using it eliminates the inner-build. This is useful for scenarios where performing a restore inside of build was problematic.
+- Write `worker.config` and `functions.metadata` only if contents have changed. (#2999)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.3.5
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR skips writing `worker.config` and `functions.metadata` if the contents have not changed. This improves incremental build support, particularly for internal cloud-build customers which has a very strict incremental build requirement.
