### PR TITLE
Better error message when Azure Functions Core Tools is missing in `dotnet run` use case.

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -124,7 +124,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </Target>
 
   <!-- This target is used to set up the run arguments for the function app, supporting `dotnet run` -->
-  <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_CheckForFuncInstallation" Condition="'$(FuncExists)' == 'true'">
+  <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools" Condition="'$(FuncExists)' == 'true'">
     <PropertyGroup>
       <RunCommand>func</RunCommand>
       <RunArguments>host start $(RunArguments)</RunArguments>
@@ -132,12 +132,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </PropertyGroup>
   </Target>
 
-  <Target Name="_CheckForFuncInstallation">
-    <PropertyGroup>
-      <PathCheckCommand Condition="'$(OS)' == 'Windows_NT'">where func</PathCheckCommand>
-      <PathCheckCommand Condition="'$(OS)' != 'Windows_NT'">which func</PathCheckCommand>
-    </PropertyGroup>
-    <Exec Command="$(PathCheckCommand)" IgnoreExitCode="true">
+  <Target Name="_FunctionsCheckForCoreTools">
+    <Exec Command="func --version" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="FuncExitCode" />
     </Exec>
     <PropertyGroup>
@@ -145,7 +141,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </PropertyGroup>
   </Target>
   
-  <Target Name="_FunctionsShowErrorWhenFuncNotInstalled" BeforeTargets="ComputeRunArguments" DependsOnTargets="_CheckForFuncInstallation">
+  <Target Name="_FunctionsShowErrorWhenFuncNotInstalled" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools">
     <Error Condition="'$(FuncExists)' != 'true'" Text="Azure Functions Core Tools is missing. Please install it and try again. Please visit https://aka.ms/azfunc-coretools-not-installed for more details." />
   </Target>
 

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -122,16 +122,39 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps." />
     <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set." />
   </Target>
-
+  
   <!-- This target is used to set up the run arguments for the function app, supporting `dotnet run` -->
-  <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments">
+  <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_CheckForFuncInstallation" Condition="'$(FuncExists)' == 'true'">
     <PropertyGroup>
       <RunCommand>func</RunCommand>
       <RunArguments>host start $(RunArguments)</RunArguments>
       <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
     </PropertyGroup>
   </Target>
+
+  <Target Name="_CheckForFuncInstallation">
+    <PropertyGroup>
+      <PathCheckCommand Condition="'$(OS)' == 'Windows_NT'">where func</PathCheckCommand>
+      <PathCheckCommand Condition="'$(OS)' != 'Windows_NT'">which func</PathCheckCommand>
+    </PropertyGroup>
+    <Exec Command="$(PathCheckCommand)" IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="FuncExitCode" />
+    </Exec>
+    <PropertyGroup>
+      <FuncExists Condition="'$(FuncExitCode)' == '0'">true</FuncExists>
+    </PropertyGroup>
+  </Target>
   
+  <Target Name="_FunctionsComputeRunArgumentsWhenFuncNotExists" BeforeTargets="ComputeRunArguments" DependsOnTargets="_CheckForFuncInstallation" Condition="'$(FuncExists)' != 'true'">
+    <PropertyGroup>
+      <ErrorMessage>Azure Functions Core Tools is missing. Please install it and try again. Please visit https://aka.ms/azfunc-coretools-not-installed for more details.</ErrorMessage>
+      <RunCommand Condition="'$(OS)' == 'Windows_NT'">cmd.exe</RunCommand>
+      <RunArguments Condition="'$(OS)' == 'Windows_NT'">/c echo $(ErrorMessage)</RunArguments>
+      <RunCommand Condition="'$(OS)' != 'Windows_NT'">sh</RunCommand>
+      <RunArguments Condition="'$(OS)' != 'Windows_NT'">-c 'echo $(ErrorMessage)'</RunArguments>
+    </PropertyGroup>
+  </Target>
+
   <!-- These two targets set up the main sequence of targets we want to run and when we want to run them. -->
   <Target Name="_FunctionsBuildExtension"
     AfterTargets="CoreCompile"

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -124,8 +124,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </Target>
 
   <!-- This target is used to set up the run arguments for the function app, supporting `dotnet run` -->
-  <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools" Condition="'$(FuncExists)' == 'true'">
-    <PropertyGroup>
+  <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools">
+    <PropertyGroup Condition="'$(FuncExists)' == 'true'">
       <RunCommand>func</RunCommand>
       <RunArguments>host start $(RunArguments)</RunArguments>
       <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
@@ -140,9 +140,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <FuncExists Condition="'$(FuncExitCode)' == '0'">true</FuncExists>
     </PropertyGroup>
   </Target>
-  
-  <Target Name="_FunctionsShowErrorWhenFuncNotInstalled" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools">
-    <Error Condition="'$(FuncExists)' != 'true'" Text="Azure Functions Core Tools is missing. Please install it and try again. Please visit https://aka.ms/azfunc-coretools-not-installed for more details." />
+
+  <Target Name="_FunctionsComputeRunArgumentsWhenFuncNotExists" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools">
+    <Error Text="Azure Functions Core Tools is missing. Please install it and try again. Visit https://aka.ms/azfunc-coretools-not-installed for more details." Condition="'$(FuncExists)' != 'true'" />
   </Target>
 
   <!-- These two targets set up the main sequence of targets we want to run and when we want to run them. -->

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -122,7 +122,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps." />
     <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set." />
   </Target>
-  
+
   <!-- This target is used to set up the run arguments for the function app, supporting `dotnet run` -->
   <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_CheckForFuncInstallation" Condition="'$(FuncExists)' == 'true'">
     <PropertyGroup>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -145,14 +145,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </PropertyGroup>
   </Target>
   
-  <Target Name="_FunctionsComputeRunArgumentsWhenFuncNotExists" BeforeTargets="ComputeRunArguments" DependsOnTargets="_CheckForFuncInstallation" Condition="'$(FuncExists)' != 'true'">
-    <PropertyGroup>
-      <ErrorMessage>Azure Functions Core Tools is missing. Please install it and try again. Please visit https://aka.ms/azfunc-coretools-not-installed for more details.</ErrorMessage>
-      <RunCommand Condition="'$(OS)' == 'Windows_NT'">cmd.exe</RunCommand>
-      <RunArguments Condition="'$(OS)' == 'Windows_NT'">/c echo $(ErrorMessage)</RunArguments>
-      <RunCommand Condition="'$(OS)' != 'Windows_NT'">sh</RunCommand>
-      <RunArguments Condition="'$(OS)' != 'Windows_NT'">-c 'echo $(ErrorMessage)'</RunArguments>
-    </PropertyGroup>
+  <Target Name="_FunctionsShowErrorWhenFuncNotInstalled" BeforeTargets="ComputeRunArguments" DependsOnTargets="_CheckForFuncInstallation">
+    <Error Condition="'$(FuncExists)' != 'true'" Text="Azure Functions Core Tools is missing. Please install it and try again. Please visit https://aka.ms/azfunc-coretools-not-installed for more details." />
   </Target>
 
   <!-- These two targets set up the main sequence of targets we want to run and when we want to run them. -->

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -13,6 +13,7 @@
 - Write `worker.config` and `functions.metadata` only if contents have changed. (#2999)
 - Updates the generated extension csproj to be net8.0 (from net6.0) 
 - Setting _ToolingSuffix for V10.0 TargetFrameworkVersion. (#2983)
+- Enhanced error message for missing Azure Functions Core Tools in the user's environment. (#2976)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators 1.3.5
 


### PR DESCRIPTION
resolves #2976

Currently, when `func` is not available, a wrapped Win32/Native exception is [thrown](https://github.com/dotnet/runtime/blob/831d23e56149cd59c40fc00c7feb7c5334bd19c4/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs#L612). This PR updates the logic to first check if `func` exists on the machine. If not, it sets `RunCommand` and `RunArguments` to display a user-friendly error message.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

