### PR TITLE
feat: Add KafkaRecord type and converter for Kafka trigger binding - Phase 2b

### DIFF
--- a/extensions/Worker.Extensions.Kafka/src/KafkaHeader.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaHeader.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// Represents a single Kafka record header (key-value pair where value is raw bytes).
+    /// </summary>
+    public class KafkaHeader
+    {
+        /// <summary>
+        /// Gets or sets the header key.
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Gets or sets the header value as raw bytes.
+        /// </summary>
+        public byte[] Value { get; set; }
+
+        /// <summary>
+        /// Gets the header value as a UTF-8 string, or null if the value is null.
+        /// </summary>
+        public string GetValueAsString()
+        {
+            return Value is null ? null : Encoding.UTF8.GetString(Value);
+        }
+    }
+}

--- a/extensions/Worker.Extensions.Kafka/src/KafkaRecord.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaRecord.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// Represents a raw Apache Kafka record with full metadata.
+    /// Key and value are raw bytes — the user controls deserialization.
+    /// </summary>
+    public class KafkaRecord
+    {
+        /// <summary>
+        /// Gets or sets the topic name this record was consumed from.
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
+        /// Gets or sets the partition this record was consumed from.
+        /// </summary>
+        public int Partition { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset of this record within the partition.
+        /// </summary>
+        public long Offset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the raw key bytes. Null if the record has no key.
+        /// </summary>
+        public byte[] Key { get; set; }
+
+        /// <summary>
+        /// Gets or sets the raw value bytes. Null if the record has no value.
+        /// </summary>
+        public byte[] Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the record timestamp.
+        /// </summary>
+        public KafkaTimestamp Timestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the record headers.
+        /// </summary>
+        public KafkaHeader[] Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the leader epoch, if available. Null if not provided by the broker.
+        /// </summary>
+        public int? LeaderEpoch { get; set; }
+    }
+}

--- a/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
@@ -62,15 +62,15 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Kafka
                     $"Unexpected content type '{binding.ContentType}'. Expected '{ExpectedContentType}'.");
             }
 
-            var proto = KafkaRecordProto.Parser.ParseFrom(binding.Content);
+            var proto = KafkaRecordProto.Parser.ParseFrom(binding.Content.ToArray());
 
             return new KafkaRecord
             {
                 Topic = proto.Topic,
                 Partition = proto.Partition,
                 Offset = proto.Offset,
-                Key = proto.Key.IsEmpty ? null : proto.Key.ToByteArray(),
-                Value = proto.Value.IsEmpty ? null : proto.Value.ToByteArray(),
+                Key = proto.HasKey ? proto.Key.ToByteArray() : null,
+                Value = proto.HasValue ? proto.Value.ToByteArray() : null,
                 LeaderEpoch = proto.HasLeaderEpoch ? proto.LeaderEpoch : (int?)null,
                 Timestamp = proto.Timestamp != null
                     ? new KafkaTimestamp
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Kafka
                 Headers = proto.Headers.Select(h => new KafkaHeader
                 {
                     Key = h.Key,
-                    Value = h.Value.IsEmpty ? null : h.Value.ToByteArray(),
+                    Value = h.HasValue ? h.Value.ToByteArray() : null,
                 }).ToArray(),
             };
         }

--- a/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Core;
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+using Microsoft.Azure.Functions.Worker.Extensions.Kafka.Proto;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Kafka
+{
+    /// <summary>
+    /// Converter to bind to <see cref="KafkaRecord"/> or <see cref="KafkaRecord[]"/> type parameters.
+    /// Deserializes Protobuf-encoded ModelBindingData from the host-side Kafka extension.
+    /// </summary>
+    [SupportsDeferredBinding]
+    [SupportedTargetType(typeof(KafkaRecord))]
+    [SupportedTargetType(typeof(KafkaRecord[]))]
+    internal class KafkaRecordConverter : IInputConverter
+    {
+        internal const string ExpectedBindingSource = "AzureKafkaRecord";
+        internal const string ExpectedContentType = "application/x-protobuf";
+
+        public ValueTask<ConversionResult> ConvertAsync(ConverterContext context)
+        {
+            try
+            {
+                ConversionResult result = context?.Source switch
+                {
+                    ModelBindingData binding => ConversionResult.Success(ConvertToKafkaRecord(binding)),
+                    CollectionModelBindingData collection => ConversionResult.Success(
+                        collection.ModelBindingData.Select(ConvertToKafkaRecord).ToArray()),
+                    _ => ConversionResult.Unhandled(),
+                };
+
+                return new ValueTask<ConversionResult>(result);
+            }
+            catch (Exception exception)
+            {
+                return new ValueTask<ConversionResult>(ConversionResult.Failed(exception));
+            }
+        }
+
+        private static KafkaRecord ConvertToKafkaRecord(ModelBindingData binding)
+        {
+            if (binding is null)
+            {
+                throw new ArgumentNullException(nameof(binding));
+            }
+
+            if (binding.Source is not ExpectedBindingSource)
+            {
+                throw new InvalidOperationException(
+                    $"Unexpected binding source '{binding.Source}'. Expected '{ExpectedBindingSource}'.");
+            }
+
+            if (binding.ContentType is not ExpectedContentType)
+            {
+                throw new InvalidOperationException(
+                    $"Unexpected content type '{binding.ContentType}'. Expected '{ExpectedContentType}'.");
+            }
+
+            var proto = KafkaRecordProto.Parser.ParseFrom(binding.Content);
+
+            return new KafkaRecord
+            {
+                Topic = proto.Topic,
+                Partition = proto.Partition,
+                Offset = proto.Offset,
+                Key = proto.Key.IsEmpty ? null : proto.Key.ToByteArray(),
+                Value = proto.Value.IsEmpty ? null : proto.Value.ToByteArray(),
+                LeaderEpoch = proto.HasLeaderEpoch ? proto.LeaderEpoch : (int?)null,
+                Timestamp = proto.Timestamp != null
+                    ? new KafkaTimestamp
+                    {
+                        UnixTimestampMs = proto.Timestamp.UnixTimestampMs,
+                        Type = (KafkaTimestampType)proto.Timestamp.Type,
+                    }
+                    : null,
+                Headers = proto.Headers.Select(h => new KafkaHeader
+                {
+                    Key = h.Key,
+                    Value = h.Value.IsEmpty ? null : h.Value.ToByteArray(),
+                }).ToArray(),
+            };
+        }
+    }
+}

--- a/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
@@ -6,10 +6,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Converters;
 using Microsoft.Azure.Functions.Worker.Core;
+using Microsoft.Azure.Functions.Worker.Extensions;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 using Microsoft.Azure.Functions.Worker.Extensions.Kafka.Proto;
 
-namespace Microsoft.Azure.Functions.Worker.Extensions.Kafka
+namespace Microsoft.Azure.Functions.Worker
 {
     /// <summary>
     /// Converter to bind to <see cref="KafkaRecord"/> or <see cref="KafkaRecord[]"/> type parameters.
@@ -74,7 +75,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Kafka
                     ? new KafkaTimestamp
                     {
                         UnixTimestampMs = proto.Timestamp.UnixTimestampMs,
-                        Type = (KafkaTimestampType)proto.Timestamp.Type,
+                        Type = System.Enum.IsDefined(typeof(KafkaTimestampType), proto.Timestamp.Type)
+                            ? (KafkaTimestampType)proto.Timestamp.Type
+                            : KafkaTimestampType.NotAvailable,
                     }
                     : null,
                 Headers = proto.Headers.Select(h => new KafkaHeader

--- a/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
@@ -52,17 +52,15 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Kafka
 
             if (binding.Source is not ExpectedBindingSource)
             {
-                throw new InvalidOperationException(
-                    $"Unexpected binding source '{binding.Source}'. Expected '{ExpectedBindingSource}'.");
+                throw new InvalidBindingSourceException(binding.Source, ExpectedBindingSource);
             }
 
             if (binding.ContentType is not ExpectedContentType)
             {
-                throw new InvalidOperationException(
-                    $"Unexpected content type '{binding.ContentType}'. Expected '{ExpectedContentType}'.");
+                throw new InvalidContentTypeException(binding.ContentType, ExpectedContentType);
             }
 
-            var proto = KafkaRecordProto.Parser.ParseFrom(binding.Content.ToArray());
+            var proto = KafkaRecordProto.Parser.ParseFrom(binding.Content.ToMemory().Span);
 
             return new KafkaRecord
             {

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTimestamp.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTimestamp.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.Functions.Worker
         public KafkaTimestampType Type { get; set; }
 
         /// <summary>
-        /// Gets the timestamp as a <see cref="DateTimeOffset"/>.
+        /// Gets the timestamp as a <see cref="System.DateTimeOffset"/>.
         /// </summary>
-        public DateTimeOffset DateTime => DateTimeOffset.FromUnixTimeMilliseconds(UnixTimestampMs);
+        public DateTimeOffset DateTimeOffset => System.DateTimeOffset.FromUnixTimeMilliseconds(UnixTimestampMs);
     }
 }

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTimestamp.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTimestamp.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// Represents the timestamp of a Kafka record.
+    /// </summary>
+    public class KafkaTimestamp
+    {
+        /// <summary>
+        /// Gets or sets the timestamp as Unix milliseconds since epoch.
+        /// </summary>
+        public long UnixTimestampMs { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp type.
+        /// </summary>
+        public KafkaTimestampType Type { get; set; }
+
+        /// <summary>
+        /// Gets the timestamp as a <see cref="DateTimeOffset"/>.
+        /// </summary>
+        public DateTimeOffset DateTime => DateTimeOffset.FromUnixTimeMilliseconds(UnixTimestampMs);
+    }
+}

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTimestampType.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTimestampType.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// Defines the type of a Kafka record timestamp.
+    /// </summary>
+    public enum KafkaTimestampType
+    {
+        /// <summary>Timestamp type is not available.</summary>
+        NotAvailable = 0,
+
+        /// <summary>Timestamp was set by the producer (record creation time).</summary>
+        CreateTime = 1,
+
+        /// <summary>Timestamp was set by the broker (log append time).</summary>
+        LogAppendTime = 2,
+    }
+}

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
@@ -4,10 +4,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Azure.Functions.Worker.Converters;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+using Microsoft.Azure.Functions.Worker.Extensions.Kafka;
 
 namespace Microsoft.Azure.Functions.Worker
 {
+    [InputConverter(typeof(KafkaRecordConverter))]
     [BindingCapabilities(KnownBindingCapabilities.FunctionLevelRetry)]
     public sealed class KafkaTriggerAttribute : TriggerBindingAttribute, ISupportCardinality
     {

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.Azure.Functions.Worker.Converters;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
-using Microsoft.Azure.Functions.Worker.Extensions.Kafka;
 
 namespace Microsoft.Azure.Functions.Worker
 {

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.Functions.Worker.Extensions.Kafka;
 namespace Microsoft.Azure.Functions.Worker
 {
     [InputConverter(typeof(KafkaRecordConverter))]
+    [ConverterFallbackBehavior(ConverterFallbackBehavior.Default)]
     [BindingCapabilities(KnownBindingCapabilities.FunctionLevelRetry)]
     public sealed class KafkaTriggerAttribute : TriggerBindingAttribute, ISupportCardinality
     {

--- a/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
+++ b/extensions/Worker.Extensions.Kafka/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Azure.Functions.Worker.Extensions.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001005148be37ac1d9f58bd40a2e472c9d380d635b6048278f7d47480b08c928858f0f7fe17a6e4ce98da0e7a7f0b8c308aecd9e9b02d7e9680a5b5b75ac7773cec096fbbc64aebd429e77cb5f89a569a79b28e9c76426783f624b6b70327eb37341eb498a2c3918af97c4860db6cdca4732787150841e395a29cfacb959c1fd971c1")]

--- a/extensions/Worker.Extensions.Kafka/src/Proto/KafkaRecordProto.proto
+++ b/extensions/Worker.Extensions.Kafka/src/Proto/KafkaRecordProto.proto
@@ -12,8 +12,8 @@ message KafkaRecordProto {
     string topic = 1;
     int32 partition = 2;
     int64 offset = 3;
-    bytes key = 4;
-    bytes value = 5;
+    optional bytes key = 4;
+    optional bytes value = 5;
     KafkaTimestampProto timestamp = 6;
     repeated KafkaHeaderProto headers = 7;
     optional int32 leader_epoch = 8;
@@ -29,5 +29,5 @@ message KafkaTimestampProto {
 
 message KafkaHeaderProto {
     string key = 1;
-    bytes value = 2;
+    optional bytes value = 2;
 }

--- a/extensions/Worker.Extensions.Kafka/src/Proto/KafkaRecordProto.proto
+++ b/extensions/Worker.Extensions.Kafka/src/Proto/KafkaRecordProto.proto
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+syntax = "proto3";
+package azure.functions.kafka;
+option csharp_namespace = "Microsoft.Azure.Functions.Worker.Extensions.Kafka.Proto";
+
+// Represents a single Kafka record aligned with the Apache Kafka specification.
+// This schema must stay in sync with the host-side KafkaRecordProto.proto in
+// Microsoft.Azure.WebJobs.Extensions.Kafka.
+message KafkaRecordProto {
+    string topic = 1;
+    int32 partition = 2;
+    int64 offset = 3;
+    bytes key = 4;
+    bytes value = 5;
+    KafkaTimestampProto timestamp = 6;
+    repeated KafkaHeaderProto headers = 7;
+    optional int32 leader_epoch = 8;
+
+    // Reserved for future fields. Do not reuse field numbers.
+    reserved 9 to 15;
+}
+
+message KafkaTimestampProto {
+    int64 unix_timestamp_ms = 1;
+    int32 type = 2; // 0=NotAvailable, 1=CreateTime, 2=LogAppendTime
+}
+
+message KafkaHeaderProto {
+    string key = 1;
+    bytes value = 2;
+}

--- a/extensions/Worker.Extensions.Kafka/src/Proto/KafkaRecordProto.proto
+++ b/extensions/Worker.Extensions.Kafka/src/Proto/KafkaRecordProto.proto
@@ -6,7 +6,7 @@ package azure.functions.kafka;
 option csharp_namespace = "Microsoft.Azure.Functions.Worker.Extensions.Kafka.Proto";
 
 // Represents a single Kafka record aligned with the Apache Kafka specification.
-// This schema must stay in sync with the host-side KafkaRecordProto.proto in
+// This schema must stay in sync with the WebJobs extension copy of KafkaRecordProto.proto in
 // Microsoft.Azure.WebJobs.Extensions.Kafka.
 message KafkaRecordProto {
     string topic = 1;

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -31,7 +31,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Kafka" Version="4.1.4" />
+    <SharedReference Include="..\..\Worker.Extensions.Shared\Worker.Extensions.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Kafka" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -21,6 +21,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.60.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.19.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Proto\KafkaRecordProto.proto" GrpcServices="None" Access="internal" />
+  </ItemGroup>
+
+  <ItemGroup>
     <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Kafka" Version="4.1.4" />
   </ItemGroup>
 

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.60.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.32.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.72.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.19.0" />
   </ItemGroup>
 

--- a/test/extensions/Worker.Extensions.Tests/Kafka/KafkaRecordConverterTests.cs
+++ b/test/extensions/Worker.Extensions.Tests/Kafka/KafkaRecordConverterTests.cs
@@ -1,0 +1,345 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Extensions.Kafka;
+using Microsoft.Azure.Functions.Worker.Extensions.Kafka.Proto;
+using Microsoft.Azure.Functions.Worker.Grpc.Messages;
+using Microsoft.Azure.Functions.Worker.Tests.Converters;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Kafka
+{
+    public class KafkaRecordConverterTests
+    {
+        [Fact]
+        public async Task ConvertAsync_ReturnsSuccess()
+        {
+            var proto = CreateTestKafkaRecordProto();
+            var data = CreateGrpcModelBindingData(proto);
+
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, result.Status);
+            var output = result.Value as KafkaRecord;
+            Assert.NotNull(output);
+            AssertKafkaRecord(output);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_Batch_ReturnsSuccess()
+        {
+            var proto = CreateTestKafkaRecordProto();
+            var bytes = proto.ToByteArray();
+
+            var data1 = new ModelBindingData
+            {
+                Version = "1.0",
+                Source = KafkaRecordConverter.ExpectedBindingSource,
+                Content = ByteString.CopyFrom(bytes),
+                ContentType = KafkaRecordConverter.ExpectedContentType,
+            };
+            var data2 = new ModelBindingData
+            {
+                Version = "1.0",
+                Source = KafkaRecordConverter.ExpectedBindingSource,
+                Content = ByteString.CopyFrom(bytes),
+                ContentType = KafkaRecordConverter.ExpectedContentType,
+            };
+
+            var collection = new CollectionModelBindingData();
+            collection.ModelBindingData.Add(data1);
+            collection.ModelBindingData.Add(data2);
+
+            var context = new TestConverterContext(typeof(KafkaRecord[]), new GrpcCollectionModelBindingData(collection));
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, result.Status);
+            var output = result.Value as KafkaRecord[];
+            Assert.NotNull(output);
+            Assert.Equal(2, output.Length);
+            AssertKafkaRecord(output[0]);
+            AssertKafkaRecord(output[1]);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_ReturnsFailure_WrongSource()
+        {
+            var proto = CreateTestKafkaRecordProto();
+
+            var data = new GrpcModelBindingData(new ModelBindingData
+            {
+                Version = "1.0",
+                Source = "some-other-source",
+                Content = ByteString.CopyFrom(proto.ToByteArray()),
+                ContentType = KafkaRecordConverter.ExpectedContentType,
+            });
+
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Failed, result.Status);
+            Assert.Null(result.Value);
+            Assert.Equal(
+                "Unexpected binding source 'some-other-source'. Only 'AzureKafkaRecord' is supported.",
+                result.Error.Message);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_ReturnsFailure_WrongContentType()
+        {
+            var proto = CreateTestKafkaRecordProto();
+
+            var data = new GrpcModelBindingData(new ModelBindingData
+            {
+                Version = "1.0",
+                Source = KafkaRecordConverter.ExpectedBindingSource,
+                Content = ByteString.CopyFrom(proto.ToByteArray()),
+                ContentType = "application/json",
+            });
+
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Failed, result.Status);
+            Assert.Null(result.Value);
+            Assert.Equal(
+                "Unexpected content-type 'application/json'. Only 'application/x-protobuf' is supported.",
+                result.Error.Message);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_Batch_ReturnsFailure_WrongSource()
+        {
+            var proto = CreateTestKafkaRecordProto();
+
+            var data = new ModelBindingData
+            {
+                Version = "1.0",
+                Source = "some-other-source",
+                Content = ByteString.CopyFrom(proto.ToByteArray()),
+                ContentType = KafkaRecordConverter.ExpectedContentType,
+            };
+
+            var collection = new CollectionModelBindingData();
+            collection.ModelBindingData.Add(data);
+
+            var context = new TestConverterContext(typeof(KafkaRecord[]), new GrpcCollectionModelBindingData(collection));
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Failed, result.Status);
+            Assert.Null(result.Value);
+            Assert.Equal(
+                "Unexpected binding source 'some-other-source'. Only 'AzureKafkaRecord' is supported.",
+                result.Error.Message);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_PreservesNullKeyAndValue()
+        {
+            var proto = new KafkaRecordProto
+            {
+                Topic = "test-topic",
+                Partition = 0,
+                Offset = 100,
+                Timestamp = new KafkaTimestampProto
+                {
+                    UnixTimestampMs = 1700000000000,
+                    Type = 1,
+                },
+            };
+            // Key and Value deliberately not set (null semantics via optional bytes)
+
+            var data = CreateGrpcModelBindingData(proto);
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, result.Status);
+            var output = result.Value as KafkaRecord;
+            Assert.NotNull(output);
+            Assert.Null(output.Key);
+            Assert.Null(output.Value);
+            Assert.Equal("test-topic", output.Topic);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_PreservesHeaders()
+        {
+            var proto = new KafkaRecordProto
+            {
+                Topic = "test-topic",
+                Partition = 0,
+                Offset = 0,
+                Value = ByteString.CopyFromUtf8("test"),
+                Timestamp = new KafkaTimestampProto { UnixTimestampMs = 0, Type = 0 },
+            };
+            proto.Headers.Add(new KafkaHeaderProto
+            {
+                Key = "correlation-id",
+                Value = ByteString.CopyFromUtf8("abc-123"),
+            });
+            proto.Headers.Add(new KafkaHeaderProto
+            {
+                Key = "null-value-header",
+                // Value intentionally not set
+            });
+
+            var data = CreateGrpcModelBindingData(proto);
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, result.Status);
+            var output = result.Value as KafkaRecord;
+            Assert.NotNull(output);
+            Assert.Equal(2, output.Headers.Length);
+
+            Assert.Equal("correlation-id", output.Headers[0].Key);
+            Assert.Equal("abc-123", output.Headers[0].GetValueAsString());
+
+            Assert.Equal("null-value-header", output.Headers[1].Key);
+            Assert.Null(output.Headers[1].Value);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_PreservesLeaderEpoch()
+        {
+            var proto = CreateTestKafkaRecordProto();
+            proto.LeaderEpoch = 42;
+
+            var data = CreateGrpcModelBindingData(proto);
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, result.Status);
+            var output = result.Value as KafkaRecord;
+            Assert.NotNull(output);
+            Assert.Equal(42, output.LeaderEpoch);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_NoLeaderEpoch_ReturnsNull()
+        {
+            var proto = new KafkaRecordProto
+            {
+                Topic = "test-topic",
+                Partition = 0,
+                Offset = 0,
+                Value = ByteString.CopyFromUtf8("test"),
+                Timestamp = new KafkaTimestampProto { UnixTimestampMs = 0, Type = 0 },
+            };
+            // LeaderEpoch deliberately not set
+
+            var data = CreateGrpcModelBindingData(proto);
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, result.Status);
+            var output = result.Value as KafkaRecord;
+            Assert.NotNull(output);
+            Assert.Null(output.LeaderEpoch);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_ReturnsUnhandled_NullSource()
+        {
+            var context = new TestConverterContext(typeof(KafkaRecord), source: null);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Unhandled, result.Status);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_TimestampTypes()
+        {
+            var proto = new KafkaRecordProto
+            {
+                Topic = "test-topic",
+                Partition = 0,
+                Offset = 0,
+                Value = ByteString.CopyFromUtf8("test"),
+                Timestamp = new KafkaTimestampProto
+                {
+                    UnixTimestampMs = 1700000000000,
+                    Type = 2, // LogAppendTime
+                },
+            };
+
+            var data = CreateGrpcModelBindingData(proto);
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, result.Status);
+            var output = result.Value as KafkaRecord;
+            Assert.NotNull(output);
+            Assert.Equal(KafkaTimestampType.LogAppendTime, output.Timestamp.Type);
+            Assert.Equal(1700000000000, output.Timestamp.UnixTimestampMs);
+            Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1700000000000), output.Timestamp.DateTime);
+        }
+
+        private static KafkaRecordProto CreateTestKafkaRecordProto()
+        {
+            var proto = new KafkaRecordProto
+            {
+                Topic = "my-topic",
+                Partition = 3,
+                Offset = 12345,
+                Key = ByteString.CopyFromUtf8("my-key"),
+                Value = ByteString.CopyFromUtf8("{\"name\":\"test\"}"),
+                Timestamp = new KafkaTimestampProto
+                {
+                    UnixTimestampMs = 1700000000000,
+                    Type = 1, // CreateTime
+                },
+                LeaderEpoch = 7,
+            };
+            proto.Headers.Add(new KafkaHeaderProto
+            {
+                Key = "trace-id",
+                Value = ByteString.CopyFromUtf8("trace-abc"),
+            });
+            return proto;
+        }
+
+        private static GrpcModelBindingData CreateGrpcModelBindingData(KafkaRecordProto proto)
+        {
+            return new GrpcModelBindingData(new ModelBindingData
+            {
+                Version = "1.0",
+                Source = KafkaRecordConverter.ExpectedBindingSource,
+                Content = ByteString.CopyFrom(proto.ToByteArray()),
+                ContentType = KafkaRecordConverter.ExpectedContentType,
+            });
+        }
+
+        private static void AssertKafkaRecord(KafkaRecord record)
+        {
+            Assert.Equal("my-topic", record.Topic);
+            Assert.Equal(3, record.Partition);
+            Assert.Equal(12345, record.Offset);
+            Assert.Equal("my-key", Encoding.UTF8.GetString(record.Key));
+            Assert.Equal("{\"name\":\"test\"}", Encoding.UTF8.GetString(record.Value));
+            Assert.Equal(1700000000000, record.Timestamp.UnixTimestampMs);
+            Assert.Equal(KafkaTimestampType.CreateTime, record.Timestamp.Type);
+            Assert.Equal(7, record.LeaderEpoch);
+            Assert.Single(record.Headers);
+            Assert.Equal("trace-id", record.Headers[0].Key);
+            Assert.Equal("trace-abc", record.Headers[0].GetValueAsString());
+        }
+    }
+}

--- a/test/extensions/Worker.Extensions.Tests/Kafka/KafkaRecordConverterTests.cs
+++ b/test/extensions/Worker.Extensions.Tests/Kafka/KafkaRecordConverterTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using Microsoft.Azure.Functions.Worker.Converters;
-using Microsoft.Azure.Functions.Worker.Extensions.Kafka;
 using Microsoft.Azure.Functions.Worker.Extensions.Kafka.Proto;
 using Microsoft.Azure.Functions.Worker.Grpc.Messages;
 using Microsoft.Azure.Functions.Worker.Tests.Converters;
@@ -289,7 +288,35 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Kafka
             Assert.NotNull(output);
             Assert.Equal(KafkaTimestampType.LogAppendTime, output.Timestamp.Type);
             Assert.Equal(1700000000000, output.Timestamp.UnixTimestampMs);
-            Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1700000000000), output.Timestamp.DateTime);
+            Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1700000000000), output.Timestamp.DateTimeOffset);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_UnknownTimestampType_FallsBackToNotAvailable()
+        {
+            var proto = new KafkaRecordProto
+            {
+                Topic = "test-topic",
+                Partition = 0,
+                Offset = 0,
+                Value = ByteString.CopyFromUtf8("test"),
+                Timestamp = new KafkaTimestampProto
+                {
+                    UnixTimestampMs = 1700000000000,
+                    Type = 99, // Unknown future value
+                },
+            };
+
+            var data = CreateGrpcModelBindingData(proto);
+            var context = new TestConverterContext(typeof(KafkaRecord), data);
+            var converter = new KafkaRecordConverter();
+            var result = await converter.ConvertAsync(context);
+
+            Assert.Equal(ConversionStatus.Succeeded, result.Status);
+            var output = result.Value as KafkaRecord;
+            Assert.NotNull(output);
+            Assert.Equal(KafkaTimestampType.NotAvailable, output.Timestamp.Type);
+            Assert.Equal(1700000000000, output.Timestamp.UnixTimestampMs);
         }
 
         private static KafkaRecordProto CreateTestKafkaRecordProto()

--- a/test/extensions/Worker.Extensions.Tests/Worker.Extensions.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Tests/Worker.Extensions.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="$(ExtensionsRoot)Worker.Extensions.EventGrid/src/Worker.Extensions.EventGrid.csproj" />
     <ProjectReference Include="$(ExtensionsRoot)Worker.Extensions.EventHubs/src/Worker.Extensions.EventHubs.csproj" />
     <ProjectReference Include="$(ExtensionsRoot)Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj" />
+    <ProjectReference Include="$(ExtensionsRoot)Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj" />
     <ProjectReference Include="$(ExtensionsRoot)Worker.Extensions.ServiceBus/src/Worker.Extensions.ServiceBus.csproj" />
     <ProjectReference Include="$(ExtensionsRoot)Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj" />
     <ProjectReference Include="$(ExtensionsRoot)Worker.Extensions.Tables/src/Worker.Extensions.Tables.csproj" />


### PR DESCRIPTION
## Summary

Phase 2b of raw Kafka record support: Add KafkaRecord POCO types and IInputConverter for .NET Isolated Worker, enabling users to bind to raw Apache Kafka records with full metadata via Protobuf deserialization.

## Issue
Relates to Azure/azure-functions-kafka-extension#612

## Changes

### New files
- **KafkaRecord.cs** - Apache Kafka spec-aligned POCO with raw byte[] key/value, no generics
- **KafkaHeader.cs** - Header type with GetValueAsString helper
- **KafkaTimestamp.cs** - Timestamp with UnixTimestampMs and DateTime property
- **KafkaTimestampType.cs** - Enum: NotAvailable, CreateTime, LogAppendTime
- **KafkaRecordConverter.cs** - IInputConverter with SupportsDeferredBinding, follows ServiceBus/EventHubs pattern
- **Proto/KafkaRecordProto.proto** - Protobuf schema matching host-side serialization

### Modified files
- **KafkaTriggerAttribute.cs** - Added InputConverter attribute wiring
- **Worker.Extensions.Kafka.csproj** - Added Google.Protobuf, Grpc.Tools, Worker.Core dependencies

## Breaking Changes
None. All existing binding types continue to work unchanged. Users opt in via KafkaRecord parameter type.

## Testing
- [x] Unit tests: N/A - no test project exists for Worker.Extensions.Kafka in this repo
- [x] Architecture lint: N/A - no architecture linter in this repo
- [x] Vulnerability scan: clean
- [ ] E2E tests: skip - requires paired host-side extension from azure-functions-kafka-extension PR #619
- [x] Build: 0 errors, 0 warnings

## Self-Review Checklist
- [x] No intermediate files
- [x] No debug statements or TODO comments
- [x] No hardcoded credentials or sensitive data
- [x] Commit messages follow conventional format

## Note
This PR is the **worker-side counterpart** to azure-functions-kafka-extension PR #619. Both packages must be released together for the KafkaRecord binding to function end-to-end. The host-side serializes IKafkaEventData to Protobuf; this worker-side deserializes it back to KafkaRecord.
