### PR TITLE
Adding support for running `dotnet run` after installing core tools thru npm

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -106,14 +106,21 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set." />
   </Target>
 
-  <!-- This target is used to set up the run arguments for the function app, supporting `dotnet run` -->
-  <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools">
-    <PropertyGroup Condition="'$(FuncExists)' == 'true'">
-      <RunCommand>func</RunCommand>
-      <RunArguments>host start $(RunArguments)</RunArguments>
-      <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
-    </PropertyGroup>
-  </Target>
+    <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools">
+        <!-- Windows Configuration -->
+        <PropertyGroup Condition="'$(FuncExists)' == 'true' AND '$(OS)' == 'Windows_NT'">
+            <RunCommand>cmd</RunCommand>
+            <RunArguments>/C func host start $(RunArguments)</RunArguments>
+            <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
+        </PropertyGroup>
+
+        <!-- Unix/Linux/macOS Configuration -->
+        <PropertyGroup Condition="'$(FuncExists)' == 'true' AND '$(OS)' != 'Windows_NT'">
+            <RunCommand>bash</RunCommand>
+            <RunArguments>-c "func host start $(RunArguments)"</RunArguments>
+            <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
+        </PropertyGroup>
+    </Target>
 
   <Target Name="_FunctionsCheckForCoreTools">
     <Exec Command="func --version" IgnoreExitCode="true">

--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -106,21 +106,21 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set." />
   </Target>
 
-    <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools">
-        <!-- Windows Configuration -->
-        <PropertyGroup Condition="'$(FuncExists)' == 'true' AND '$(OS)' == 'Windows_NT'">
-            <RunCommand>cmd</RunCommand>
-            <RunArguments>/C func host start $(RunArguments)</RunArguments>
-            <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
-        </PropertyGroup>
+  <Target Name="_FunctionsComputeRunArguments" BeforeTargets="ComputeRunArguments" DependsOnTargets="_FunctionsCheckForCoreTools">
+    <!-- Windows Configuration -->
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+        <RunCommand>cmd</RunCommand>
+        <RunArguments>/C func start $(RunArguments)</RunArguments>
+        <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
+    </PropertyGroup>
 
-        <!-- Unix/Linux/macOS Configuration -->
-        <PropertyGroup Condition="'$(FuncExists)' == 'true' AND '$(OS)' != 'Windows_NT'">
-            <RunCommand>bash</RunCommand>
-            <RunArguments>-c "func host start $(RunArguments)"</RunArguments>
-            <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
-        </PropertyGroup>
-    </Target>
+    <!-- Unix/Linux/macOS Configuration -->
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+        <RunCommand>func</RunCommand>
+        <RunArguments>start $(RunArguments)</RunArguments>
+        <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>
+    </PropertyGroup>
+  </Target>
 
   <Target Name="_FunctionsCheckForCoreTools">
     <Exec Command="func --version" IgnoreExitCode="true">

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -7,6 +7,7 @@
 ### Microsoft.Azure.Functions.Worker.Sdk <version>
 
 - Build no longer generates `functions.metadata` if source-generated metadata provider is enabled. (#2974)
+- Fixing `dotnet run` to work on Windows when core tools is installed from NPM (#3127)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves [#2884](https://github.com/Azure/azure-functions-dotnet-worker/issues/2884)

This image shows the previous behavior if we installed core tools through npm via running `npm install -g azure-functions-core-tools@4` and running `dotnet run` after

<img width="1910" height="203" alt="image" src="https://github.com/user-attachments/assets/2f7bf319-e1e1-4efd-9470-086fd93f47d2" />

Now we run the target with either bash or cmd depending on the target machine and now get the following output (tested with a local nuget package on my machine after running `npm install -g azure-functions-core-tools@4`)
<img width="1898" height="449" alt="image" src="https://github.com/user-attachments/assets/2429584c-fe27-4cb3-b308-cf8b9409fe25" />


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
