### PR TITLE
Use retail artifact inputs in validationJob

### DIFF
--- a/eng/ci/official-release.yml
+++ b/eng/ci/official-release.yml
@@ -67,18 +67,18 @@ extends:
         - job: Prepare
 
           variables:
-            drop_path: $(Pipeline.Workspace)/drop
+          - name: drop_path
+            value: $(Pipeline.Workspace)/build/$(artifact_name)
 
           templateContext:
             type: validationJob
-            inputs:
-            - input: pipelineArtifact
-              targetPath: $(drop_path)
-              artifactName: $(artifact_name)
-              pipeline: build
 
           steps:
           - checkout: none
+
+          # validationJob uses retail artifact inputs
+          - download: build
+            artifact: $(artifact_name)
 
           # Our build does not have a custom version number set. To convey the version number to the release stage,
           # we parse out the version from the .nupkg in the drop and set that as the build number. The release stage

--- a/eng/ci/templates/pipelines/release-extension-packages.yml
+++ b/eng/ci/templates/pipelines/release-extension-packages.yml
@@ -36,18 +36,17 @@ extends:
           variables:
           - template: ci/variables/cfs.yml@eng
           - name: drop_path
-            value: $(Pipeline.Workspace)/drop
+            value: $(Pipeline.Workspace)/build/${{ parameters.artifactName }}
 
           templateContext:
             type: validationJob
-            inputs:
-            - input: pipelineArtifact
-              targetPath: $(drop_path)
-              artifactName: ${{ parameters.artifactName }}
-              pipeline: build
 
           steps:
           - checkout: none
+
+          # validationJob uses retail artifact inputs
+          - download: build
+            artifact: ${{ parameters.artifactName }}
 
           # For extension releases, we assume the first package (alphanumerically) in the drop is the one we want to version off of.
           # This is a bit of a hack, but it works for our current setup.


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

`validationJob`'s do not use `templateContext: inputs` section, instead they use retail artifact download steps.
