### PR TITLE
Remove net6.0 prelaunch app

### DIFF
--- a/eng/ci/templates/official/jobs/build-host-prelaunch-artifacts.yml
+++ b/eng/ci/templates/official/jobs/build-host-prelaunch-artifacts.yml
@@ -12,7 +12,7 @@ jobs:
       artifact: _preLaunchAppPackages
 
   variables:
-    dotnetVersions: 'net10.0,net9.0,net8.0,net6.0'
+    dotnetVersions: 'net10.0,net9.0,net8.0'
 
   steps:
   - template: /eng/ci/templates/steps/install-dotnet.yml@self

--- a/host/src/PrelaunchApp/App.csproj
+++ b/host/src/PrelaunchApp/App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <DebugSymbols>False</DebugSymbols>
     <DebugType>None</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
Removing unsupported .net versions (net6,0, net7.0) from prelaunch app.

Net7.0 was already removed in [this change](https://github.com/Azure/azure-functions-dotnet-worker/commit/52c54406d28f96dc52fd4872379d24c966904856#diff-8ab6a51b6f9f40b8125c8e8f0397522d3ad5ad9999bb5f94c05a92d26f328bc7L15) which prevented the pipeline to publish the net7 version of the prelaunch app. In this PR, I am also removing the unsupported entries from the project file as well.

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
