### PR TITLE
Add query string to avoid caching issues for core-tools download

### DIFF
--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -83,8 +83,11 @@ else
         exit 1
     }
 
-    $coreToolsURL = $asset.browser_download_url
+    $coreToolsURL = $asset.browser_download_url;
   }
+
+  # Add query string to avoid caching issues
+  $coreToolsURL = $coreToolsURL + "?raw=true"
 
   Write-Host ""
   Write-Host "---Downloading the Core Tools for Functions V$FunctionsRuntimeVersion---"


### PR DESCRIPTION
Add query string to avoid caching issues for core-tools download during E2E test setup