### PR TITLE
Use name of function instead of class for input/output queue example

### DIFF
--- a/samples/Extensions/Queue/QueueFunction.cs
+++ b/samples/Extensions/Queue/QueueFunction.cs
@@ -20,9 +20,9 @@ namespace SampleApp
 
         //<docsnippet_queue_output_binding>
         //<docsnippet_queue_trigger>
-        [Function(nameof(QueueFunction))]
+        [Function(nameof(QueueInputOutputFunction))]
         [QueueOutput("output-queue")]
-        public string[] Run([QueueTrigger("input-queue")] Album myQueueItem, FunctionContext context)
+        public string[] QueueInputOutputFunction([QueueTrigger("input-queue")] Album myQueueItem, FunctionContext context)
         //</docsnippet_queue_trigger>
         {
             // Use a string array to return more than one message.


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves [#3211]

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

The example function with input/output is used standalone on https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger . When copying this the code does not compile because it uses the class name, which is not included in the example, as function name.

Renaming the function to something more explicit, and using that as function name, should improve the example.