### PR TITLE
Fix ServiceBusMessageActions.cs AbandonMessageAsync doc inheritance

### DIFF
--- a/extensions/Worker.Extensions.ServiceBus/src/ServiceBusMessageActions.cs
+++ b/extensions/Worker.Extensions.ServiceBus/src/ServiceBusMessageActions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.Worker
             await _settlement.CompleteAsync(new() { Locktoken = message.LockToken }, cancellationToken: cancellationToken);
         }
 
-        ///<inheritdoc cref="ServiceBusReceiver.CompleteMessageAsync(ServiceBusReceivedMessage, CancellationToken)"/>
+        ///<inheritdoc cref="ServiceBusReceiver.AbandonMessageAsync(ServiceBusReceivedMessage, IDictionary{string, object}, CancellationToken)"/>
         public virtual async Task AbandonMessageAsync(
             ServiceBusReceivedMessage message,
             IDictionary<string, object>? propertiesToModify = default,


### PR DESCRIPTION
### Issue describing the changes in this PR

The AbandonMessageAsync method has a 

        ///<inheritdoc cref="ServiceBusReceiver.CompleteMessageAsync(ServiceBusReceivedMessage, CancellationToken)"/>

item, while it should inherit from `ServiceBusReceiver.AbandonMessageAsync`

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [ ] I have added all required tests (Unit tests, E2E tests) -> not applicable
