### PR TITLE
Revert "Updating extension dependencies (#3155)"

### DIFF
--- a/extensions/Worker.Extensions.EventGrid/release_notes.md
+++ b/extensions/Worker.Extensions.EventGrid/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.EventGrid 3.6.0
+### Microsoft.Azure.Functions.Worker.Extensions.EventGrid <version>
 
-- Updating `Microsoft.Azure.WebJobs.Extensions.EventGrid` reference to 3.5.0 (#3155)
+- <entry>

--- a/extensions/Worker.Extensions.EventGrid/src/Worker.Extensions.EventGrid.csproj
+++ b/extensions/Worker.Extensions.EventGrid/src/Worker.Extensions.EventGrid.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Event Grid extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.6.0</VersionPrefix>
+    <VersionPrefix>3.5.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="3.5.0" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="3.4.4" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Blob Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>6.8.0</VersionPrefix>
+    <VersionPrefix>6.7.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.20.0" />
   </ItemGroup>
 
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Storage.Blobs" Version="5.3.5" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Storage.Blobs" Version="5.3.4" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Worker.Extensions.Storage.Queues/src/Worker.Extensions.Storage.Queues.csproj
+++ b/extensions/Worker.Extensions.Storage.Queues/src/Worker.Extensions.Storage.Queues.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Queue Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.5.3</VersionPrefix>
+    <VersionPrefix>5.5.2</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.3.5" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.3.4" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Worker.Extensions.Storage/release_notes.md
+++ b/extensions/Worker.Extensions.Storage/release_notes.md
@@ -4,15 +4,14 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Storage 6.8.0
+### Microsoft.Azure.Functions.Worker.Extensions.Storage <version>
 
-- Updating `Microsoft.Azure.WebJobs.Extensions.Storage.Blobs` reference to 5.3.5 (#3155)
-- Updating `Microsoft.Azure.WebJobs.Extensions.Storage.Queues` reference to 5.3.5 (#3155)
+- <entry>
 
-### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs 6.8.0
+### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs <version>
 
-- Updating `Microsoft.Azure.WebJobs.Extensions.Storage.Blobs` reference to 5.3.5 (#3155)
+- <entry>
 
-### Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues 5.5.3
+### Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues <version>
 
-- Updating `Microsoft.Azure.WebJobs.Extensions.Storage.Queues` reference to 5.3.5 (#3155)
+- <entry>

--- a/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
+++ b/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>6.8.0</VersionPrefix>
+    <VersionPrefix>6.7.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
This reverts commit 23110d03d772ebefae99ae0a265cdf856e9cdc4a.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

The original commit updates the storage blob extension references to 5.3.5, and that version introduced a regression we want to patch before releasing. This change also reverts the Event Grid updates, but those will come in separately. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

