### PR TITLE
Add compile-time duplicate function name detection (AZFW0017)

### DIFF
--- a/docs/analyzer-rules/AZFW0017.md
+++ b/docs/analyzer-rules/AZFW0017.md
@@ -1,0 +1,41 @@
+# AZFW0017: Duplicate function name
+
+| | Value |
+|-|-|
+| **Rule ID** |AZFW0017|
+| **Category** |[FunctionMetadataGeneration]|
+| **Severity** |Error|
+
+## Cause
+
+This rule is triggered when two or more functions in the same project share the same name (case-insensitive).
+
+## Rule description
+
+Each function in an Azure Functions app must have a unique name. The Azure Functions host treats function names as case-insensitive identifiers, so `MyFunc` and `myfunc` are considered duplicates. When duplicate names are present, the host fails to start.
+
+This analyzer detects duplicate function names at compile time, giving you immediate feedback instead of a runtime failure.
+
+## How to fix violations
+
+Rename one of the duplicate functions so that every `[Function("...")]` attribute in the project specifies a unique name.
+
+```csharp
+// Before (violation)
+[Function("MyFunc")]
+public string RunA([HttpTrigger("get")] string req) { ... }
+
+[Function("MyFunc")]  // duplicate
+public string RunB([HttpTrigger("get")] string req) { ... }
+
+// After (fixed)
+[Function("MyFuncA")]
+public string RunA([HttpTrigger("get")] string req) { ... }
+
+[Function("MyFuncB")]
+public string RunB([HttpTrigger("get")] string req) { ... }
+```
+
+## When to suppress warnings
+
+This rule should not be suppressed. Duplicate function names will cause the Azure Functions host to fail at startup.

--- a/sdk/Sdk.Generators/DiagnosticDescriptors.cs
+++ b/sdk/Sdk.Generators/DiagnosticDescriptors.cs
@@ -69,5 +69,12 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     category: "FunctionMetadataGeneration",
                     severity: DiagnosticSeverity.Error);
 
+        public static DiagnosticDescriptor DuplicateFunctionName { get; }
+                = Create(id: "AZFW0014",
+                    title: "Duplicate function name.",
+                    messageFormat: "The function name '{0}' is used by multiple functions. Function names must be unique. Duplicate entry points: {1}",
+                    category: "FunctionMetadataGeneration",
+                    severity: DiagnosticSeverity.Error);
+
     }
 }

--- a/sdk/Sdk.Generators/DiagnosticDescriptors.cs
+++ b/sdk/Sdk.Generators/DiagnosticDescriptors.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
                     severity: DiagnosticSeverity.Error);
 
         public static DiagnosticDescriptor DuplicateFunctionName { get; }
-                = Create(id: "AZFW0014",
+                = Create(id: "AZFW0017",
                     title: "Duplicate function name.",
                     messageFormat: "The function name '{0}' is used by multiple functions. Function names must be unique. Duplicate entry points: {1}",
                     category: "FunctionMetadataGeneration",

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
             // Check for duplicate function names (case-insensitive, matching host behavior)
             var duplicateGroups = functionMetadataInfo
+                .Where(f => f.Name is not null)
                 .GroupBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
                 .Where(g => g.Count() > 1)
                 .ToList();

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.cs
@@ -59,6 +59,24 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
             IReadOnlyList<GeneratorFunctionMetadata> functionMetadataInfo = entryAssemblyFunctions.Concat(dependentAssemblyFunctions).ToList();
 
+            // Check for duplicate function names (case-insensitive, matching host behavior)
+            var duplicateGroups = functionMetadataInfo
+                .GroupBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1)
+                .ToList();
+
+            foreach (var group in duplicateGroups)
+            {
+                var entryPoints = string.Join(", ", group.Select(f => f.EntryPoint));
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.DuplicateFunctionName, Location.None, group.Key, entryPoints));
+            }
+
+            if (duplicateGroups.Count > 0)
+            {
+                return;
+            }
+
             // Proceed to generate the file if function metadata info was successfully returned
             if (functionMetadataInfo.Count > 0)
             {

--- a/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.cs
+++ b/sdk/Sdk.Generators/FunctionMetadataProviderGenerator/FunctionMetadataProviderGenerator.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Functions.Worker.Sdk.Generators
 
             IReadOnlyList<GeneratorFunctionMetadata> functionMetadataInfo = entryAssemblyFunctions.Concat(dependentAssemblyFunctions).ToList();
 
-            // Check for duplicate function names (case-insensitive, matching host behavior)
+            // Case-insensitive: the host treats function names as case-insensitive
             var duplicateGroups = functionMetadataInfo
                 .Where(f => f.Name is not null)
                 .GroupBy(f => f.Name, StringComparer.OrdinalIgnoreCase)

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -10,4 +10,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 
-- <entry>
+- Added compile-time duplicate function name detection (AZFW0014) (#3158)

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -10,4 +10,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 
-- Added compile-time duplicate function name detection (AZFW0014) (#3158)
+- Added compile-time duplicate function name detection (AZFW0017) (#3158)

--- a/test/Sdk.Generator.Tests/FunctionMetadataProvider/DiagnosticResultTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProvider/DiagnosticResultTests.cs
@@ -260,111 +260,111 @@ namespace Microsoft.Azure.Functions.Sdk.Generator.FunctionMetadataProvider.Tests
                     languageVersion: languageVersion);
             }
 
-        [Theory]
-        [InlineData(LanguageVersion.CSharp7_3)]
-        [InlineData(LanguageVersion.CSharp8)]
-        [InlineData(LanguageVersion.CSharp9)]
-        [InlineData(LanguageVersion.CSharp10)]
-        [InlineData(LanguageVersion.CSharp11)]
-        [InlineData(LanguageVersion.Latest)]
-        public async Task DuplicateFunctionNamesFails(LanguageVersion languageVersion)
-        {
-            var inputCode = @"using System;
-                using System.Threading.Tasks;
-                using Microsoft.Azure.Functions.Worker;
-                using Microsoft.Azure.Functions.Worker.Http;
-
-                namespace FunctionApp
-                {
-                    public class FunctionClassA
-                    {
-                        [Function(""MyFunc"")]
-                        public string RunA([HttpTrigger(""get"")] string req)
-                        {
-                            throw new NotImplementedException();
-                        }
-                    }
-
-                    public class FunctionClassB
-                    {
-                        [Function(""MyFunc"")]
-                        public string RunB([HttpTrigger(""get"")] string req)
-                        {
-                            throw new NotImplementedException();
-                        }
-                    }
-                }";
-
-            string? expectedGeneratedFileName = null;
-            string? expectedOutput = null;
-
-            var expectedDiagnosticResults = new List<DiagnosticResult>
+            [Theory]
+            [InlineData(LanguageVersion.CSharp7_3)]
+            [InlineData(LanguageVersion.CSharp8)]
+            [InlineData(LanguageVersion.CSharp9)]
+            [InlineData(LanguageVersion.CSharp10)]
+            [InlineData(LanguageVersion.CSharp11)]
+            [InlineData(LanguageVersion.Latest)]
+            public async Task DuplicateFunctionNamesFails(LanguageVersion languageVersion)
             {
-                new DiagnosticResult(DiagnosticDescriptors.DuplicateFunctionName)
-                    .WithArguments("MyFunc", "FunctionApp.FunctionClassA.RunA, FunctionApp.FunctionClassB.RunB")
-            };
+                var inputCode = @"using System;
+                    using System.Threading.Tasks;
+                    using Microsoft.Azure.Functions.Worker;
+                    using Microsoft.Azure.Functions.Worker.Http;
 
-            await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                referencedExtensionAssemblies,
-                inputCode,
-                expectedGeneratedFileName,
-                expectedOutput,
-                expectedDiagnosticResults,
-                languageVersion: languageVersion);
-        }
+                    namespace FunctionApp
+                    {
+                        public class FunctionClassA
+                        {
+                            [Function(""MyFunc"")]
+                            public string RunA([HttpTrigger(""get"")] string req)
+                            {
+                                throw new NotImplementedException();
+                            }
+                        }
 
-        [Theory]
-        [InlineData(LanguageVersion.CSharp7_3)]
-        [InlineData(LanguageVersion.CSharp8)]
-        [InlineData(LanguageVersion.CSharp9)]
-        [InlineData(LanguageVersion.CSharp10)]
-        [InlineData(LanguageVersion.CSharp11)]
-        [InlineData(LanguageVersion.Latest)]
-        public async Task DuplicateFunctionNamesCaseInsensitiveFails(LanguageVersion languageVersion)
-        {
-            var inputCode = @"using System;
-                using System.Threading.Tasks;
-                using Microsoft.Azure.Functions.Worker;
-                using Microsoft.Azure.Functions.Worker.Http;
+                        public class FunctionClassB
+                        {
+                            [Function(""MyFunc"")]
+                            public string RunB([HttpTrigger(""get"")] string req)
+                            {
+                                throw new NotImplementedException();
+                            }
+                        }
+                    }";
 
-                namespace FunctionApp
+                string? expectedGeneratedFileName = null;
+                string? expectedOutput = null;
+
+                var expectedDiagnosticResults = new List<DiagnosticResult>
                 {
-                    public class FunctionClassA
-                    {
-                        [Function(""MyFunc"")]
-                        public string RunA([HttpTrigger(""get"")] string req)
-                        {
-                            throw new NotImplementedException();
-                        }
-                    }
+                    new DiagnosticResult(DiagnosticDescriptors.DuplicateFunctionName)
+                        .WithArguments("MyFunc", "FunctionApp.FunctionClassA.RunA, FunctionApp.FunctionClassB.RunB")
+                };
 
-                    public class FunctionClassB
-                    {
-                        [Function(""myfunc"")]
-                        public string RunB([HttpTrigger(""get"")] string req)
-                        {
-                            throw new NotImplementedException();
-                        }
-                    }
-                }";
+                await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
+                    referencedExtensionAssemblies,
+                    inputCode,
+                    expectedGeneratedFileName,
+                    expectedOutput,
+                    expectedDiagnosticResults,
+                    languageVersion: languageVersion);
+            }
 
-            string? expectedGeneratedFileName = null;
-            string? expectedOutput = null;
-
-            var expectedDiagnosticResults = new List<DiagnosticResult>
+            [Theory]
+            [InlineData(LanguageVersion.CSharp7_3)]
+            [InlineData(LanguageVersion.CSharp8)]
+            [InlineData(LanguageVersion.CSharp9)]
+            [InlineData(LanguageVersion.CSharp10)]
+            [InlineData(LanguageVersion.CSharp11)]
+            [InlineData(LanguageVersion.Latest)]
+            public async Task DuplicateFunctionNamesCaseInsensitiveFails(LanguageVersion languageVersion)
             {
-                new DiagnosticResult(DiagnosticDescriptors.DuplicateFunctionName)
-                    .WithArguments("MyFunc", "FunctionApp.FunctionClassA.RunA, FunctionApp.FunctionClassB.RunB")
-            };
+                var inputCode = @"using System;
+                    using System.Threading.Tasks;
+                    using Microsoft.Azure.Functions.Worker;
+                    using Microsoft.Azure.Functions.Worker.Http;
 
-            await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
-                referencedExtensionAssemblies,
-                inputCode,
-                expectedGeneratedFileName,
-                expectedOutput,
-                expectedDiagnosticResults,
-                languageVersion: languageVersion);
-        }
+                    namespace FunctionApp
+                    {
+                        public class FunctionClassA
+                        {
+                            [Function(""MyFunc"")]
+                            public string RunA([HttpTrigger(""get"")] string req)
+                            {
+                                throw new NotImplementedException();
+                            }
+                        }
+
+                        public class FunctionClassB
+                        {
+                            [Function(""myfunc"")]
+                            public string RunB([HttpTrigger(""get"")] string req)
+                            {
+                                throw new NotImplementedException();
+                            }
+                        }
+                    }";
+
+                string? expectedGeneratedFileName = null;
+                string? expectedOutput = null;
+
+                var expectedDiagnosticResults = new List<DiagnosticResult>
+                {
+                    new DiagnosticResult(DiagnosticDescriptors.DuplicateFunctionName)
+                        .WithArguments("MyFunc", "FunctionApp.FunctionClassA.RunA, FunctionApp.FunctionClassB.RunB")
+                };
+
+                await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
+                    referencedExtensionAssemblies,
+                    inputCode,
+                    expectedGeneratedFileName,
+                    expectedOutput,
+                    expectedDiagnosticResults,
+                    languageVersion: languageVersion);
+            }
         }
     }
 }

--- a/test/Sdk.Generator.Tests/FunctionMetadataProvider/DiagnosticResultTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadataProvider/DiagnosticResultTests.cs
@@ -259,6 +259,112 @@ namespace Microsoft.Azure.Functions.Sdk.Generator.FunctionMetadataProvider.Tests
                     expectedDiagnosticResults,
                     languageVersion: languageVersion);
             }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp7_3)]
+        [InlineData(LanguageVersion.CSharp8)]
+        [InlineData(LanguageVersion.CSharp9)]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        [InlineData(LanguageVersion.Latest)]
+        public async Task DuplicateFunctionNamesFails(LanguageVersion languageVersion)
+        {
+            var inputCode = @"using System;
+                using System.Threading.Tasks;
+                using Microsoft.Azure.Functions.Worker;
+                using Microsoft.Azure.Functions.Worker.Http;
+
+                namespace FunctionApp
+                {
+                    public class FunctionClassA
+                    {
+                        [Function(""MyFunc"")]
+                        public string RunA([HttpTrigger(""get"")] string req)
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+
+                    public class FunctionClassB
+                    {
+                        [Function(""MyFunc"")]
+                        public string RunB([HttpTrigger(""get"")] string req)
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                }";
+
+            string? expectedGeneratedFileName = null;
+            string? expectedOutput = null;
+
+            var expectedDiagnosticResults = new List<DiagnosticResult>
+            {
+                new DiagnosticResult(DiagnosticDescriptors.DuplicateFunctionName)
+                    .WithArguments("MyFunc", "FunctionApp.FunctionClassA.RunA, FunctionApp.FunctionClassB.RunB")
+            };
+
+            await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
+                referencedExtensionAssemblies,
+                inputCode,
+                expectedGeneratedFileName,
+                expectedOutput,
+                expectedDiagnosticResults,
+                languageVersion: languageVersion);
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp7_3)]
+        [InlineData(LanguageVersion.CSharp8)]
+        [InlineData(LanguageVersion.CSharp9)]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        [InlineData(LanguageVersion.Latest)]
+        public async Task DuplicateFunctionNamesCaseInsensitiveFails(LanguageVersion languageVersion)
+        {
+            var inputCode = @"using System;
+                using System.Threading.Tasks;
+                using Microsoft.Azure.Functions.Worker;
+                using Microsoft.Azure.Functions.Worker.Http;
+
+                namespace FunctionApp
+                {
+                    public class FunctionClassA
+                    {
+                        [Function(""MyFunc"")]
+                        public string RunA([HttpTrigger(""get"")] string req)
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+
+                    public class FunctionClassB
+                    {
+                        [Function(""myfunc"")]
+                        public string RunB([HttpTrigger(""get"")] string req)
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                }";
+
+            string? expectedGeneratedFileName = null;
+            string? expectedOutput = null;
+
+            var expectedDiagnosticResults = new List<DiagnosticResult>
+            {
+                new DiagnosticResult(DiagnosticDescriptors.DuplicateFunctionName)
+                    .WithArguments("MyFunc", "FunctionApp.FunctionClassA.RunA, FunctionApp.FunctionClassB.RunB")
+            };
+
+            await TestHelpers.RunTestAsync<FunctionMetadataProviderGenerator>(
+                referencedExtensionAssemblies,
+                inputCode,
+                expectedGeneratedFileName,
+                expectedOutput,
+                expectedDiagnosticResults,
+                languageVersion: languageVersion);
+        }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a new Roslyn analyzer diagnostic **AZFW0014** that reports an error at compile time when two or more functions share the same name (case-insensitive), preventing a confusing runtime failure from the Azure Functions host.
- The check runs inside `FunctionMetadataProviderGenerator` after collecting all function metadata; if duplicates are found the generator emits the diagnostic and skips code generation.
- Includes two new test cases covering exact-match and case-insensitive duplicate detection across all supported C# language versions.

Closes #3158

## Test plan
- [x] `DuplicateFunctionNamesFails` — two functions with identical name `"MyFunc"` produce AZFW0014
- [x] `DuplicateFunctionNamesCaseInsensitiveFails` — `"MyFunc"` vs `"myfunc"` also produce AZFW0014
- [x] Existing generator tests continue to pass (no regressions)