### PR TITLE
Use task instead of outputs for nuget publish

### DIFF
--- a/eng/ci/host/official-release.yml
+++ b/eng/ci/host/official-release.yml
@@ -94,11 +94,13 @@ extends:
             artifactName: $(artifact_name)
             pipeline: build
 
-          outputs:
-          - output: nuget
-            packagesToPush: $(packages_pattern)
-            packageParentPath: $(drop_path)
-            publishVstsFeed: $(nuget_feed)
-            nuGetFeedType: internal
-            allowPackageConflicts: true
-            publishPackageMetadata: true
+          steps:
+          - task: 1ES.PublishNuget@1
+            displayName: Publish packages
+            inputs:
+              packagesToPush: $(packages_pattern)
+              packageParentPath: $(drop_path)
+              publishVstsFeed: $(nuget_feed)
+              nuGetFeedType: internal
+              allowPackageConflicts: true
+              publishPackageMetadata: true


### PR DESCRIPTION
Quick fix for nuget publish. 1ESPT recommends using `outputs`, but it then errors out if using that with a releaseJob. Switching to the publish nuget task instead.