### PR TITLE
Add initial Azure.Functions.Sdk project

### DIFF
--- a/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
+++ b/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>Azure Functions SDK for dotnet isolated workers.</Description>
+    <PackageTags>Azure Functions Dotnet Dotnet-Isolated</PackageTags>
+    <PackageType>MSBuildSdk</PackageType>
+    <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <VersionPrefix>0.1.0</VersionPrefix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" ExcludeAssets="Runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="**/*.props;**/*.targets" Pack="true" CamelCasePath="true" />
+  </ItemGroup>
+
+  <Target Name="_AddPackagePath" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <!-- Convert these file paths to camel case, which is the nuget package convention. -->
+      <!-- This way we can keep our folders pascal case on disk for consistency. -->
+      <None Update="@(None)"
+        PackagePath="$([System.String]::new('%(RecursiveDir)').Substring(0, 1).ToLowerInvariant())$([System.String]::new('%(RecursiveDir)').Substring(1))%(Filename)%(Extension)"
+        Condition="'%(None.CamelCasePath)' == 'true'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage"
+          BeforeTargets="_GetBuildOutputFilesWithTfm"
+          DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))"
+                            TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))"
+                            TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Azure.Functions.Sdk/Build/Azure.Functions.Sdk.targets
+++ b/src/Azure.Functions.Sdk/Build/Azure.Functions.Sdk.targets
@@ -1,0 +1,19 @@
+<!--
+***********************************************************************************************
+Azure.Functions.Sdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project>
+
+  <!-- Fail the build if we are referenced via PackageReference and not Sdk element. -->
+  <Target Name="_AzureFunctionsIncorrectImport" BeforeTargets="Build">
+    <Error Text="Azure.Functions.Sdk must be imported through an 'Sdk' element and not a 'PackageReference'." />
+  </Target>
+
+</Project>

--- a/src/Azure.Functions.Sdk/README.md
+++ b/src/Azure.Functions.Sdk/README.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Sdk
+
+The MSBuild SDK to use for building dotnet isolated function apps.
+
+This is intended to replace `Microsoft.Azure.Functions.Worker.Sdk` (which is at sdk/Sdk in this repo).

--- a/src/Azure.Functions.Sdk/Sdk/Sdk.props
+++ b/src/Azure.Functions.Sdk/Sdk/Sdk.props
@@ -1,0 +1,18 @@
+<!--
+***********************************************************************************************
+Sdk.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project>
+
+  <PropertyGroup>
+    <UsingAzureFunctionsSdk>true</UsingAzureFunctionsSdk>
+  </PropertyGroup>
+
+</Project>

--- a/src/Azure.Functions.Sdk/Sdk/Sdk.targets
+++ b/src/Azure.Functions.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,19 @@
+<!--
+***********************************************************************************************
+Sdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project>
+
+  <PropertyGroup>
+    <AzureFunctionsSdkTasksDirectory>$(MSBuildThisFileDirectory)../tools/netstandard2.0/</AzureFunctionsSdkTasksDirectory>
+    <AzureFunctionsSdkTasksAssembly>$(AzureFunctionsSdkTasksDirectory)Azure.Functions.Sdk.dll</AzureFunctionsSdkTasksAssembly>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #3132 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR introduces the initial `Azure.Functions.Sdk.csproj`. Sets up this project to be an MSBuild SDK nuget package. Includes initial targets for packing correctly and a README.md to briefly explain the difference between it and the existing SDK.

Not adding release notes as this is to a feature branch. Will add release notes when we merge to main.
