### PR TITLE
Resource detector update

### DIFF
--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
         private static readonly string AssemblyVersion =
             typeof(FunctionsResourceDetector).Assembly.GetName().Version?.ToString() ?? "unknown";
 
-        private static readonly int ProcessId = Process.GetCurrentProcess().Id;
-
         public Resource Detect()
         {
             try
@@ -24,7 +22,7 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
                 var attributes = new List<KeyValuePair<string, object>>(capacity: 10)
                 {
                     new(ResourceSemanticConventions.AISDKPrefix, $"{OpenTelemetryConstants.SDKPrefix}:{AssemblyVersion}"),
-                    new(ResourceSemanticConventions.ProcessId, ProcessId)
+                    new(ResourceSemanticConventions.ProcessId, Process.GetCurrentProcess().Id)
                 };
 
                 string? siteName = Environment.GetEnvironmentVariable(OpenTelemetryConstants.SiteNameEnvVar);

--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -12,64 +12,145 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
 
     public sealed class FunctionsResourceDetector : IResourceDetector
     {
+        private static readonly string s_assemblyVersion =
+            typeof(FunctionsResourceDetector).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+        private static readonly int s_processId = Process.GetCurrentProcess().Id;
+
         public Resource Detect()
         {
-            List<KeyValuePair<string, object>> attributeList = new(8);
             try
             {
-                string serviceName = Environment.GetEnvironmentVariable(OpenTelemetryConstants.SiteNameEnvVar);
-                string version = Assembly.GetEntryAssembly().GetName().Version.ToString();
+                var attributes = new List<KeyValuePair<string, object>>(capacity: 10)
+                {
+                    new(ResourceSemanticConventions.AISDKPrefix, $"{OpenTelemetryConstants.SDKPrefix}:{s_assemblyVersion}"),
+                    new(ResourceSemanticConventions.ProcessId, s_processId)
+                };
 
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ServiceVersion, version));
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AISDKPrefix, 
-                    $@"{OpenTelemetryConstants.SDKPrefix}:{typeof(FunctionsResourceDetector).Assembly.GetName().Version}"));
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ProcessId, Process.GetCurrentProcess().Id));
+                string? siteName = Environment.GetEnvironmentVariable(OpenTelemetryConstants.SiteNameEnvVar);
+                string? resourceAttributes = Environment.GetEnvironmentVariable(OpenTelemetryConstants.ResourceAttributeEnvVar);
+
+                // Priority: OTEL_SERVICE_NAME > OTEL_RESOURCE_ATTRIBUTES[service.name] > WEBSITE_SITE_NAME > AssemblyName
+                if (!IsServiceNameConfigured(resourceAttributes))
+                {
+                    attributes.Add(new(ResourceSemanticConventions.ServiceName,
+                        siteName ?? Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown"));
+                }
+
+                // Priority: OTEL_RESOURCE_ATTRIBUTES[service.version] > AssemblyVersion
+                // OTel decided to not have OTEL_SERVICE_VERSION, so we only check OTEL_RESOURCE_ATTRIBUTES.
+                // https://github.com/open-telemetry/semantic-conventions/issues/2669
+                if (!IsResourceAttributeConfigured(ResourceSemanticConventions.ServiceVersion, resourceAttributes))
+                {
+                    attributes.Add(new(ResourceSemanticConventions.ServiceVersion,
+                        Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "unknown"));
+                }
 
                 // Add these attributes only if running in Azure.
-                if (!string.IsNullOrEmpty(serviceName))
+                if (!string.IsNullOrEmpty(siteName))
                 {
-                    attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ServiceName, serviceName));
-                    attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.CloudProvider, OpenTelemetryConstants.AzureCloudProviderValue));
-                    attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.CloudPlatform, OpenTelemetryConstants.AzurePlatformValue));
+                    attributes.Add(new(ResourceSemanticConventions.CloudProvider, OpenTelemetryConstants.AzureCloudProviderValue));
+                    attributes.Add(new(ResourceSemanticConventions.CloudPlatform, OpenTelemetryConstants.AzurePlatformValue));
 
-                    string region = Environment.GetEnvironmentVariable(OpenTelemetryConstants.RegionNameEnvVar);
-                    if (!string.IsNullOrEmpty(region))
+                    if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.RegionNameEnvVar) is { Length: > 0 } region)
                     {
-                        attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.CloudRegion, region));
+                        attributes.Add(new(ResourceSemanticConventions.CloudRegion, region));
                     }
 
-                    var azureResourceUri = GetAzureResourceURI(serviceName);
-                    if (!string.IsNullOrEmpty(azureResourceUri))
+                    if (GetAzureResourceUri(siteName!) is { } uri)
                     {
-                        attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.CloudResourceId, azureResourceUri));
+                        attributes.Add(new(ResourceSemanticConventions.CloudResourceId, uri));
+                    }
+
+                    if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.SlotNameEnvVar) is { Length: > 0 } slot)
+                    {
+                        attributes.Add(new(ResourceSemanticConventions.DeploymentEnvironmentName, slot));
+                    }
+
+                    if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.SiteUpdateIdEnvVar) is { Length: > 0 } siteUpdateId)
+                    {
+                        attributes.Add(new(ResourceSemanticConventions.SiteUpdateId, siteUpdateId));
                     }
                 }
-                else
-                {
-                    attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ServiceName, Assembly.GetEntryAssembly().GetName().Name));
-                }
+
+                return new Resource(attributes);
             }
             catch
             {
                 // return empty resource.
                 return Resource.Empty;
             }
-            return new Resource(attributeList);
         }
 
-        private static string GetAzureResourceURI(string websiteSiteName)
+        private static bool IsServiceNameConfigured(string? resourceAttributes)
         {
-            string websiteResourceGroup = Environment.GetEnvironmentVariable(OpenTelemetryConstants.ResourceGroupEnvVar);
-            string websiteOwnerName = Environment.GetEnvironmentVariable(OpenTelemetryConstants.OwnerNameEnvVar) ?? string.Empty;
-            int idx = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);
-            string subscriptionId = idx > 0 ? websiteOwnerName.Substring(0, idx) : websiteOwnerName;
-
-            if (string.IsNullOrEmpty(websiteResourceGroup) || string.IsNullOrEmpty(subscriptionId))
+            if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.ServiceNameEnvVar) is { Length: > 0 })
             {
-                return string.Empty;
+                return true;
             }
 
-            return $"/subscriptions/{subscriptionId}/resourceGroups/{websiteResourceGroup}/providers/Microsoft.Web/sites/{websiteSiteName}";
+            return IsResourceAttributeConfigured(ResourceSemanticConventions.ServiceName, resourceAttributes);
+        }
+
+        private static bool IsResourceAttributeConfigured(string key, string? resourceAttributes)
+        {
+            if (resourceAttributes is not { Length: > 2 })
+            {
+                return false;
+            }
+
+            // TODO: Replace manual parsing with MemoryExtensions.Split when we upgrade to .NET 10.
+            var remaining = resourceAttributes.AsSpan();
+
+            while (remaining.Length > 0)
+            {
+                var commaIndex = remaining.IndexOf(',');
+                var segment = commaIndex >= 0
+                    ? remaining[..commaIndex]
+                    : remaining;
+
+                var trimmed = segment.Trim();
+                var equalsIndex = trimmed.IndexOf('=');
+
+                if (equalsIndex > 0)
+                {
+                    var attributeKey = trimmed[..equalsIndex];
+                    if (attributeKey.Equals(key, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+
+                if (commaIndex < 0)
+                {
+                    break;
+                }
+
+                remaining = remaining[(commaIndex + 1)..];
+            }
+
+            return false;
+        }
+
+        private static string? GetAzureResourceUri(string siteName)
+        {
+            var resourceGroup = Environment.GetEnvironmentVariable(OpenTelemetryConstants.ResourceGroupEnvVar);
+            var owner = Environment.GetEnvironmentVariable(OpenTelemetryConstants.OwnerNameEnvVar);
+
+            if (string.IsNullOrEmpty(resourceGroup) || string.IsNullOrEmpty(owner))
+            {
+                return null;
+            }
+
+            // owner format: "{subscriptionId}+{something}"
+            var span = owner.AsSpan();
+            var plusIndex = span.IndexOf('+');
+
+            var subscriptionId = plusIndex > 0
+                ? span[..plusIndex].ToString()
+                : owner;
+
+            return $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/sites/{siteName}";
         }
     }
 }

--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
 
     public sealed class FunctionsResourceDetector : IResourceDetector
     {
-        private static readonly string s_assemblyVersion =
+        private static readonly string AssemblyVersion =
             typeof(FunctionsResourceDetector).Assembly.GetName().Version?.ToString() ?? "unknown";
 
-        private static readonly int s_processId = Process.GetCurrentProcess().Id;
+        private static readonly int ProcessId = Process.GetCurrentProcess().Id;
 
         public Resource Detect()
         {
@@ -23,8 +23,8 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
             {
                 var attributes = new List<KeyValuePair<string, object>>(capacity: 10)
                 {
-                    new(ResourceSemanticConventions.AISDKPrefix, $"{OpenTelemetryConstants.SDKPrefix}:{s_assemblyVersion}"),
-                    new(ResourceSemanticConventions.ProcessId, s_processId)
+                    new(ResourceSemanticConventions.AISDKPrefix, $"{OpenTelemetryConstants.SDKPrefix}:{AssemblyVersion}"),
+                    new(ResourceSemanticConventions.ProcessId, ProcessId)
                 };
 
                 string? siteName = Environment.GetEnvironmentVariable(OpenTelemetryConstants.SiteNameEnvVar);

--- a/src/DotNetWorker.OpenTelemetry/OpenTelemetryConstants.cs
+++ b/src/DotNetWorker.OpenTelemetry/OpenTelemetryConstants.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
         internal const string RegionNameEnvVar = "REGION_NAME";
         internal const string ResourceGroupEnvVar = "WEBSITE_RESOURCE_GROUP";
         internal const string OwnerNameEnvVar = "WEBSITE_OWNER_NAME";
+        internal const string ServiceNameEnvVar = "OTEL_SERVICE_NAME";
+        internal const string ResourceAttributeEnvVar = "OTEL_RESOURCE_ATTRIBUTES";
+        internal const string SiteUpdateIdEnvVar = "FUNCTIONS_SITE_UPDATE_ID";
+        internal const string SlotNameEnvVar = "WEBSITE_SLOT_NAME";
         internal const string WorkerDefaultSchemaVersion = "1.37.0";
         internal const string WorkerActivitySourceName = "Microsoft.Azure.Functions.Worker";
 

--- a/src/DotNetWorker.OpenTelemetry/ResourceSemanticConventions.cs
+++ b/src/DotNetWorker.OpenTelemetry/ResourceSemanticConventions.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
 {
     internal static class ResourceSemanticConventions

--- a/src/DotNetWorker.OpenTelemetry/ResourceSemanticConventions.cs
+++ b/src/DotNetWorker.OpenTelemetry/ResourceSemanticConventions.cs
@@ -21,5 +21,11 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
 
         // AI
         internal const string AISDKPrefix = "ai.sdk.prefix";
+
+        // Deployment
+        internal const string DeploymentEnvironmentName = "deployment.environment.name";
+
+        // Azure Functions
+        internal const string SiteUpdateId = "azure.functions.site.update_id";
     }
 }

--- a/src/DotNetWorker.OpenTelemetry/release_notes.md
+++ b/src/DotNetWorker.OpenTelemetry/release_notes.md
@@ -3,3 +3,4 @@
 ### Microsoft.Azure.Functions.Worker.OpenTelemetry <version>
 
 - Add support for propagating OpenTelemetry baggage to the worker (#3319).
+- `FunctionsResourceDetector` now respects `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` — when either is set, the detector skips adding `service.name` and/or `service.version` so the OTel SDK picks them up without duplication  (#3362).

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -252,48 +252,31 @@ public class EndToEndTests
         Assert.DoesNotContain(resource.Attributes, a => a.Key == "azure.functions.site.update_id");
     }
 
-    [Fact]
-    public void ResourceDetector_OtelServiceName_SkipsServiceName()
-    {
-        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
-        {
-            { "WEBSITE_SITE_NAME", "appName" },
-            { "OTEL_SERVICE_NAME", "my-custom-service" }
-        });
+    public static IEnumerable<object[]> ServiceNameSkippedData =>
+    [
+        // OTEL_SERVICE_NAME in Azure
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "OTEL_SERVICE_NAME", "my-custom-service" } }],
+        // OTEL_SERVICE_NAME locally
+        [new Dictionary<string, string> { { "OTEL_SERVICE_NAME", "my-custom-service" } }],
+        // OTEL_RESOURCE_ATTRIBUTES[service.name] in Azure
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "OTEL_RESOURCE_ATTRIBUTES", "service.name=my-custom-service,other.key=value" } }],
+        // OTEL_RESOURCE_ATTRIBUTES[service.name] locally
+        [new Dictionary<string, string> { { "OTEL_RESOURCE_ATTRIBUTES", "service.name=my-custom-service" } }],
+        // OTEL_SERVICE_NAME takes priority over OTEL_RESOURCE_ATTRIBUTES
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "OTEL_SERVICE_NAME", "from-env" }, { "OTEL_RESOURCE_ATTRIBUTES", "service.name=from-attributes" } }],
+        // Leading/trailing whitespace around pair is trimmed
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "OTEL_RESOURCE_ATTRIBUTES", "other.key=value, service.name=my-custom-service" } }],
+    ];
 
+    [Theory]
+    [MemberData(nameof(ServiceNameSkippedData))]
+    public void ResourceDetector_ServiceName_SkippedWhenConfigured(Dictionary<string, string> envVars)
+    {
+        using var _ = new TestScopedEnvironmentVariable(envVars);
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
         Resource resource = detector.Detect();
 
         Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
-    }
-
-    [Fact]
-    public void ResourceDetector_OtelResourceAttributes_ServiceName_SkipsServiceName()
-    {
-        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
-        {
-            { "WEBSITE_SITE_NAME", "appName" },
-            { "OTEL_RESOURCE_ATTRIBUTES", "service.name=my-custom-service,other.key=value" }
-        });
-
-        FunctionsResourceDetector detector = new FunctionsResourceDetector();
-        Resource resource = detector.Detect();
-
-        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
-    }
-
-    [Fact]
-    public void ResourceDetector_OtelResourceAttributes_ServiceVersion_SkipsServiceVersion()
-    {
-        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
-        {
-            { "OTEL_RESOURCE_ATTRIBUTES", "service.version=1.2.3" }
-        });
-
-        FunctionsResourceDetector detector = new FunctionsResourceDetector();
-        Resource resource = detector.Detect();
-
-        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.version");
     }
 
     [Fact]
@@ -312,53 +295,18 @@ public class EndToEndTests
         Assert.Equal("appName", resource.Attributes.FirstOrDefault(a => a.Key == "service.name").Value);
     }
 
-    [Fact]
-    public void ResourceDetector_OtelServiceName_SkipsServiceName_WhenLocal()
+    [Theory]
+    [InlineData(false)] // locally
+    [InlineData(true)]  // in Azure
+    public void ResourceDetector_OtelResourceAttributes_ServiceVersion_SkipsServiceVersion(bool inAzure)
     {
-        using var _ = new TestScopedEnvironmentVariable("OTEL_SERVICE_NAME", "my-custom-service");
-
-        FunctionsResourceDetector detector = new FunctionsResourceDetector();
-        Resource resource = detector.Detect();
-
-        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
-    }
-
-    [Fact]
-    public void ResourceDetector_OtelResourceAttributes_ServiceName_SkipsServiceName_WhenLocal()
-    {
-        using var _ = new TestScopedEnvironmentVariable("OTEL_RESOURCE_ATTRIBUTES", "service.name=my-custom-service");
-
-        FunctionsResourceDetector detector = new FunctionsResourceDetector();
-        Resource resource = detector.Detect();
-
-        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
-    }
-
-    [Fact]
-    public void ResourceDetector_OtelServiceName_TakesPriorityOver_OtelResourceAttributes()
-    {
-        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        var envVars = new Dictionary<string, string> { { "OTEL_RESOURCE_ATTRIBUTES", "service.version=1.2.3" } };
+        if (inAzure)
         {
-            { "WEBSITE_SITE_NAME", "appName" },
-            { "OTEL_SERVICE_NAME", "from-env" },
-            { "OTEL_RESOURCE_ATTRIBUTES", "service.name=from-attributes" }
-        });
+            envVars["WEBSITE_SITE_NAME"] = "appName";
+        }
 
-        FunctionsResourceDetector detector = new FunctionsResourceDetector();
-        Resource resource = detector.Detect();
-
-        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
-    }
-
-    [Fact]
-    public void ResourceDetector_OtelResourceAttributes_ServiceVersion_SkipsServiceVersion_WhenInAzure()
-    {
-        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
-        {
-            { "WEBSITE_SITE_NAME", "appName" },
-            { "OTEL_RESOURCE_ATTRIBUTES", "service.version=1.2.3" }
-        });
-
+        using var _ = new TestScopedEnvironmentVariable(envVars);
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
         Resource resource = detector.Detect();
 
@@ -389,13 +337,15 @@ public class EndToEndTests
         Assert.DoesNotContain(resource.Attributes, a => a.Key == "cloud.resource_id");
     }
 
-    [Fact]
-    public void ResourceDetector_CloudResourceId_NotAddedWhenResourceGroupMissing()
+    [Theory]
+    [InlineData("WEBSITE_OWNER_NAME", "AAAAA-AAAAA-AAAAA-AAA+appName-EastUSwebspace")] // missing resource group
+    [InlineData("WEBSITE_RESOURCE_GROUP", "rg")]                                        // missing owner name
+    public void ResourceDetector_CloudResourceId_NotAddedWhenEnvVarMissing(string presentEnvVar, string value)
     {
         using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
         {
             { "WEBSITE_SITE_NAME", "appName" },
-            { "WEBSITE_OWNER_NAME", "AAAAA-AAAAA-AAAAA-AAA+appName-EastUSwebspace" }
+            { presentEnvVar, value }
         });
 
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
@@ -405,29 +355,22 @@ public class EndToEndTests
     }
 
     [Fact]
-    public void ResourceDetector_CloudResourceId_NotAddedWhenOwnerNameMissing()
+    public void ResourceDetector_ProcessId_IsInt()
     {
-        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
-        {
-            { "WEBSITE_SITE_NAME", "appName" },
-            { "WEBSITE_RESOURCE_GROUP", "rg" }
-        });
-
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
         Resource resource = detector.Detect();
 
-        Assert.DoesNotContain(resource.Attributes, a => a.Key == "cloud.resource_id");
+        var processId = resource.Attributes.FirstOrDefault(a => a.Key == "process.pid").Value;
+        Assert.IsType<long>(processId);
+        Assert.Equal(Process.GetCurrentProcess().Id, (int)(long)processId);
     }
 
     [Fact]
-    public void ResourceDetector_OtelResourceAttributes_TrimsWhitespaceAroundPairs()
+    public void ResourceDetector_OtelResourceAttributes_EmptyValue_TreatedAsConfigured()
     {
-        // OTel spec doesn't allow spaces around '=', but leading/trailing whitespace on a pair is tolerated.
-        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
-        {
-            { "WEBSITE_SITE_NAME", "appName" },
-            { "OTEL_RESOURCE_ATTRIBUTES", "other.key=value, service.name=my-custom-service" }
-        });
+        // A key with an empty value (service.name=) is still treated as explicitly configured —
+        // the OTel SDK will set service.name to empty from OTEL_RESOURCE_ATTRIBUTES.
+        using var _ = new TestScopedEnvironmentVariable("OTEL_RESOURCE_ATTRIBUTES", "service.name=");
 
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
         Resource resource = detector.Detect();

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -175,6 +175,7 @@ public class EndToEndTests
         Assert.Equal(4, resource.Attributes.Count());
         Assert.Equal("testhost", resource.Attributes.FirstOrDefault(a => a.Key == "service.name").Value);
         Assert.Contains("dotnetiso", resource.Attributes.FirstOrDefault(a => a.Key == "ai.sdk.prefix").Value as string);
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name");
     }
 
     [Fact]
@@ -187,6 +188,251 @@ public class EndToEndTests
         Assert.Equal($"/subscriptions/AAAAA-AAAAA-AAAAA-AAA/resourceGroups/rg/providers/Microsoft.Web/sites/appName"
             , resource.Attributes.FirstOrDefault(a => a.Key == "cloud.resource_id").Value);
         Assert.Equal($"EastUS", resource.Attributes.FirstOrDefault(a => a.Key == "cloud.region").Value);
+        Assert.Equal("appName", resource.Attributes.FirstOrDefault(a => a.Key == "service.name").Value);
+    }
+
+    [Fact]
+    public void ResourceDetector_SiteUpdateId_AddedWhenInAzure()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "WEBSITE_RESOURCE_GROUP", "rg" },
+            { "WEBSITE_OWNER_NAME", "AAAAA-AAAAA-AAAAA-AAA+appName-EastUSwebspace" },
+            { "REGION_NAME", "EastUS" },
+            { "FUNCTIONS_SITE_UPDATE_ID", "update-123" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.Equal("update-123", resource.Attributes.FirstOrDefault(a => a.Key == "azure.functions.site.update_id").Value);
+    }
+
+    [Fact]
+    public void ResourceDetector_SlotName_AddedAsDeploymentEnvironmentName()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "WEBSITE_SLOT_NAME", "staging" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.Equal("staging", resource.Attributes.FirstOrDefault(a => a.Key == "deployment.environment.name").Value);
+    }
+    
+    [Fact]
+    public void ResourceDetector_SlotName_NotAddedWhenLocal()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SLOT_NAME", "staging" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name");
+    }
+
+    [Fact]
+    public void ResourceDetector_SiteUpdateId_NotAddedWhenLocal()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "FUNCTIONS_SITE_UPDATE_ID", "update-123" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "azure.functions.site.update_id");
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelServiceName_SkipsServiceName()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "OTEL_SERVICE_NAME", "my-custom-service" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelResourceAttributes_ServiceName_SkipsServiceName()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "OTEL_RESOURCE_ATTRIBUTES", "service.name=my-custom-service,other.key=value" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelResourceAttributes_ServiceVersion_SkipsServiceVersion()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "OTEL_RESOURCE_ATTRIBUTES", "service.version=1.2.3" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.version");
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelResourceAttributes_KeyMatching_CaseSensitive()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "OTEL_RESOURCE_ATTRIBUTES", "Service.Name=my-custom-service" }
+        });
+
+        // Keys are case-sensitive; "Service.Name" should NOT match "service.name"
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.Equal("appName", resource.Attributes.FirstOrDefault(a => a.Key == "service.name").Value);
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelServiceName_SkipsServiceName_WhenLocal()
+    {
+        using var _ = new TestScopedEnvironmentVariable("OTEL_SERVICE_NAME", "my-custom-service");
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelResourceAttributes_ServiceName_SkipsServiceName_WhenLocal()
+    {
+        using var _ = new TestScopedEnvironmentVariable("OTEL_RESOURCE_ATTRIBUTES", "service.name=my-custom-service");
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelServiceName_TakesPriorityOver_OtelResourceAttributes()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "OTEL_SERVICE_NAME", "from-env" },
+            { "OTEL_RESOURCE_ATTRIBUTES", "service.name=from-attributes" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelResourceAttributes_ServiceVersion_SkipsServiceVersion_WhenInAzure()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "OTEL_RESOURCE_ATTRIBUTES", "service.version=1.2.3" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.version");
+    }
+
+    [Fact]
+    public void ResourceDetector_CloudAttributes_AddedWhenInAzure()
+    {
+        using var _ = new TestScopedEnvironmentVariable("WEBSITE_SITE_NAME", "appName");
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.Equal("azure", resource.Attributes.FirstOrDefault(a => a.Key == "cloud.provider").Value);
+        Assert.Equal("azure_functions", resource.Attributes.FirstOrDefault(a => a.Key == "cloud.platform").Value);
+    }
+
+    [Fact]
+    public void ResourceDetector_CloudAttributes_NotAddedWhenLocal()
+    {
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "cloud.provider");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "cloud.platform");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "cloud.region");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "cloud.resource_id");
+    }
+
+    [Fact]
+    public void ResourceDetector_CloudResourceId_NotAddedWhenResourceGroupMissing()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "WEBSITE_OWNER_NAME", "AAAAA-AAAAA-AAAAA-AAA+appName-EastUSwebspace" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "cloud.resource_id");
+    }
+
+    [Fact]
+    public void ResourceDetector_CloudResourceId_NotAddedWhenOwnerNameMissing()
+    {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "WEBSITE_RESOURCE_GROUP", "rg" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "cloud.resource_id");
+    }
+
+    [Fact]
+    public void ResourceDetector_OtelResourceAttributes_TrimsWhitespaceAroundPairs()
+    {
+        // OTel spec doesn't allow spaces around '=', but leading/trailing whitespace on a pair is tolerated.
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", "appName" },
+            { "OTEL_RESOURCE_ATTRIBUTES", "other.key=value, service.name=my-custom-service" }
+        });
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
     }
 
     private static IDisposable SetupDefaultEnvironmentVariables()

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -169,6 +169,13 @@ public class EndToEndTests
     [Fact]
     public void ResourceDetectorLocalDevelopment()
     {
+        using var _ = new TestScopedEnvironmentVariable(new Dictionary<string, string>
+        {
+            { "WEBSITE_SITE_NAME", null! },
+            { "OTEL_SERVICE_NAME", null! },
+            { "OTEL_RESOURCE_ATTRIBUTES", null! }
+        });
+
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
         Resource resource = detector.Detect();
 
@@ -398,7 +405,9 @@ public class EndToEndTests
             { "WEBSITE_SITE_NAME", "appName" },
             { "WEBSITE_RESOURCE_GROUP", "rg" },
             { "WEBSITE_OWNER_NAME", "AAAAA-AAAAA-AAAAA-AAA+appName-EastUSwebspace" },
-            { "REGION_NAME", "EastUS" }
+            { "REGION_NAME", "EastUS" },
+            { "OTEL_SERVICE_NAME", null! },
+            { "OTEL_RESOURCE_ATTRIBUTES", null! }
         });
     }
 

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -378,6 +378,19 @@ public class EndToEndTests
         Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
     }
 
+    [Fact]
+    public void ResourceDetector_OtelResourceAttributes_WhitespaceOnly_NotTreatedAsConfigured()
+    {
+        // A whitespace-only value with 3+ spaces passes the Length > 2 guard but Trim() + IndexOf('=')
+        // correctly returns false — no '=' found means the key is not matched.
+        using var _ = new TestScopedEnvironmentVariable("OTEL_RESOURCE_ATTRIBUTES", "   ");
+
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name");
+    }
+
     private static IDisposable SetupDefaultEnvironmentVariables()
     {
         return new TestScopedEnvironmentVariable(new Dictionary<string, string>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Brings the isolated worker's FunctionsResourceDetector in line with the equivalent changes made to the Azure Functions host in Azure/azure-functions-host#11506.

  FunctionsResourceDetector
  - service.name now follows priority order: OTEL_SERVICE_NAME → OTEL_RESOURCE_ATTRIBUTES[service.name] →
  WEBSITE_SITE_NAME → assembly name ("unknown" as final fallback). When a higher-priority source is present the detector   skips adding service.name, letting the OTel SDK pick it up instead.
  - service.version now follows priority order: OTEL_RESOURCE_ATTRIBUTES[service.version] → assembly version. There is no OTEL_SERVICE_VERSION per OTel spec (https://github.com/open-telemetry/semantic-conventions/issues/2669).
  - New attribute deployment.environment.name populated from WEBSITE_SLOT_NAME (Azure only).
  - New attribute azure.functions.site.update_id populated from FUNCTIONS_SITE_UPDATE_ID (Azure only).
  - GetAzureResourceUri uses span-based parsing for the subscription ID and returns null instead of string.Empty when env vars are missing.
  - OTEL_RESOURCE_ATTRIBUTES parsing uses ReadOnlySpan<char> to avoid allocations; key matching is case-sensitive   ordinal. TODO left to replace with MemoryExtensions.Split once the library targets .NET 10.
  - AssemblyVersion is cached as private static readonly fields — computed once at class load rather than on every Detect() call.

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
