### PR TITLE
Fix WorkerExtensions.csproj TFM to match project target framework

### DIFF
--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -46,15 +46,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         internal string GetCsProjContent()
         {
             string extensionReferences = GetExtensionReferences();
-            string targetFramework = Constants.Net80;
-
-            if (_targetFrameworkIdentifier.Equals(Constants.NetCoreApp, StringComparison.OrdinalIgnoreCase))
-            {
-                if (_azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) || _targetFrameworkVersion.Equals(Constants.NetCoreVersion31, StringComparison.OrdinalIgnoreCase))
-                {
-                    targetFramework = Constants.NetCoreApp31;
-                }
-            }
+            string targetFramework = GetTargetFramework();
 
             string netSdkVersion = _azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) ? "3.1.2" : "4.6.0";
 
@@ -77,6 +69,27 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
     </Target>
 </Project>
 ";
+        }
+
+        private string GetTargetFramework()
+        {
+            if (_targetFrameworkIdentifier.Equals(Constants.NetCoreApp, StringComparison.OrdinalIgnoreCase))
+            {
+                if (_azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase)
+                    || _targetFrameworkVersion.Equals(Constants.NetCoreVersion31, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Constants.NetCoreApp31;
+                }
+
+                // Generic derivation: "v9.0" -> "net9.0", "v10.0" -> "net10.0"
+                string versionString = _targetFrameworkVersion.TrimStart('v', 'V');
+                if (Version.TryParse(versionString, out Version? version) && version.Major >= 5)
+                {
+                    return $"net{version.Major}.{version.Minor}";
+                }
+            }
+
+            return Constants.Net80;
         }
 
         private string GetExtensionReferences()

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -8,6 +8,10 @@
 
 - Reversal of change to suppress generation of functions.metadata file
 
+### Microsoft.Azure.Functions.Worker.Sdk <version>
+
+- Fixed WorkerExtensions.csproj to use the project's actual target framework instead of always defaulting to net8.0 (#3317)
+
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 
 - <entry>

--- a/test/Sdk.Generator.Tests/FunctionMetadata/ExtensionsCsProjGeneratorTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadata/ExtensionsCsProjGeneratorTests.cs
@@ -74,6 +74,39 @@ namespace Microsoft.Azure.Functions.Sdk.Generator.FunctionMetadata.Tests
             Assert.Equal(first, second);
         }
 
+        [Theory]
+        [InlineData("v8.0", "net8.0")]
+        [InlineData("v9.0", "net9.0")]
+        [InlineData("v10.0", "net10.0")]
+        public void GetCsProjContent_UsesCorrectTargetFramework_ForNewerTfms(string targetFrameworkVersion, string expectedTfm)
+        {
+            // Regression test for https://github.com/Azure/azure-functions-dotnet-worker/issues/3317
+            // The generated WorkerExtensions.csproj must match the project's TFM.
+            Dictionary<string, string> extensions = new()
+            {
+                { "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "5.24.0" },
+            };
+
+            var generator = new ExtensionsCsprojGenerator(extensions, "test.csproj", "v4", Constants.NetCoreApp, targetFrameworkVersion);
+            string content = generator.GetCsProjContent();
+
+            Assert.Contains($"<TargetFramework>{expectedTfm}</TargetFramework>", content);
+            Assert.Contains($"'$(TargetFramework)' != '{expectedTfm}'", content);
+        }
+
+        [Fact]
+        public void GetCsProjContent_FallsBackToNet80_ForNonNetCoreApp()
+        {
+            Dictionary<string, string> extensions = new()
+            {
+                { "Microsoft.Azure.WebJobs.Extensions.ServiceBus", "5.24.0" },
+            };
+
+            var generator = new ExtensionsCsprojGenerator(extensions, "test.csproj", "v4", ".NETFramework", "v4.7.2");
+            string content = generator.GetCsProjContent();
+            Assert.Contains("<TargetFramework>net8.0</TargetFramework>", content);
+        }
+
         [Fact]
         public async Task Generate_Updates()
         {


### PR DESCRIPTION
## Summary

Fixes #3317

- `ExtensionsCsprojGenerator.GetCsProjContent()` hardcoded `net8.0` as the target framework for the generated `WorkerExtensions.csproj`, causing extension startup classes (e.g. `ServiceBusExtensionStartup`) to not be discovered at runtime when targeting `net9.0` or `net10.0`
- Extracted TFM derivation into a `GetTargetFramework()` method that generically parses `TargetFrameworkVersion` (e.g. `v9.0` → `net9.0`, `v10.0` → `net10.0`) using `Version.TryParse`, with `net8.0` as the fallback for non-`.NETCoreApp` identifiers
- Added regression tests for `net8.0`/`net9.0`/`net10.0` TFM derivation and a fallback test for `.NETFramework`

## Test plan

- [x] Existing V3/V4 snapshot tests pass unchanged
- [x] New parameterized test verifies `v8.0`→`net8.0`, `v9.0`→`net9.0`, `v10.0`→`net10.0`
- [x] New fallback test verifies `.NETFramework` identifier → `net8.0`
- [x] Full SDK generator test suite passes (419 tests)