### PR TITLE
[MSBUILD SDK] Add target to resolve extension packages

### DIFF
--- a/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
+++ b/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
@@ -13,10 +13,16 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <PolySharpExcludeGeneratedTypes>System.Runtime.CompilerServices.ModuleInitializerAttribute</PolySharpExcludeGeneratedTypes>
+    <PolySharpExcludeGeneratedTypes>System.Runtime.CompilerServices.ModuleInitializerAttribute;System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute</PolySharpExcludeGeneratedTypes>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.15" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- These packages are provided by MSBuild / dotnet sdk at runtime, we want to reference but NOT include them. -->
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.48" ExcludeAssets="Runtime" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.14.0" ExcludeAssets="Runtime" />
   </ItemGroup>

--- a/src/Azure.Functions.Sdk/Constants.cs
+++ b/src/Azure.Functions.Sdk/Constants.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Commonly used constants.
+/// </summary>
+internal static class Constants
+{
+    /// <summary>
+    /// The folder name where Azure Functions extensions are output.
+    /// </summary>
+    public const string ExtensionsOutputFolder = ".azurefunctions";
+}

--- a/src/Azure.Functions.Sdk/ExceptionExtensions.cs
+++ b/src/Azure.Functions.Sdk/ExceptionExtensions.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace System;
+
+/// <summary>
+/// Extensions for exceptions.
+/// </summary>
+internal static class ExceptionExtensions
+{
+    /// <summary>
+    /// Determines whether the exception is considered fatal and should not be caught.
+    /// </summary>
+    /// <param name="exception">The exception to check.</param>
+    /// <returns></returns>
+    public static bool IsFatal(this Exception? exception)
+    {
+        while (exception is not null)
+        {
+            if (exception
+                is (OutOfMemoryException and not InsufficientMemoryException)
+                or AppDomainUnloadedException
+                or BadImageFormatException
+                or CannotUnloadAppDomainException
+                or InvalidProgramException
+                or AccessViolationException)
+            {
+                return true;
+            }
+
+            if (exception is AggregateException aggregate)
+            {
+                foreach (Exception inner in aggregate.InnerExceptions)
+                {
+                    if (inner.IsFatal())
+                    {
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                exception = exception.InnerException;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Azure.Functions.Sdk/ExtensionReference.cs
+++ b/src/Azure.Functions.Sdk/ExtensionReference.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Mono.Cecil;
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Represents an Azure Functions extension reference.
+/// </summary>
+public static class ExtensionReference
+{
+    private const string ExtensionsInformationType = "Microsoft.Azure.Functions.Worker.Extensions.Abstractions.ExtensionInformationAttribute";
+
+    /// <summary>
+    /// Gets the root path of the Azure Functions SDK module.
+    /// </summary>
+    /// <param name="path">The path to the assembly.</param>
+    /// <param name="sourcePackageId">The source package ID.</param>
+    /// <param name="extensionReference">The resulting extension reference, if found.</param>
+    public static bool TryGetFromModule(
+        string path,
+        string sourcePackageId,
+        [NotNullWhen(true)] out ITaskItem? extensionReference)
+    {
+        // Read the assembly from the specified path
+        using AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(path);
+
+        // Find the extension attribute
+        foreach (CustomAttribute customAttribute in assembly.CustomAttributes)
+        {
+            if (string.Equals(
+                    customAttribute.AttributeType.FullName,
+                    ExtensionsInformationType,
+                    StringComparison.Ordinal))
+            {
+                customAttribute.GetArguments(out string name, out string version);
+                extensionReference = new TaskItem(name);
+                extensionReference.SetVersion(version);
+                extensionReference.SetIsImplicitlyDefined(true);
+                extensionReference.SetSourcePackageId(sourcePackageId);
+
+                return true;
+            }
+        }
+
+        extensionReference = default;
+        return false;
+    }
+}

--- a/src/Azure.Functions.Sdk/FunctionsAssemblyScanner.cs
+++ b/src/Azure.Functions.Sdk/FunctionsAssemblyScanner.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.RegularExpressions;
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Class to help with scanning functions related assemblies.
+/// </summary>
+public sealed partial class FunctionsAssemblyScanner
+{
+    private static readonly Regex ExcludedPackagesRegex = new(
+        @"^(System|Azure\.Core|Azure\.Identity|Microsoft\.Bcl|Microsoft\.Extensions|Microsoft\.Identity|Microsoft\.NETCore|Microsoft\.NETStandard|Microsoft\.Win32|Grpc)(\..*|$)",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Checks if the given package name should be scanned or not.
+    /// </summary>
+    /// <param name="name">The name of the package.</param>
+    /// <returns><c>true</c> if package should be scanned, <c>false</c> otherwise.</returns>
+    public static bool ShouldScanPackage(string name)
+    {
+        return !string.IsNullOrEmpty(name) && !ExcludedPackagesRegex.IsMatch(name);
+    }
+}

--- a/src/Azure.Functions.Sdk/LockFileExtensions.cs
+++ b/src/Azure.Functions.Sdk/LockFileExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Extensions for NuGet lock files.
+/// </summary>
+public static class LockFileExtensions
+{
+    /// <summary>
+    /// Gets a package path resolver for the given lock file.
+    /// </summary>
+    /// <param name="lockFile">The lock file.</param>
+    /// <returns></returns>
+    public static FallbackPackagePathResolver GetPathResolver(this LockFile lockFile)
+    {
+        Throw.IfNull(lockFile);
+        string? userPackageFolder = lockFile.PackageFolders.FirstOrDefault()?.Path;
+        return new(userPackageFolder, lockFile.PackageFolders.Skip(1).Select(folder => folder.Path));
+    }
+}

--- a/src/Azure.Functions.Sdk/MSBuildNugetLogger.cs
+++ b/src/Azure.Functions.Sdk/MSBuildNugetLogger.cs
@@ -1,0 +1,195 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Common;
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Provides an implementation of the NuGet logger that routes log messages to MSBuild's logging infrastructure.
+/// </summary>
+/// <param name="logger">The MSBuild task logging helper used to record log messages. Cannot be null.</param>
+internal sealed class MSBuildNugetLogger(TaskLoggingHelper logger)
+    : NuGet.Common.ILogger
+{
+    private readonly TaskLoggingHelper _logger = Throw.IfNull(logger);
+
+    private delegate void LogMessageWithDetails(string subcategory,
+        string code,
+        string helpKeyword,
+        string? file,
+        int lineNumber,
+        int columnNumber,
+        int endLineNumber,
+        int endColumnNumber,
+        MessageImportance importance,
+        string message,
+        params object[] messageArgs);
+
+    private delegate void LogErrorWithDetails(string subcategory,
+        string code,
+        string helpKeyword,
+        string? file,
+        int lineNumber,
+        int columnNumber,
+        int endLineNumber,
+        int endColumnNumber,
+        string message,
+        params object[] messageArgs);
+
+    private delegate void LogMessageAsString(MessageImportance importance,
+        string message,
+        params object[] messageArgs);
+
+    private delegate void LogErrorAsString(string message,
+        params object[] messageArgs);
+
+    /// <inheritdoc />
+    public void Log(LogLevel level, string data)
+    {
+        switch (level)
+        {
+            case LogLevel.Warning:
+                _logger.LogWarning(data);
+                break;
+            case LogLevel.Error:
+                _logger.LogError(data);
+                break;
+            default:
+                MessageImportance importance = Convert(level);
+                _logger.LogMessage(importance, data);
+                break;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Log(ILogMessage message)
+    {
+        INuGetLogMessage nugetMessage = message switch
+        {
+            INuGetLogMessage nugetLogMessage => nugetLogMessage,
+            _ => new RestoreLogMessage(message.Level, message.Message)
+            {
+                Code = message.Code,
+                FilePath = message.ProjectPath,
+                ProjectPath = message.ProjectPath,
+            },
+        };
+
+        if (nugetMessage.Code == NuGetLogCode.Undefined)
+        {
+            Log(nugetMessage.Level, nugetMessage.Message);
+        }
+        else
+        {
+            string enumName = Enum.GetName(typeof(NuGetLogCode), nugetMessage.Code);
+            switch (nugetMessage.Level)
+            {
+                case LogLevel.Warning:
+                    _logger.LogWarning(string.Empty,
+                        enumName,
+                        enumName,
+                        nugetMessage.FilePath,
+                        nugetMessage.StartLineNumber,
+                        nugetMessage.StartColumnNumber,
+                        nugetMessage.EndLineNumber,
+                        nugetMessage.EndColumnNumber,
+                        nugetMessage.Message);
+                    break;
+                case LogLevel.Error:
+                    _logger.LogError(string.Empty,
+                        enumName,
+                        enumName,
+                        nugetMessage.FilePath,
+                        nugetMessage.StartLineNumber,
+                        nugetMessage.StartColumnNumber,
+                        nugetMessage.EndLineNumber,
+                        nugetMessage.EndColumnNumber,
+                        nugetMessage.Message);
+                    break;
+                default:
+                    _logger.LogMessage(string.Empty,
+                        enumName,
+                        enumName,
+                        nugetMessage.FilePath,
+                        nugetMessage.StartLineNumber,
+                        nugetMessage.StartColumnNumber,
+                        nugetMessage.EndLineNumber,
+                        nugetMessage.EndColumnNumber,
+                        Convert(nugetMessage.Level),
+                        nugetMessage.Message);
+                    break;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public System.Threading.Tasks.Task LogAsync(LogLevel level, string data)
+    {
+        Log(level, data);
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public System.Threading.Tasks.Task LogAsync(ILogMessage message)
+    {
+        Log(message);
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void LogDebug(string data)
+    {
+        Log(LogLevel.Debug, data);
+    }
+
+    /// <inheritdoc />
+    public void LogError(string data)
+    {
+        Log(LogLevel.Error, data);
+    }
+
+    /// <inheritdoc />
+    public void LogInformation(string data)
+    {
+        Log(LogLevel.Information, data);
+    }
+
+    /// <inheritdoc />
+    public void LogInformationSummary(string data)
+    {
+        LogInformation(data);
+    }
+
+    /// <inheritdoc />
+    public void LogMinimal(string data)
+    {
+        Log(LogLevel.Minimal, data);
+    }
+
+    /// <inheritdoc />
+    public void LogVerbose(string data)
+    {
+        Log(LogLevel.Verbose, data);
+    }
+
+    /// <inheritdoc />
+    public void LogWarning(string data)
+    {
+        Log(LogLevel.Warning, data);
+    }
+
+    private static MessageImportance Convert(LogLevel level)
+    {
+        return level switch
+        {
+            LogLevel.Debug => MessageImportance.Low,
+            LogLevel.Verbose => MessageImportance.Low,
+            LogLevel.Information => MessageImportance.Normal,
+            LogLevel.Minimal => MessageImportance.High,
+            _ => MessageImportance.Low,
+        };
+    }
+}

--- a/src/Azure.Functions.Sdk/MonoExtensions.cs
+++ b/src/Azure.Functions.Sdk/MonoExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Mono.Cecil;
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Extensions for Mono.Cecil types.
+/// </summary>
+public static class MonoExtensions
+{
+    /// <summary>
+    /// Gets the first and second arguments from a custom attribute.
+    /// </summary>
+    /// <typeparam name="TFirst">The expected type of the first argument.</typeparam>
+    /// <typeparam name="TSecond">The expected type of the second arargumentg.</typeparam>
+    /// <param name="attribute">The custom attribude.</param>
+    /// <param name="first">The value of the first argument.</param>
+    /// <param name="second">The value of the second argument.</param>
+    public static void GetArguments<TFirst, TSecond>(
+        this CustomAttribute attribute, out TFirst first, out TSecond second)
+    {
+        Throw.IfNull(attribute);
+        Throw.IfLessThan(attribute.ConstructorArguments.Count, 2,
+            "Expected at least two constructor arguments for the attribute.");
+
+        first = (TFirst)attribute.ConstructorArguments[0].Value;
+        second = (TSecond)attribute.ConstructorArguments[1].Value;
+    }
+}

--- a/src/Azure.Functions.Sdk/Strings.resx
+++ b/src/Azure.Functions.Sdk/Strings.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+    <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,119 +59,122 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+        <xsd:element name="root" msdata:IsDataSet="true">
             <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
+                <xsd:choice maxOccurs="unbounded">
+                    <xsd:element name="metadata">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="name" use="required" type="xsd:string"/>
+                            <xsd:attribute name="type" type="xsd:string"/>
+                            <xsd:attribute name="mimetype" type="xsd:string"/>
+                            <xsd:attribute ref="xml:space"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="assembly">
+                        <xsd:complexType>
+                            <xsd:attribute name="alias" type="xsd:string"/>
+                            <xsd:attribute name="name" type="xsd:string"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="data">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+                            <xsd:attribute ref="xml:space"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="resheader">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
             </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
-  <resheader name="resmimetype">
-    <value>text/microsoft-resx</value>
-  </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
-  <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <data name="AZFW0100_Error_CannotRunFuncCli" xml:space="preserve">
-    <value>Unable to launch the Azure Functions Core Tools. Please visit https://aka.ms/azfunc-dotnet-run-error for more details on how to address this problem.</value>
-  </data>
-  <data name="AZFW0101_Error_ExtensionPackageConflict" xml:space="preserve">
-    <value>The AzureFunctionsExtensionPackage {0}/{1} conflicts with existing package  {0}/{2}</value>
-  </data>
-  <data name="AZFW0102_Warning_ExtensionPackageDuplicate" xml:space="preserve">
-    <value>Duplicate extension package found: {0}/{1}</value>
-  </data>
-  <data name="AZFW0103_Error_InvalidExtensionPackageVersion" xml:space="preserve">
-    <value>The Invalid version for AzureFunctionsExtensionPackage '{0}': '{1}'. Ensure the Version metadata on this item is a valid NuGet package version.</value>
-  </data>
-  <data name="AZFW0104_Warning_EndOfLifeFunctionsVersion" xml:space="preserve">
-    <value>Azure Functions '{0}' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/azure-functions-retired-versions for more information on the support policy.</value>
-  </data>
-  <data name="AZFW0105_Error_UsingLegacyFunctionsSdk" xml:space="preserve">
-    <value>Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package.</value>
-  </data>
-  <data name="AZFW0106_Error_UnknownFunctionsVersion" xml:space="preserve">
-    <value>The AzureFunctionsVersion '{0}' is unknown or not supported.</value>
-  </data>
-  <data name="AZFW0107_Warning_UnsupportedTargetFramework" xml:space="preserve">
-    <value>Target framework '{0}' is not supported by Azure Functions. Please see https://learn.microsoft.com/azure/azure-functions/functions-versions?tabs=isolated-process%2Cv4&amp;pivots=programming-language-csharp#languages for in-support versions.</value>
-  </data>
-  <data name="AZFW0108_Error_CustomFunctionPackageReferencesNotAllowed" xml:space="preserve">
-    <value>Custom items in the '_AzureFunctionPackageReference' item group are not allowed.\n{0}</value>
-  </data>
-  <data name="Deploy_AsyncDeployment" xml:space="preserve">
-    <value>Asynchronous deployment. Polling status at {0}</value>
-  </data>
-  <data name="Deploy_BeginPublish" xml:space="preserve">
-    <value>Publishing {0} to {1}</value>
-  </data>
-  <data name="Deploy_CompletedFailure" xml:space="preserve">
-    <value>Failed to publish {0} to {1}.  Status: {2}</value>
-  </data>
-  <data name="Deploy_CompletedSuccess" xml:space="preserve">
-    <value>Successfully published {0} to {1}. Status: {2}</value>
-  </data>
-  <data name="Deploy_Failed" xml:space="preserve">
-    <value>Zip deployment to {0} has failed.\n    {1}\n    HTTP Status: {2}\n    Deployment Status: {3}</value>
-  </data>
-  <data name="Deploy_InvalidPublishUrl" xml:space="preserve">
-    <value>The publish url '{0}' is invalid. Publish url must be an absolute HTTP or HTTPS url.</value>
-  </data>
-  <data name="Deploy_PollFailure" xml:space="preserve">
-    <value>Failed to poll '{0}'. HTTP Status: {1}. Retry count {2}/{3}</value>
-  </data>
-  <data name="Deploy_Status" xml:space="preserve">
-    <value>Deployment status is {0}.</value>
-  </data>
-  <data name="Deploy_StatusWithText" xml:space="preserve">
-    <value>Deployment status is {0}: {1}</value>
-  </data>
-  <data name="Deploy_ZipNotFound" xml:space="preserve">
-    <value>The provided zip file '{0}' was not found.</value>
-  </data>
+        </xsd:element>
+    </xsd:schema>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>2.0</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="AZFW0100_Error_CannotRunFuncCli" xml:space="preserve">
+        <value>Unable to launch the Azure Functions Core Tools. Please visit https://aka.ms/azfunc-dotnet-run-error for more details on how to address this problem.</value>
+    </data>
+    <data name="AZFW0101_Error_ExtensionPackageConflict" xml:space="preserve">
+        <value>The AzureFunctionsExtensionPackage {0}/{1} conflicts with existing package  {0}/{2}</value>
+    </data>
+    <data name="AZFW0102_Warning_ExtensionPackageDuplicate" xml:space="preserve">
+        <value>Duplicate extension package found: {0}/{1}</value>
+    </data>
+    <data name="AZFW0103_Error_InvalidExtensionPackageVersion" xml:space="preserve">
+        <value>The Invalid version for AzureFunctionsExtensionPackage '{0}': '{1}'. Ensure the Version metadata on this item is a valid NuGet package version.</value>
+    </data>
+    <data name="AZFW0104_Warning_EndOfLifeFunctionsVersion" xml:space="preserve">
+        <value>Azure Functions '{0}' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/azure-functions-retired-versions for more information on the support policy.</value>
+    </data>
+    <data name="AZFW0105_Error_UsingLegacyFunctionsSdk" xml:space="preserve">
+        <value>Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package.</value>
+    </data>
+    <data name="AZFW0106_Error_UnknownFunctionsVersion" xml:space="preserve">
+        <value>The AzureFunctionsVersion '{0}' is unknown or not supported.</value>
+    </data>
+    <data name="AZFW0107_Warning_UnsupportedTargetFramework" xml:space="preserve">
+        <value>Target framework '{0}' is not supported by Azure Functions. Please see https://learn.microsoft.com/azure/azure-functions/functions-versions?tabs=isolated-process%2Cv4&amp;pivots=programming-language-csharp#languages for in-support versions.</value>
+    </data>
+    <data name="AZFW0108_Error_CustomFunctionPackageReferencesNotAllowed" xml:space="preserve">
+        <value>Custom items in the '_AzureFunctionPackageReference' item group are not allowed.\n{0}</value>
+    </data>
+    <data name="Deploy_AsyncDeployment" xml:space="preserve">
+        <value>Asynchronous deployment. Polling status at {0}</value>
+    </data>
+    <data name="Deploy_BeginPublish" xml:space="preserve">
+        <value>Publishing {0} to {1}</value>
+    </data>
+    <data name="Deploy_CompletedFailure" xml:space="preserve">
+        <value>Failed to publish {0} to {1}.  Status: {2}</value>
+    </data>
+    <data name="Deploy_CompletedSuccess" xml:space="preserve">
+        <value>Successfully published {0} to {1}. Status: {2}</value>
+    </data>
+    <data name="Deploy_Failed" xml:space="preserve">
+        <value>Zip deployment to {0} has failed.\n    {1}\n    HTTP Status: {2}\n    Deployment Status: {3}</value>
+    </data>
+    <data name="Deploy_InvalidPublishUrl" xml:space="preserve">
+        <value>The publish url '{0}' is invalid. Publish url must be an absolute HTTP or HTTPS url.</value>
+    </data>
+    <data name="Deploy_PollFailure" xml:space="preserve">
+        <value>Failed to poll '{0}'. HTTP Status: {1}. Retry count {2}/{3}</value>
+    </data>
+    <data name="Deploy_Status" xml:space="preserve">
+        <value>Deployment status is {0}.</value>
+    </data>
+    <data name="Deploy_StatusWithText" xml:space="preserve">
+        <value>Deployment status is {0}: {1}</value>
+    </data>
+    <data name="Deploy_ZipNotFound" xml:space="preserve">
+        <value>The provided zip file '{0}' was not found.</value>
+    </data>
+    <data name="MissingProjectAssetsFile" xml:space="preserve">
+        <value>Assets file '{0}' does not exist. Please ensure restore successfully ran.</value>
+    </data>
 </root>

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.props
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.props
@@ -17,6 +17,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.Worker" Project="Sdk.props" />
+  <Import Project="$(MSBuildThisFileDirectory)extensions/Azure.Functions.Sdk.Extensions.props" />
 
   <!-- Enable Azure Functions project capability to enable tools -->
   <ItemGroup>

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
@@ -14,6 +14,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Import Sdk="Microsoft.NET.Sdk.Worker" Project="Sdk.targets" />
   <UsingTask TaskName="$(AzureFunctionsTaskNamespace).FuncSdkLog" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
 
+
   <PropertyGroup>
     <_AzureFunctionsVersionStandardized>$(AzureFunctionsVersion.ToLowerInvariant().Split('-')[0])</_AzureFunctionsVersionStandardized>
     <_FunctionsRuntimeMajorVersion>$(_AzureFunctionsVersionStandardized.TrimStart('vV'))</_FunctionsRuntimeMajorVersion>
@@ -22,6 +23,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
   </PropertyGroup>
 
+  <Import Project="$(MSBuildThisFileDirectory)extensions/Azure.Functions.Sdk.Extensions.targets" />
   <Import Project="$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets"
           Condition="Exists('$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets')" />
 

--- a/src/Azure.Functions.Sdk/Targets/Extensions/Azure.Functions.Sdk.Extensions.props
+++ b/src/Azure.Functions.Sdk/Targets/Extensions/Azure.Functions.Sdk.Extensions.props
@@ -1,0 +1,28 @@
+<!--
+***********************************************************************************************
+Azure.Functions.Sdk.Extensions.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project>
+
+  <PropertyGroup>
+    <AzureFunctionsExtensionProjectName>azure_functions.g.csproj</AzureFunctionsExtensionProjectName>
+    <AzureFunctionsExtensionProjectDirectory Condition="'$(AzureFunctionsExtensionProjectDirectory)' == ''">$(BaseIntermediateOutputPath)azure_functions/</AzureFunctionsExtensionProjectDirectory>
+    <AzureFunctionsExtensionProjectPath Condition="'$(AzureFunctionsExtensionProjectPath)' == ''">$(AzureFunctionsExtensionProjectDirectory)$(AzureFunctionsExtensionProjectName)</AzureFunctionsExtensionProjectPath>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <_AzureFunctionPackageReference>
+      <Version />
+      <SourcePackageId />
+      <IsImplicitlyDefined />
+    </_AzureFunctionPackageReference>
+  </ItemDefinitionGroup>
+
+</Project>

--- a/src/Azure.Functions.Sdk/Targets/Extensions/Azure.Functions.Sdk.Extensions.targets
+++ b/src/Azure.Functions.Sdk/Targets/Extensions/Azure.Functions.Sdk.Extensions.targets
@@ -1,0 +1,32 @@
+<!--
+***********************************************************************************************
+Azure.Functions.Sdk.Extensions.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project>
+
+  <UsingTask TaskName="$(AzureFunctionsTaskNamespace).Extensions.ResolveExtensionPackages" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
+
+  <PropertyGroup>
+    <_FunctionsPackageHashPath>$(AzureFunctionsExtensionProjectDirectory)azure_functions.package.hash</_FunctionsPackageHashPath>
+    <_FunctionsIntermediateExtensionJsonPath>$(IntermediateOutputPath)$(_FunctionsExtensionsJsonName)</_FunctionsIntermediateExtensionJsonPath>
+    <_FunctionsUnusedPackagesCachePath>$(AzureFunctionsExtensionProjectDirectory)azure_functions.unused_packages.cache</_FunctionsUnusedPackagesCachePath>
+  </PropertyGroup>
+
+  <Target Name="GenerateFunctionsExtensionProject" DependsOnTargets="CollectExtensionPackages"
+    AfterTargets="Restore"
+    Condition="'$(DesignTimeBuild)' != 'true'" />
+
+  <Target Name="CollectExtensionPackages" Returns="@(_AzureFunctionPackageReference)">
+    <ResolveExtensionPackages ProjectAssetsFile="$(ProjectAssetsFile)">
+      <Output TaskParameter="ExtensionPackages" ItemName="_AzureFunctionPackageReference" />
+    </ResolveExtensionPackages>
+  </Target>
+
+</Project>

--- a/src/Azure.Functions.Sdk/TaskItemExtensions.cs
+++ b/src/Azure.Functions.Sdk/TaskItemExtensions.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Build.Framework;
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Extensions for <see cref="ITaskItem"/>.
+/// </summary>
+public static class TaskItemExtensions
+{
+    /// <summary>
+    /// Gets the "Version" metadata from the task item.
+    /// </summary>
+    /// <param name="taskItem">The task item.</param>
+    /// <returns>The version metadata, or empty string if not present.</returns>
+    public static string GetVersion(this ITaskItem taskItem)
+    {
+        return taskItem.GetMetadata("Version") ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Sets the "Version" metadata on the task item.
+    /// </summary>
+    /// <param name="taskItem">The task item.</param>
+    /// <param name="version">The version to set.</param>
+    public static void SetVersion(this ITaskItem taskItem, string version)
+    {
+        taskItem.SetMetadata("Version", version);
+    }
+
+    /// <summary>
+    /// Gets the "IsImplicitlyDefined" metadata from the task item.
+    /// </summary>
+    /// <param name="taskItem">The task item.</param>
+    /// <returns><c>true</c> if implicitly defined, <c>false</c> otherwise.</returns>
+    public static bool GetIsImplicitlyDefined(this ITaskItem taskItem)
+    {
+        return bool.TryParse(taskItem.GetMetadata("IsImplicitlyDefined"), out bool isImplicitlyDefined)
+            && isImplicitlyDefined;
+    }
+
+    /// <summary>
+    /// Sets the "IsImplicitlyDefined" metadata on the task item.
+    /// </summary>
+    /// <param name="taskItem">The task item.</param>
+    /// <param name="isImplicitlyDefined">The value to set.</param>
+    public static void SetIsImplicitlyDefined(this ITaskItem taskItem, bool isImplicitlyDefined)
+    {
+        taskItem.SetMetadata("IsImplicitlyDefined", isImplicitlyDefined.ToString().ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// Gets the "SourcePackageId" metadata from the task item.
+    /// </summary>
+    /// <param name="taskItem">The task item.</param>
+    /// <param name="packageId">The package ID, if found.</param>
+    /// <returns><c>true</c> if "SourcePackageId" is found, <c>false</c> if not found.</returns>
+    public static bool TryGetSourcePackageId(
+        this ITaskItem taskItem, [NotNullWhen(true)] out string? packageId)
+    {
+        packageId = taskItem.GetMetadata("SourcePackageId");
+        return !string.IsNullOrEmpty(packageId);
+    }
+
+    /// <summary>
+    /// Sets the "SourcePackageId" metadata on the task item.
+    /// </summary>
+    /// <param name="taskItem">The task item.</param>
+    /// <param name="sourcePackageId">The source package ID to set.</param>
+    public static void SetSourcePackageId(this ITaskItem taskItem, string sourcePackageId)
+    {
+        taskItem.SetMetadata("SourcePackageId", sourcePackageId);
+    }
+}

--- a/src/Azure.Functions.Sdk/Tasks/Extensions/ResolveExtensionPackages.cs
+++ b/src/Azure.Functions.Sdk/Tasks/Extensions/ResolveExtensionPackages.cs
@@ -1,0 +1,171 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
+using Microsoft.Build.Framework;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+
+namespace Azure.Functions.Sdk.Tasks.Extensions;
+
+public class ResolveExtensionPackages(IFileSystem fileSystem)
+    : Microsoft.Build.Utilities.Task, ICancelableTask, IDisposable
+{
+    private readonly CancellationTokenSource _cts = new();
+    private readonly IFileSystem _fileSystem = Throw.IfNull(fileSystem);
+
+    public ResolveExtensionPackages()
+        : this(new FileSystem())
+    {
+    }
+
+    [Required]
+    public string ProjectAssetsFile { get; set; } = string.Empty;
+
+    [Output]
+    public ITaskItem[] ExtensionPackages { get; private set; } = [];
+
+    public void Cancel()
+    {
+        _cts.Cancel();
+    }
+
+    public void Dispose()
+    {
+        _cts.Dispose();
+    }
+
+    public override bool Execute()
+    {
+        if (!TryGetLockFile(out LockFile? lockFile))
+        {
+            return false;
+        }
+
+        List<ITaskItem> extensionPackages = [];
+        FallbackPackagePathResolver resolver = lockFile.GetPathResolver();
+        foreach (LockFileTarget target in lockFile.Targets)
+        {
+            if (!string.IsNullOrEmpty(target.RuntimeIdentifier))
+            {
+                // Scanning specific RID's will be redundant as packages can only condition on TFM.
+                continue;
+            }
+
+            if (_cts.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            foreach (ITaskItem ext in GetExtensionPackages(target, resolver))
+            {
+                extensionPackages.Add(ext);
+            }
+        }
+
+        if (_cts.IsCancellationRequested)
+        {
+            return false;
+        }
+
+        ExtensionPackages = [.. extensionPackages];
+        return !Log.HasLoggedErrors;
+    }
+
+    private static bool ShouldScanLibrary(LockFileTargetLibrary library)
+    {
+        return library.Type == LibraryType.Package
+            && library.Name is not null
+            && FunctionsAssemblyScanner.ShouldScanPackage(library.Name);
+    }
+
+    private bool TryGetLockFile([NotNullWhen(true)] out LockFile? lockFile)
+    {
+        if (_cts.IsCancellationRequested)
+        {
+            lockFile = null;
+            return false;
+        }
+
+        if (!_fileSystem.File.Exists(ProjectAssetsFile))
+        {
+            Log.LogError(Strings.MissingProjectAssetsFile, ProjectAssetsFile);
+            lockFile = null;
+            return false;
+        }
+
+        IFileInfo info = _fileSystem.FileInfo.New(ProjectAssetsFile);
+        using FileSystemStream stream = info.OpenRead();
+        LockFileFormat format = new();
+        lockFile = format.Read(stream, new MSBuildNugetLogger(Log), ProjectAssetsFile);
+        return true;
+    }
+
+    private IEnumerable<ITaskItem> GetExtensionPackages(LockFileTarget target, FallbackPackagePathResolver resolver)
+    {
+        foreach (LockFileTargetLibrary library in target.Libraries)
+        {
+            if (_cts.IsCancellationRequested)
+            {
+                yield break;
+            }
+
+            if (!ShouldScanLibrary(library))
+            {
+                continue;
+            }
+
+            string packagePath = resolver.GetPackageDirectory(library.Name, library.Version);
+            foreach (LockFileItem assembly in library.RuntimeAssemblies)
+            {
+                string path = _fileSystem.Path.Combine(packagePath, assembly.Path);
+                if (TryGetExtensionReference(path, library, out ITaskItem? ext))
+                {
+                    yield return ext;
+                }
+            }
+        }
+    }
+
+    private bool TryGetExtensionReference(
+        string path, LockFileTargetLibrary library, [NotNullWhen(true)] out ITaskItem? ext)
+    {
+        // Lock file will sometimes insert '_._' for assemblies that are not present on disk for a given RID.
+        if (Path.GetExtension(path).ToLowerInvariant() is not (".dll" or ".exe") || !_fileSystem.File.Exists(path))
+        {
+            ext = null;
+            return false;
+        }
+
+        try
+        {
+            if (ExtensionReference.TryGetFromModule(path, library.Name!, out ext))
+            {
+                Log.LogMessage(
+                    MessageImportance.Low,
+                    "Extension {0}/{1} referenced by {2}/{3}",
+                    ext.ItemSpec,
+                    ext.GetVersion(),
+                    library.Name,
+                    library.Version);
+
+                return true;
+            }
+        }
+        catch (Exception ex) when (!ex.IsFatal())
+        {
+            Log.LogError(
+                "Failed to read assembly '{0}' from package '{1}/{2}'.\n{3}: {4}",
+                path,
+                library.Name,
+                library.Version,
+                ex.GetType(),
+                ex.Message);
+        }
+
+        ext = null;
+        return false;
+    }
+}

--- a/src/Azure.Functions.Sdk/Throw.cs
+++ b/src/Azure.Functions.Sdk/Throw.cs
@@ -4,8 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
-namespace Azure.Functions.Sdk;
-
 // TODO: Move this to a shared project.
 /// <summary>
 /// Defines static methods used to throw exceptions.
@@ -15,9 +13,6 @@ namespace Azure.Functions.Sdk;
 /// messages.
 /// Code from https://github.com/dotnet/extensions/blob/v9.7.2/src/Shared/Throw/Throw.cs
 /// </remarks>
-[SuppressMessage("Minor Code Smell", "S4136:Method overloads should be grouped together", Justification = "Doesn't work with the region layout")]
-[SuppressMessage("Minor Code Smell", "S2333:Partial is gratuitous in this context", Justification = "Some projects add additional partial parts.")]
-[SuppressMessage("Design", "CA1716", Justification = "Not part of an API")]
 internal static partial class Throw
 {
     #region For Object

--- a/test/Azure.Functions.Sdk.Tests/Assertions/BuildOutputAssertions.cs
+++ b/test/Azure.Functions.Sdk.Tests/Assertions/BuildOutputAssertions.cs
@@ -27,6 +27,7 @@ internal class BuildOutputAssertions(BuildOutput subject, AssertionChain asserti
     [CustomAssertion]
     public AndConstraint<BuildOutputAssertions> BeSuccessful(string because = "", params object[] becauseArgs)
     {
+        NotBeNull(because, becauseArgs);
         _chain
             .ForCondition(Subject.Succeeded.GetValueOrDefault(false))
             .BecauseOf(because, becauseArgs)
@@ -39,6 +40,7 @@ internal class BuildOutputAssertions(BuildOutput subject, AssertionChain asserti
     [CustomAssertion]
     public AndConstraint<BuildOutputAssertions> BeFailed(string because = "", params object[] becauseArgs)
     {
+        NotBeNull(because, becauseArgs);
         _chain
             .ForCondition(!Subject.Succeeded.GetValueOrDefault(false))
             .BecauseOf(because, becauseArgs)
@@ -57,6 +59,7 @@ internal class BuildOutputAssertions(BuildOutput subject, AssertionChain asserti
     [CustomAssertion]
     public AndConstraint<BuildOutputAssertions> HaveNoErrors(string because = "", params object[] becauseArgs)
     {
+        NotBeNull(because, becauseArgs);
         _chain
             .ForCondition(Subject.ErrorEvents.Count == 0)
             .BecauseOf(because, becauseArgs)
@@ -67,6 +70,7 @@ internal class BuildOutputAssertions(BuildOutput subject, AssertionChain asserti
     [CustomAssertion]
     public AndConstraint<BuildOutputAssertions> HaveNoWarnings(string because = "", params object[] becauseArgs)
     {
+        NotBeNull(because, becauseArgs);
         _chain
             .ForCondition(Subject.WarningEvents.Count == 0)
             .BecauseOf(because, becauseArgs)
@@ -77,6 +81,7 @@ internal class BuildOutputAssertions(BuildOutput subject, AssertionChain asserti
     [CustomAssertion]
     public AndWhichConstraint<BuildOutputAssertions, BuildErrorEventArgs> HaveSingleError(string because = "", params object[] becauseArgs)
     {
+        NotBeNull(because, becauseArgs);
         _chain
             .ForCondition(Subject.ErrorEvents.Count == 1)
             .BecauseOf(because, becauseArgs)
@@ -87,6 +92,7 @@ internal class BuildOutputAssertions(BuildOutput subject, AssertionChain asserti
     [CustomAssertion]
     public AndWhichConstraint<BuildOutputAssertions, BuildWarningEventArgs> HaveSingleWarning(string because = "", params object[] becauseArgs)
     {
+        NotBeNull(because, becauseArgs);
         _chain
             .ForCondition(Subject.WarningEvents.Count == 1)
             .BecauseOf(because, becauseArgs)

--- a/test/Azure.Functions.Sdk.Tests/Assertions/TaskItemAssertions.cs
+++ b/test/Azure.Functions.Sdk.Tests/Assertions/TaskItemAssertions.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AwesomeAssertions.Execution;
+using AwesomeAssertions.Formatting;
+using AwesomeAssertions.Primitives;
+using Microsoft.Build.Framework;
+
+namespace AwesomeAssertions;
+
+internal static partial class AssertionExtensions
+{
+    public static TaskItemAssertions Should(this ITaskItem instance)
+        => new(instance, AssertionChain.GetOrCreate());
+}
+
+internal class TaskItemAssertions(ITaskItem subject, AssertionChain assertionChain)
+    : ObjectAssertions<ITaskItem, TaskItemAssertions>(subject, assertionChain), IProvidesFormatter
+{
+    private readonly AssertionChain _chain = assertionChain;
+
+    protected override string Identifier => "TaskItem";
+
+    public static IValueFormatter CreateFormatter() => new Formatter();
+
+    [CustomAssertion]
+    public AndConstraint<TaskItemAssertions> HaveItemSpec(
+        string expected, string because = "", params object[] becauseArgs)
+    {
+        return HaveItemSpec(expected, StringComparer.Ordinal, because, becauseArgs);
+    }
+
+    [CustomAssertion]
+    public AndConstraint<TaskItemAssertions> HaveItemSpec(
+        string expected, IEqualityComparer<string> comparer, string because = "", params object[] becauseArgs)
+    {
+        NotBeNull(because, becauseArgs);
+
+        string actual = Subject.ItemSpec;
+        _chain
+            .ForCondition(comparer.Equals(actual, expected))
+            .BecauseOf(because, becauseArgs)
+            .FailWith(
+                "Expected {context:TaskItem} to have ItemSpec {0}{reason}, but found {1}.",
+                expected,
+                actual);
+
+        return new AndConstraint<TaskItemAssertions>(this);
+    }
+
+    [CustomAssertion]
+    public AndConstraint<TaskItemAssertions> HaveMetadata(
+        string name, string value, string because = "", params object[] becauseArgs)
+    {
+        return HaveMetadata(name, value, StringComparer.Ordinal, because, becauseArgs);
+    }
+
+    [CustomAssertion]
+    public AndConstraint<TaskItemAssertions> HaveMetadata(
+        string name,
+        string value,
+        IEqualityComparer<string> comparer,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        NotBeNull(because, becauseArgs);
+
+        string? actual = Subject.GetMetadata(name);
+        _chain
+            .ForCondition(comparer.Equals(actual, value))
+            .BecauseOf(because, becauseArgs)
+            .FailWith(
+                "Expected {context:ProjectItem} to have metadata {0} with value {1}{reason}, but found {2}.",
+                name,
+                value,
+                actual ?? "<null>");
+        return new AndConstraint<TaskItemAssertions>(this);
+    }
+
+    private class Formatter : IValueFormatter
+    {
+        public bool CanHandle(object value) => value is ITaskItem;
+
+        public void Format(
+            object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+        {
+            ITaskItem item = (ITaskItem)value;
+            if (context.UseLineBreaks)
+            {
+                formattedGraph.AddLine(item.ItemSpec);
+            }
+            else
+            {
+                formattedGraph.AddFragment(item.ItemSpec);
+            }
+        }
+    }
+}

--- a/test/Azure.Functions.Sdk.Tests/Azure.Functions.Sdk.Tests.csproj
+++ b/test/Azure.Functions.Sdk.Tests/Azure.Functions.Sdk.Tests.csproj
@@ -21,7 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/test/Azure.Functions.Sdk.Tests/FunctionsAssemblyScannerTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/FunctionsAssemblyScannerTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Azure.Functions.Sdk.Tests;
+
+public class FunctionsAssemblyScannerTests
+{
+    public static TheoryData<string> ShouldScanPackageFalseData =>
+        new()
+        {
+            "System.Text.Json",
+            "Azure.Core",
+            "Azure.Identity",
+            "Microsoft.Bcl.AsyncInterfaces",
+            "Microsoft.Extensions.Azure",
+            "Microsoft.Extensions.Configuration",
+            "Microsoft.Extensions.Hosting",
+            "Microsoft.Identity.Client",
+            "Microsoft.NETCore.Platforms",
+            "Microsoft.NETStandard.Library",
+            "Microsoft.Win32.Registry",
+            "Grpc.AspNetCore",
+            "Grpc.Net.Client",
+        };
+
+    public static TheoryData<string> ShouldScanPackageTrueData =>
+        new()
+        {
+            "Azure.CoreOther",
+            "SystemSomethingElse",
+            "Microsoft.BclOther",
+            "Microsoft.Azure.Functions.Worker.Extensions",
+            "Microsoft.Azure.Functions.Worker.Extensions.ServiceBus",
+            "Some.Custom.Package",
+        };
+
+    [Theory]
+    [MemberData(nameof(ShouldScanPackageFalseData))]
+    public void ShouldScanPackage_ReturnsFalse(string assembly)
+    {
+        bool result = FunctionsAssemblyScanner.ShouldScanPackage(assembly);
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(ShouldScanPackageTrueData))]
+    public void ShouldScanPackage_ReturnsTrue(string assembly)
+    {
+        bool result = FunctionsAssemblyScanner.ShouldScanPackage(assembly);
+        result.Should().BeTrue();
+    }
+}

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Targets.CollectExtensionPackages.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Targets.CollectExtensionPackages.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AwesomeAssertions;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities.ProjectCreation;
+
+namespace Azure.Functions.Sdk.Tests.Integration;
+
+public partial class SdkEndToEndTests
+{
+    [Fact]
+    public void Target_CollectExtensionPackages_NoPackageRefs()
+    {
+        // Arrange
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            GetTempCsproj())
+            .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);
+
+        // Act
+        project.Restore().Should().BeSuccessful().And.HaveNoIssues();
+        TargetResult result = project.RunTarget("CollectExtensionPackages")!;
+
+        // Assert
+        result.Should().NotBeNull();
+        result.ResultCode.Should().Be(TargetResultCode.Success);
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Target_CollectExtensionPackages_NonExtensionPackage()
+    {
+        // Arrange
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            GetTempCsproj())
+            .ItemPackageReference("System.Text.Json", "8.0.6")
+            .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);
+
+        // Act
+        project.Restore().Should().BeSuccessful().And.HaveNoIssues();
+        TargetResult result = project.RunTarget("CollectExtensionPackages")!;
+
+        // Assert
+        result.Should().NotBeNull();
+        result.ResultCode.Should().Be(TargetResultCode.Success);
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Target_CollectExtensionPackages()
+    {
+        // Arrange
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            GetTempCsproj())
+            .ItemPackageReference("Microsoft.Azure.Functions.Worker.Extensions.ServiceBus", "5.23.0")
+            .ItemPackageReference("Microsoft.Azure.Functions.Worker.Extensions.Storage", "6.8.0")
+            .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);
+
+        // Act
+        project.Restore().Should().BeSuccessful().And.HaveNoIssues();
+        TargetResult result = project.RunTarget("CollectExtensionPackages")!;
+
+        // Assert
+        result.Should().NotBeNull();
+        result.ResultCode.Should().Be(TargetResultCode.Success);
+        result.Items.Should().HaveCount(3);
+
+        ValidatePackage(
+            result.Items[0],
+            "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "5.17.0",
+            "Microsoft.Azure.Functions.Worker.Extensions.ServiceBus");
+
+        ValidatePackage(
+            result.Items[1],
+            "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "5.3.6",
+            "Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs");
+
+        ValidatePackage(
+            result.Items[2],
+            "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "5.3.6",
+            "Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues");
+    }
+
+    private static void ValidatePackage(
+        ITaskItem package, string expectedId, string expectedVersion, string expectedSourceId)
+    {
+        package.Should().HaveItemSpec(expectedId)
+            .And.HaveMetadata("Version", expectedVersion)
+            .And.HaveMetadata("SourcePackageId", expectedSourceId)
+            .And.HaveMetadata("IsImplicitlyDefined", "true");
+    }
+}

--- a/test/Azure.Functions.Sdk.Tests/TargetOutputs.cs
+++ b/test/Azure.Functions.Sdk.Tests/TargetOutputs.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.Build.Utilities.ProjectCreation;
+
+internal class TargetOutputs : IReadOnlyDictionary<string, TargetResult>
+{
+    public static readonly TargetOutputs Empty = new(ImmutableDictionary<string, TargetResult>.Empty);
+
+    private readonly IDictionary<string, TargetResult> _results;
+
+    private TargetOutputs(IDictionary<string, TargetResult> results)
+    {
+        _results = results ?? ImmutableDictionary<string, TargetResult>.Empty;
+    }
+
+    public TargetResult this[string targetName] => _results[targetName];
+
+    public IEnumerable<string> Keys => _results.Keys;
+
+    public IEnumerable<TargetResult> Values => _results.Values;
+
+    public int Count => _results.Count;
+
+    public static TargetOutputs Create(IDictionary<string, TargetResult>? results)
+        => results is null ? Empty : new(results);
+
+    public bool ContainsKey(string key) => _results.ContainsKey(key);
+
+    public IEnumerator<KeyValuePair<string, TargetResult>> GetEnumerator()
+        => _results.GetEnumerator();
+
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out TargetResult value)
+        => _results.TryGetValue(key, out value);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/test/Azure.Functions.Sdk.Tests/Tasks/Extensions/ResolveExtensionPackagesTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/Extensions/ResolveExtensionPackagesTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Azure.Functions.Sdk.Tests;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities.ProjectCreation;
+using Moq;
+
+namespace Azure.Functions.Sdk.Tasks.Extensions.Tests;
+
+public sealed class ResolveExtensionPackagesTests : IDisposable
+{
+    private readonly TempDirectory _temp = new();
+
+    public void Dispose() => _temp.Dispose();
+
+    [Fact]
+    public void Execute_ReturnsFalse_WhenLockFileDoesNotExist()
+    {
+        // Arrange
+        ResolveExtensionPackages task = CreateTask(_temp.Path, new MockFileSystem());
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeFalse();
+        task.ExtensionPackages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Execute_ReturnsFalse_WhenCancelledBeforeProcessing()
+    {
+        // Arrange
+        Mock<IFileSystem> fileSystem = new(MockBehavior.Strict);
+        ResolveExtensionPackages task = CreateTask(_temp.Path, fileSystem.Object);
+
+        task.Cancel();
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeFalse();
+        fileSystem.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void Execute_ReturnsExtensionPackages_NoPackageRefs()
+    {
+        // Arrange
+        string restore = RestoreProject();
+        ResolveExtensionPackages task = CreateTask(restore);
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();
+        task.ExtensionPackages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Execute_ReturnsExtensionPackages_NonExtensionPackages()
+    {
+        // Arrange
+        string restore = RestoreProject(project =>
+        {
+            project.ItemPackageReference("System.Text.Json", "8.0.6");
+        });
+
+        ResolveExtensionPackages task = CreateTask(restore);
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();
+        task.ExtensionPackages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Execute_ReturnsExtensionPackages_SinglePackage()
+    {
+        // Arrange
+        string restore = RestoreProject(project =>
+        {
+            project.ItemPackageReference("Microsoft.Azure.Functions.Worker.Extensions.ServiceBus", "5.23.0");
+        });
+
+        ResolveExtensionPackages task = CreateTask(restore);
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();
+        task.ExtensionPackages.Should().ContainSingle();
+
+        ValidatePackage(
+            task.ExtensionPackages[0],
+            "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "5.17.0",
+            "Microsoft.Azure.Functions.Worker.Extensions.ServiceBus");
+    }
+
+    [Fact]
+    public void Execute_ReturnsExtensionPackages_MultiplePackages()
+    {
+        // Arrange
+        string restore = RestoreProject(project =>
+        {
+            project.ItemPackageReference("Microsoft.Azure.Functions.Worker.Extensions.ServiceBus", "5.23.0");
+            project.ItemPackageReference("Microsoft.Azure.Functions.Worker.Extensions.Storage", "6.8.0");
+        });
+
+        ResolveExtensionPackages task = CreateTask(restore);
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();   
+        task.ExtensionPackages.Should().HaveCount(3);
+
+        ValidatePackage(
+            task.ExtensionPackages[0],
+            "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "5.17.0",
+            "Microsoft.Azure.Functions.Worker.Extensions.ServiceBus");
+
+        ValidatePackage(
+            task.ExtensionPackages[1],
+            "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "5.3.6",
+            "Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs");
+
+        ValidatePackage(
+            task.ExtensionPackages[2],
+            "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "5.3.6",
+            "Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues");
+    }
+
+    [Fact]
+    public void Dispose_CancelsTokenSource()
+    {
+        MockFileSystem fileSystem = new();
+        ResolveExtensionPackages task = new(fileSystem);
+
+        // No direct assertion, but Dispose should not throw
+        task.Dispose();
+    }
+
+    private static void ValidatePackage(
+        ITaskItem package, string expectedId, string expectedVersion, string expectedSourceId)
+    {
+        package.Should().HaveItemSpec(expectedId)
+            .And.HaveMetadata("Version", expectedVersion)
+            .And.HaveMetadata("SourcePackageId", expectedSourceId)
+            .And.HaveMetadata("IsImplicitlyDefined", "true");
+    }
+
+    private static ResolveExtensionPackages CreateTask(
+        string assetsFile, IFileSystem? fileSystem = null)
+    {
+        return new ResolveExtensionPackages(fileSystem ?? new FileSystem())
+        {
+            BuildEngine = Mock.Of<IBuildEngine>(),
+            ProjectAssetsFile = assetsFile
+        };
+    }
+
+    private string RestoreProject(Action<ProjectCreator>? configure = null)
+    {
+        _temp.WriteNugetConfig();
+        ProjectCreator project = ProjectCreator.Templates.NetCoreProject(
+            path: _temp.GetRandomFile(ext: ".csproj"), targetFramework: "net8.0", configure: configure);
+
+        project.Restore().Should().BeSuccessful(); // use assertion to throw on failure.
+        project.TryGetPropertyValue("ProjectAssetsFile", out string? value);
+        value.Should().NotBeNullOrEmpty();
+        return value!;
+    }
+}

--- a/test/Azure.Functions.Sdk.Tests/TempDirectory.cs
+++ b/test/Azure.Functions.Sdk.Tests/TempDirectory.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using IOPath = System.IO.Path;
+
+namespace Azure.Functions.Sdk.Tests;
+
+internal sealed class TempDirectory : IDisposable
+{
+    public TempDirectory()
+    {
+        Path = IOPath.Combine(IOPath.GetTempPath(), IOPath.GetRandomFileName());
+        Directory.CreateDirectory(Path);
+    }
+
+    public string Path { get; }
+
+    public void WriteNugetConfig()
+    {
+        File.WriteAllText(
+            IOPath.Combine(Path, "nuget.config"),
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+            <packageSources>
+                <clear />
+                <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+            </packageSources>
+            </configuration>
+            """);
+    }
+
+    public string GetRandomFile(string? ext = null)
+    {
+        string path = IOPath.Combine(Path, IOPath.GetRandomFileName());
+        if (!string.IsNullOrEmpty(ext))
+        {
+            if (!ext.StartsWith('.'))
+            {
+                ext = "." + ext;
+            }
+
+            path += ext;
+        }
+
+        return path;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore exceptions during cleanup
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Part of #3133

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR adds a target and task which scan for and collect all WebJobs extension references from the currently referenced nuget packages. This is done by directly loading the `project.assets.json` after restore has finished, scanning all referenced runtime assemblies, and checking for the `ExtensionInformationAttribute`.

**KNOWN GAP**: there is a known gap with this approach with the current SDK: we cannot pickup `ExtensionInformationAttribute` from p2p references, as we are hooking into restore. Any p2p reference will not be built yet, and thus we cannot discover attributes from them. The only potential solution to this is to support a way to supply extension references via MSBuild. Which we are unsure about at this time.
