### PR TITLE
Update e2e setup script to download latest cli from GH

### DIFF
--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -25,65 +25,75 @@ param(
 
 $FunctionsRuntimeVersion = 4
 
-# A function that checks exit codes and fails script if an error is found 
 function StopOnFailedExecution {
-  if ($LastExitCode) 
-  { 
-    exit $LastExitCode 
+  if ($LastExitCode)
+  {
+    exit $LastExitCode
   }
 }
 
 if($SkipCoreTools)
 {
   Write-Host
-  Write-Host "---Skipping Core Tools download---"  
+  Write-Host "---Skipping Core Tools download---"
 }
 else
 {
   $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+
   if ($IsWindows) {
       $os = "win"
       $coreToolsURL = $env:CORE_TOOLS_URL
   }
+  elseif ($IsMacOS) {
+      $os = "osx"
+  }
   else {
-      if ($IsMacOS) {
-          $os = "osx"
-      } else {
-          $os = "linux"
-          $coreToolsURL = $env:CORE_TOOLS_URL_LINUX
-      }
+      $os = "linux"
+      $coreToolsURL = $env:CORE_TOOLS_URL_LINUX
   }
 
-  if ($UseCoreToolsBuildFromIntegrationTests.IsPresent)
-  {
+  if ($UseCoreToolsBuildFromIntegrationTests -eq $true -or $UseCoreToolsBuildFromIntegrationTests.IsPresent) {
     Write-Host ""
-    Write-Host "Install the Core Tools for Integration Tests..."
-    $coreToolsURL = "https://functionsintegclibuilds.blob.core.windows.net/builds/$FunctionsRuntimeVersion/latest/Azure.Functions.Cli.$os-$arch.zip"
-    $versionUrl = "https://functionsintegclibuilds.blob.core.windows.net/builds/$FunctionsRuntimeVersion/latest/version.txt"
-  }
-  else
-  {
-    if ([string]::IsNullOrWhiteSpace($coreToolsURL))
-    {
-      $coreToolsURL = "https://functionsclibuilds.blob.core.windows.net/builds/$FunctionsRuntimeVersion/latest/Azure.Functions.Cli.$os-$arch.zip"
-      $versionUrl = "https://functionsclibuilds.blob.core.windows.net/builds/$FunctionsRuntimeVersion/latest/version.txt"
+    Write-Host "Using Core Tools from integration test feed..."
+
+    if ([string]::IsNullOrWhiteSpace($coreToolsURL)) {
+        Write-Error "CORE_TOOLS_URL (or CORE_TOOLS_URL_LINUX) is not set."
+        exit 1
     }
+  }
+  else {
+    Write-Host ""
+    Write-Host "Using latest Core Tools release from GitHub..."
+
+    # GitHub API call for latest release
+    $releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest" -Headers @{ "User-Agent" = "PowerShell" }
+
+    $latestVersion = $releaseInfo.tag_name
+    Write-Host "`nLatest Core Tools version: $latestVersion"
+
+    # Look for zip file matching os and arch
+    $pattern = "Azure\.Functions\.Cli\.$os-$arch\..*\.zip$"
+    $asset = $releaseInfo.assets | Where-Object {
+        $_.name -match $pattern
+    }
+
+    if (-not $asset) {
+        Write-Error "Could not find a Core Tools .zip for OS '$os' and arch '$arch'"
+        exit 1
+    }
+
+    $coreToolsURL = $asset.browser_download_url
   }
 
   Write-Host ""
   Write-Host "---Downloading the Core Tools for Functions V$FunctionsRuntimeVersion---"
-  Write-Host "Core Tools download url: $coreToolsURL"
+  Write-Host "Core Tools download URL: $coreToolsURL"
 
   $FUNC_CLI_DIRECTORY = Join-Path $PSScriptRoot 'Azure.Functions.Cli'
   Write-Host 'Deleting Functions Core Tools if exists...'
   Remove-Item -Force "$FUNC_CLI_DIRECTORY.zip" -ErrorAction Ignore
   Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
-
-  if ($versionUrl)
-  {
-    $version = Invoke-RestMethod -Uri $versionUrl
-    Write-Host "Downloading Functions Core Tools (Version: $version)..."
-  }
 
   $output = "$FUNC_CLI_DIRECTORY.zip"
   Invoke-RestMethod -Uri $coreToolsURL -OutFile $output
@@ -95,11 +105,11 @@ else
   {
     & "chmod" "a+x" "$FUNC_CLI_DIRECTORY/func"
   }
-  
+
   Write-Host "------"
 }
 
-if (Test-Path $output) 
+if (Test-Path $output)
 {
   Remove-Item $output -Recurse -Force -ErrorAction Ignore
 }
@@ -121,7 +131,7 @@ if ($SkipStorageEmulator -And $SkipCosmosDBEmulator)
   Write-Host "---Skipping emulator startup---"
   Write-Host
 }
-else 
+else
 {
   .\tools\start-emulators.ps1 -SkipStorageEmulator:$SkipStorageEmulator -SkipCosmosDBEmulator:$SkipCosmosDBEmulator
 }

--- a/test/E2ETests/E2ETests/Fixtures/FixtureHelpers.cs
+++ b/test/E2ETests/E2ETests/Fixtures/FixtureHelpers.cs
@@ -45,9 +45,7 @@ namespace Microsoft.Azure.Functions.Tests.E2ETests
             funcProcess.StartInfo.CreateNoWindow = true;
             funcProcess.StartInfo.WorkingDirectory = e2eAppPath;
             funcProcess.StartInfo.FileName = cliPath;
-            funcProcess.StartInfo.ArgumentList.Add("host");
             funcProcess.StartInfo.ArgumentList.Add("start");
-            funcProcess.StartInfo.ArgumentList.Add("--csharp");
             funcProcess.StartInfo.ArgumentList.Add("--verbose");
 
             if (enableAuth)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

`functionsintegclibuilds` is no longer a valid storage account to get Core Tools from. Updating the script to download from GH releases using the `latest` tag. Option to set `CORE_TOOLS_URL` still available.

Also fixed the func start command.
