### PR TITLE
Add package README for Microsoft.Azure.Functions.Worker.Sdk

### DIFF
--- a/sdk/Sdk/README.md
+++ b/sdk/Sdk/README.md
@@ -1,0 +1,13 @@
+# Microsoft.Azure.Functions.Worker.Sdk
+
+This package provides development-time support for Azure Functions .NET isolated worker apps, including MSBuild targets, a Roslyn source generator for function metadata, and analyzers.
+
+## Getting Started
+
+This package is typically added via the Azure Functions project template. To add it manually:
+
+```dotnet
+dotnet add package Microsoft.Azure.Functions.Worker.Sdk
+```
+
+For more information, see the [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).

--- a/sdk/Sdk/README.md
+++ b/sdk/Sdk/README.md
@@ -1,6 +1,6 @@
 # Microsoft.Azure.Functions.Worker.Sdk
 
-This package provides development-time support for Azure Functions .NET isolated worker apps, including MSBuild targets, a Roslyn source generator for function metadata, and analyzers.
+This package provides development-time support for Azure Functions .NET isolated worker apps, including MSBuild build and publish targets, a Roslyn source generator for function metadata, and analyzers.
 
 ## Getting Started
 
@@ -11,3 +11,54 @@ dotnet add package Microsoft.Azure.Functions.Worker.Sdk
 ```
 
 For more information, see the [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).
+
+## What's Included
+
+### Build & Publish Targets
+
+The SDK adds MSBuild targets that run during build and publish:
+
+- **Function indexing** — Analyzes your compiled assembly and generates function metadata (`functions.metadata`) so the Azure Functions host can discover your functions without runtime reflection.
+- **Extension bundling** — Auto-generates a `WorkerExtensions` project that compiles all binding extension packages into a single assembly.
+- **Publish support** — Configures output for deployment, including Docker base image assignment for container scenarios.
+
+### Source Generators
+
+Three Roslyn source generators run at compile time:
+
+- **FunctionMetadataProvider** — Generates a `IFunctionMetadataProvider` implementation that returns metadata for all `[Function]`-attributed methods. This enables build-time indexing for fast cold starts.
+- **FunctionExecutor** — Generates strongly-typed wrapper methods for invoking user functions with correct parameter binding.
+- **ExtensionStartupRunner** — Generates a startup orchestrator that calls `Configure()` on all extension startup types.
+
+### Analyzers
+
+| Diagnostic | Severity | Description |
+|------------|----------|-------------|
+| AZFW0001 | Error | WebJobs binding attributes (in-process) used instead of isolated worker attributes |
+| AZFW0002 | Error | Async function method returns `void` instead of `Task` |
+| AZFW0009 | Error | `SupportsDeferredBinding` applied to an output binding |
+| AZFW0010 | Warning | Parameter type not supported by the binding attribute |
+| AZFW0011 | Error | Blob container path requires an iterable type or `BlobContainerClient` |
+
+## Configuration
+
+The SDK exposes MSBuild properties you can set in your `.csproj` to control its behavior:
+
+```xml
+<PropertyGroup>
+  <!-- Azure Functions runtime version (default: v4) -->
+  <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+
+  <!-- Disable build-time function indexing (default: true) -->
+  <FunctionsEnableWorkerIndexing>true</FunctionsEnableWorkerIndexing>
+
+  <!-- Control metadata source generation independently (default: mirrors FunctionsEnableWorkerIndexing) -->
+  <FunctionsEnableMetadataSourceGen>true</FunctionsEnableMetadataSourceGen>
+
+  <!-- Control executor source generation independently (default: true) -->
+  <FunctionsEnableExecutorSourceGen>true</FunctionsEnableExecutorSourceGen>
+
+  <!-- Namespace for generated code (default: your project's RootNamespace) -->
+  <FunctionsGeneratedCodeNamespace>MyApp.Generated</FunctionsGeneratedCodeNamespace>
+</PropertyGroup>
+```

--- a/sdk/Sdk/Sdk.csproj
+++ b/sdk/Sdk/Sdk.csproj
@@ -13,7 +13,12 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <FunctionsGeneratorOutputPath>..\FunctionMetadataLoaderExtension\bin\$(Configuration)\netstandard2.0\</FunctionsGeneratorOutputPath>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
 
   <Import Project="..\..\build\Common.props" />
 


### PR DESCRIPTION
## Summary

- Adds a `README.md` to the `Microsoft.Azure.Functions.Worker.Sdk` package so NuGet/Visual Studio displays documentation instead of "no README available"
- Wires the README into the `.nupkg` via `PackageReadmeFile` and a `Content` item in `Sdk.csproj`
- README covers what the SDK provides: build/publish targets, source generators, analyzers (with diagnostic IDs), and user-configurable MSBuild properties

Closes #3249

## Test plan

- [x] `dotnet build sdk/Sdk/Sdk.csproj` succeeds
- [x] `dotnet pack sdk/Sdk/Sdk.csproj` produces a `.nupkg` containing `README.md` at the package root