### PR TITLE
Update HttpResultAttribute analyzer to include case where return type is Task<T>

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/CodeFixForHttpResultAttributeExpected.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/CodeFixForHttpResultAttributeExpected.cs
@@ -66,14 +66,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
                     .FirstAncestorOrSelf<TypeSyntax>();
                 var typeSymbol = semanticModel.GetSymbolInfo(typeNode).Symbol;
 
-                // Unwrap Task<T> if present
-                var taskType = semanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
-                if (typeSymbol is INamedTypeSymbol namedTypeSymbol &&
-                    namedTypeSymbol.ConstructedFrom != null &&
-                    SymbolEqualityComparer.Default.Equals(namedTypeSymbol.ConstructedFrom, taskType) &&
-                    namedTypeSymbol.TypeArguments.Length == 1)
+                if (SymbolUtils.TryUnwrapTaskOfT(typeSymbol, semanticModel, out var innerSymbol))
                 {
-                    typeSymbol = namedTypeSymbol.TypeArguments[0];
+                    typeSymbol = innerSymbol;
                 }
 
                 var typeDeclarationSyntaxReference = typeSymbol.DeclaringSyntaxReferences.FirstOrDefault();

--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/CodeFixForHttpResultAttributeExpected.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/CodeFixForHttpResultAttributeExpected.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
                     .FirstAncestorOrSelf<TypeSyntax>();
                 var typeSymbol = semanticModel.GetSymbolInfo(typeNode).Symbol;
 
+                if (typeSymbol is null)
+                {
+                    return _document;
+                }
+
                 if (SymbolUtils.TryUnwrapTaskOfT(typeSymbol, semanticModel, out var innerSymbol))
                 {
                     typeSymbol = innerSymbol;

--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/HttpResultAttributeExpectedAnalyzer.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/HttpResultAttributeExpectedAnalyzer.cs
@@ -59,7 +59,19 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             }
 
             var returnType = methodDeclaration.ReturnType;
+
             var returnTypeSymbol = semanticModel.GetTypeInfo(returnType).Type;
+
+            // Unwrap Task<T> if present
+            var taskType = semanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+            if (returnTypeSymbol is INamedTypeSymbol namedTypeSymbol &&
+                namedTypeSymbol.ConstructedFrom != null &&
+                SymbolEqualityComparer.Default.Equals(namedTypeSymbol.ConstructedFrom, taskType) &&
+                namedTypeSymbol.TypeArguments.Length == 1)
+            {
+                returnTypeSymbol = namedTypeSymbol.TypeArguments[0];
+            }
+
 
             if (IsHttpReturnType(returnTypeSymbol, semanticModel))
             {

--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/HttpResultAttributeExpectedAnalyzer.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/HttpResultAttributeExpectedAnalyzer.cs
@@ -61,7 +61,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             var returnType = methodDeclaration.ReturnType;
             var returnTypeSymbol = semanticModel.GetTypeInfo(returnType).Type;
 
-           if (SymbolUtils.TryUnwrapTaskOfT(returnTypeSymbol, semanticModel, out var innerSymbol))
+            if (returnTypeSymbol is null)
+            {
+                return;
+            }
+
+            if (SymbolUtils.TryUnwrapTaskOfT(returnTypeSymbol, semanticModel, out var innerSymbol))
             {
                 returnTypeSymbol = innerSymbol;
             }

--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/HttpResultAttributeExpectedAnalyzer.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/HttpResultAttributeExpectedAnalyzer.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             }
 
             var returnType = methodDeclaration.ReturnType;
-
             var returnTypeSymbol = semanticModel.GetTypeInfo(returnType).Type;
 
             // Unwrap Task<T> if present
@@ -71,7 +70,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             {
                 returnTypeSymbol = namedTypeSymbol.TypeArguments[0];
             }
-
 
             if (IsHttpReturnType(returnTypeSymbol, semanticModel))
             {

--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/HttpResultAttributeExpectedAnalyzer.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/HttpResultAttributeExpectedAnalyzer.cs
@@ -61,14 +61,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             var returnType = methodDeclaration.ReturnType;
             var returnTypeSymbol = semanticModel.GetTypeInfo(returnType).Type;
 
-            // Unwrap Task<T> if present
-            var taskType = semanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
-            if (returnTypeSymbol is INamedTypeSymbol namedTypeSymbol &&
-                namedTypeSymbol.ConstructedFrom != null &&
-                SymbolEqualityComparer.Default.Equals(namedTypeSymbol.ConstructedFrom, taskType) &&
-                namedTypeSymbol.TypeArguments.Length == 1)
+           if (SymbolUtils.TryUnwrapTaskOfT(returnTypeSymbol, semanticModel, out var innerSymbol))
             {
-                returnTypeSymbol = namedTypeSymbol.TypeArguments[0];
+                returnTypeSymbol = innerSymbol;
             }
 
             if (IsHttpReturnType(returnTypeSymbol, semanticModel))

--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/SymbolUtils.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/SymbolUtils.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
+{
+    internal class SymbolUtils
+    {
+        private static string TaskWrapperTypeName = "System.Threading.Tasks.Task`1";
+
+        internal static bool TryUnwrapTaskOfT(ISymbol symbol, SemanticModel semanticModel, out ITypeSymbol resultSymbol)
+        {
+            var taskType = semanticModel.Compilation.GetTypeByMetadataName(TaskWrapperTypeName);
+
+            resultSymbol = null;
+
+            if (symbol is INamedTypeSymbol namedTypeSymbol &&
+                namedTypeSymbol is not null &&
+                namedTypeSymbol.ConstructedFrom is not null &&
+                SymbolEqualityComparer.Default.Equals(namedTypeSymbol.ConstructedFrom, taskType) &&
+                namedTypeSymbol.TypeArguments.Length == 1)
+            {
+                resultSymbol = namedTypeSymbol.TypeArguments[0];
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/SymbolUtils.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/SymbolUtils.cs
@@ -14,9 +14,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             var taskType = semanticModel.Compilation.GetTypeByMetadataName(TaskWrapperTypeName);
 
             resultSymbol = null;
-
+            
             if (symbol is INamedTypeSymbol namedTypeSymbol &&
-                namedTypeSymbol is not null &&
                 namedTypeSymbol.ConstructedFrom is not null &&
                 SymbolEqualityComparer.Default.Equals(namedTypeSymbol.ConstructedFrom, taskType) &&
                 namedTypeSymbol.TypeArguments.Length == 1)

--- a/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/Worker.Extensions.Http.AspNetCore.Analyzers.csproj
+++ b/extensions/Worker.Extensions.Http.AspNetCore.Analyzers/src/Worker.Extensions.Http.AspNetCore.Analyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <VersionPrefix>1.0.3</VersionPrefix>
+        <VersionPrefix>1.0.4</VersionPrefix>
         <OutputType>Library</OutputType>
         <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
         <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -4,10 +4,10 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 2.02
 
 - Fix intermittent error `IFeatureCollection has been disposed` exception in multiple-output binding scenarios. (#2896)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Analyzers 1.0.4
 
-- Include case where customer POCO is wrapped in `Task<T>` in the `HttpResultAttribute` analyzer for multiple output binding scenarios.
+- Include case where customer POCO is wrapped in `Task<T>` in the `HttpResultAttribute` analyzer for multiple output binding scenarios. (#3506)

--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -4,7 +4,7 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 2.02
+### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 2.0.2
 
 - Fix intermittent error `IFeatureCollection has been disposed` exception in multiple-output binding scenarios. (#2896)
 

--- a/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
+++ b/extensions/Worker.Extensions.Http.AspNetCore/release_notes.md
@@ -8,6 +8,6 @@
 
 - Fix intermittent error `IFeatureCollection has been disposed` exception in multiple-output binding scenarios. (#2896)
 
-### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Analyzers  <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Analyzers 1.0.4
 
-- <entry>
+- Include case where customer POCO is wrapped in `Task<T>` in the `HttpResultAttribute` analyzer for multiple output binding scenarios.

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <Description>ASP.NET Core extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/HttpResultAttributeExpectedTests.cs
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/HttpResultAttributeExpectedTests.cs
@@ -460,6 +460,66 @@ namespace AspNetIntegration
             await test.RunAsync();
         }
 
+        [Fact]
+        public async Task HttpTriggerFunctionWithHttpResponseData_NoDiagnostic()
+        {
+            string testCode = @"
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.Functions.Worker;
+
+namespace AspNetIntegration
+{
+    public class SimpleHttpFunction
+    {
+        [Function(""SimpleHttpTaskOutput"")]
+        public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Function, ""post"")] HttpRequestData req)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = LoadRequiredDependencyAssemblies(),
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task HttpTriggerFunctionWithTaskOfIActionResult_NoDiagnostic()
+        {
+            string testCode = @"
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace AspNetIntegration
+{
+    public class SimpleHttpFunction
+    {
+        [Function(""SimpleHttpTaskOutput"")]
+        public Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Function, ""post"")] HttpRequest req)
+        {
+            return Task.FromResult<IActionResult>(new OkResult());
+        }
+    }
+}";
+
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = LoadRequiredDependencyAssemblies(),
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
         private static ReferenceAssemblies LoadRequiredDependencyAssemblies()
         {
             var referenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Discovered this missing case from [this comment](https://github.com/Azure/azure-functions-dotnet-worker/issues/2682#issuecomment-27205736890) where the customer was on a package version that should have notified them to use the `HttpResult` attribute.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

<img width="907" alt="task-analyzer-works" src="https://github.com/user-attachments/assets/8d665694-2a8b-4a63-9537-c0abfd4b5b12" />

Code fix also works as expected.