### PR TITLE
Fix design time build when not build yet

### DIFF
--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorProductVersion>2</MajorProductVersion>
     <MinorProductVersion>0</MinorProductVersion>
-    <PatchProductVersion>4</PatchProductVersion>
+    <PatchProductVersion>5</PatchProductVersion>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <PackageId>Microsoft.Azure.Functions.Worker.Sdk</PackageId>
     <Description>This package provides development time support for the Azure Functions .NET Worker.</Description>

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -128,13 +128,14 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   <!-- These two targets set up the main sequence of targets we want to run and when we want to run them. -->
   <Target Name="_FunctionsBuildExtension"
+    Condition="'$(_FunctionsBuildEnabled)' == 'true'"
     AfterTargets="CoreCompile"
     BeforeTargets="GetCopyToOutputDirectoryItems"
-    Condition="'$(_FunctionsBuildEnabled)' == 'true'"
     DependsOnTargets="_FunctionsGenerateMetadata;_FunctionsPostBuild;_FunctionsInnerBuild;_FunctionsExtensionUpdateMetadata;_FunctionsExtensionAssignTargetPaths"/>
 
   <!-- This target builds the generated WorkerExtension.csproj. Does not run for design time builds or if extension project is externally provided. -->
   <Target Name="_FunctionsInnerBuild"
+    Condition="'$(_FunctionsBuildEnabled)' == 'true'"
     AfterTargets="CoreCompile"
     DependsOnTargets="_WorkerExtensionsRestore;_WorkerExtensionsBuild" />
 

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -4,9 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Sdk 2.0.4
+### Microsoft.Azure.Functions.Worker.Sdk 2.0.5
 
-- Address issue with `dotnet publish --no-build` producing an error. (#3068)
+- Address issue with design time build producing an error when project had not yet been built yet. (#3081)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Prevents targets from running during design time build when they are not meant to be.
