### PR TITLE
Updating extension dependencies (Event Grid)

### DIFF
--- a/extensions/Worker.Extensions.EventGrid/release_notes.md
+++ b/extensions/Worker.Extensions.EventGrid/release_notes.md
@@ -4,6 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.EventGrid <version>
+### Microsoft.Azure.Functions.Worker.Extensions.EventGrid 3.6.0
 
-- <entry>
+- Updating `Microsoft.Azure.WebJobs.Extensions.EventGrid` reference to 3.5.0 (#3160)

--- a/extensions/Worker.Extensions.EventGrid/src/Worker.Extensions.EventGrid.csproj
+++ b/extensions/Worker.Extensions.EventGrid/src/Worker.Extensions.EventGrid.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Event Grid extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.6.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="3.4.4" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="3.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updating the host extension version. This reintroduces behavior that had to be reverted in #3159. The Event Grid behavior is fine to bring back in, and it really should always have been a separate PR/commit.

### Issue describing the changes in this PR

resolves #3101

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
