### PR TITLE
Fix sdk publish --no-build

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -141,7 +141,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <!-- For publish we have very little targets. Either:
     1) It is a publish with build, in which case _FunctionsInnerBuild will already be ran.
     2) It is publish no-build, in which case we assume everything is as expected in the output directory already. -->
-  <Target Name="_FunctionsInnerPublish" BeforeTargets="GetCopyToPublishDirectoryItems" DependsOnTargets="_FunctionsExtensionAssignTargetPaths" />
+  <Target Name="_FunctionsInnerPublish" BeforeTargets="GetCopyToPublishDirectoryItems" DependsOnTargets="_FunctionsPreBuild;_WorkerExtensionsBuild;_FunctionsExtensionAssignTargetPaths" />
 
   <!-- Invoke restore on WorkerExtension.csproj.
     We depend on _GetRestoreSettings, which is a task from nuget targets that will resolve various nuget restore settings.
@@ -154,6 +154,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Target Name="_WorkerExtensionsBuild">
     <PropertyGroup>
       <_WorkerExtensionTarget>Build</_WorkerExtensionTarget>
+      <_WorkerExtensionTarget Condition="'$(NoBuild)' == 'true'">GetTargetPath</_WorkerExtensionTarget>
       <_WorkerExtensionProperties>Configuration=Release;$(_FunctionsExtensionCommonProps)</_WorkerExtensionProperties>
     </PropertyGroup>
 

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,9 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk <version>
+### Microsoft.Azure.Functions.Worker.Sdk 2.0.4
 
-- <entry>
+- Address issue with `dotnet publish --no-build` producing an error. (#3068)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #3067

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests) -- evaluating. May add them in a separate PR as this is not trivial.

<!-- Optional: delete if not applicable  -->
### Additional information

Addresses a regression in `dotnet publish --no-build` with worker SDK 2.0.3. Necessary targets were not hooked up to ensure we resolved paths and retrieved the worker extensions output directory during publish without build.
