### PR TITLE
Default empty, nullable input bindings to null instead of empty string

### DIFF
--- a/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
+++ b/src/DotNetWorker.Core/Context/Features/DefaultFunctionInputBindingFeature.cs
@@ -55,7 +55,17 @@ namespace Microsoft.Azure.Functions.Worker.Context.Features
 
                     TryGetBindingSource(parameter.Name, functionBindings, out object? source);
 
+                    // Option 1: Check if source is an empty string and parameter is reference or nullable type
+                    if (source is string str && string.IsNullOrEmpty(str))
+                    {
+                        // OR we can set `parameterValues[i] = null`. However, we already have checks for HasDefaultValue & IsReferenceOrNullableType
+                        // in the `(bindingResult.Status == ConversionStatus.Unhandled)` case below which will hanlde what we need it to.
+                        // So it depends on if we want to short circuit or not.
+                        source = null;
+                    }
+
                     ConversionResult bindingResult = await ConvertAsync(context, parameter, _converterContextFactory, inputConversionFeature, source);
+
 
                     if (bindingResult.Status == ConversionStatus.Succeeded)
                     {

--- a/src/DotNetWorker.Core/Converters/TypeConverter.cs
+++ b/src/DotNetWorker.Core/Converters/TypeConverter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Functions.Worker.Converters
     {
         public ValueTask<ConversionResult> ConvertAsync(ConverterContext context)
         {
+            // Option 2: Check the source for null or empty and return unhandled if so.
+            // However with this approach we would need to ensure all Converters handle this scenario.
             Type? sourceType = context.Source?.GetType();
 
             if (sourceType is not null &&

--- a/src/DotNetWorker.Grpc/GrpcWorker.cs
+++ b/src/DotNetWorker.Grpc/GrpcWorker.cs
@@ -64,6 +64,12 @@ namespace Microsoft.Azure.Functions.Worker
         Task IMessageProcessor.ProcessMessageAsync(StreamingMessage message)
         {
             // Dispatch and return.
+            // Option 3: The incoming invovation request has already set `name` to an empty string. So we could fix it host side?
+            // But this feels like overkill and potentially a breaking change somewhere in the stack.
+            // [0] [ParameterBinding] =
+            // { "name": "context", "data": { "string": "{\"name\":\"SayHello\",\"arguments\":{},\"_meta\":{\"progressToken\":\"5bbee852-45ea-40b3-a270-286c506e4500\"}}" } }
+            // [1] [ParameterBinding] =
+            // { "name": "name", "data": { "string": "" } }
             Task.Run(() => ProcessRequestCoreAsync(message));
 
             return Task.CompletedTask;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-mcp-extension/issues/70

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

When an argument is not required, it may be omitted from the tool call request. This should lead to a null input binding value. However, it seems like strings, for example, will get the empty string.

For the draft, I have a couple of suggestions on how to address this issue (see code comments).
