### PR TITLE
Add AZFW0017 to analyzer table in Sdk README

### DIFF
--- a/docs/analyzer-rules/index.md
+++ b/docs/analyzer-rules/index.md
@@ -1,1 +1,30 @@
-Azure Functions .NET Worker Analyzer Rules
+# Azure Functions .NET Worker Analyzer Rules
+
+This page lists all analyzer rules shipped with the Azure Functions .NET Worker packages.
+
+## Microsoft.Azure.Functions.Worker.Sdk
+
+| Rule ID | Severity | Description |
+|---------|----------|-------------|
+| [AZFW0001](AZFW0001.md) | Error | Invalid binding attributes |
+| [AZFW0002](AZFW0002.md) | Error | Avoid async void |
+| [AZFW0003](AZFW0003.md) | Error | Invalid base class for extension startup type |
+| [AZFW0004](AZFW0004.md) | Error | Extension startup type is missing parameterless constructor |
+| [AZFW0005](AZFW0005.md) | Error | Multiple Azure Functions Binding Attributes grouped together |
+| [AZFW0006](AZFW0006.md) | Warning | Symbol not found |
+| [AZFW0007](AZFW0007.md) | Error | Multiple HTTP response binding types for Azure Function |
+| [AZFW0008](AZFW0008.md) | Error | Invalid cardinality |
+| [AZFW0009](AZFW0009.md) | Error | Invalid use of SupportsDeferredBinding attribute |
+| [AZFW0010](AZFW0010.md) | Warning | Invalid binding type |
+| [AZFW0011](AZFW0011.md) | Error | Invalid binding type |
+| [AZFW0012](AZFW0012.md) | Error | Invalid retry options |
+| [AZFW0013](AZFW0013.md) | Error | Unable to parse binding argument |
+| [AZFW0017](AZFW0017.md) | Error | Duplicate function name |
+
+## Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
+
+| Rule ID | Severity | Description |
+|---------|----------|-------------|
+| [AZFW0014](AZFW0014.md) | Error | Missing registration for ASP.NET Core Integration |
+| [AZFW0015](AZFW0015.md) | Error | Missing HttpResult attribute for multi-output function |
+| [AZFW0016](AZFW0016.md) | Warning | Missing HttpResult attribute for multi-output function |

--- a/sdk/Sdk/README.md
+++ b/sdk/Sdk/README.md
@@ -32,14 +32,7 @@ Three Roslyn source generators run at compile time:
 
 ### Analyzers
 
-| Diagnostic | Severity | Description |
-|------------|----------|-------------|
-| AZFW0001 | Error | WebJobs binding attributes (in-process) used instead of isolated worker attributes |
-| AZFW0002 | Error | Async function method returns `void` instead of `Task` |
-| AZFW0009 | Error | `SupportsDeferredBinding` applied to an output binding |
-| AZFW0010 | Warning | Parameter type not supported by the binding attribute |
-| AZFW0011 | Error | Blob container path requires an iterable type or `BlobContainerClient` |
-| AZFW0017 | Error | Duplicate function name — function names must be unique across the app |
+This package includes analyzers (AZFW0001–AZFW0013, AZFW0017) that catch common issues at compile time. For the full list of rules and detailed documentation, see the [analyzer rules reference](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/docs/analyzer-rules/index.md).
 
 ## Configuration
 

--- a/sdk/Sdk/README.md
+++ b/sdk/Sdk/README.md
@@ -39,6 +39,7 @@ Three Roslyn source generators run at compile time:
 | AZFW0009 | Error | `SupportsDeferredBinding` applied to an output binding |
 | AZFW0010 | Warning | Parameter type not supported by the binding attribute |
 | AZFW0011 | Error | Blob container path requires an iterable type or `BlobContainerClient` |
+| AZFW0017 | Error | Duplicate function name — function names must be unique across the app |
 
 ## Configuration
 

--- a/sdk/Sdk/README.md
+++ b/sdk/Sdk/README.md
@@ -32,7 +32,7 @@ Three Roslyn source generators run at compile time:
 
 ### Analyzers
 
-This package includes analyzers (AZFW0001–AZFW0013, AZFW0017) that catch common issues at compile time. For the full list of rules and detailed documentation, see the [analyzer rules reference](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/docs/analyzer-rules/index.md).
+This package includes analyzers (AZFW0001–AZFW0013, AZFW0017) that catch common issues during development. For the full list of rules and detailed documentation, see the [analyzer rules reference](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/docs/analyzer-rules/index.md).
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Adds the missing `AZFW0017` (Duplicate function name) diagnostic to the analyzer table in the `Microsoft.Azure.Functions.Worker.Sdk` package README.

This diagnostic was shipped as part of #3158 but was not included in the README table added by #3357.

## Changes

- [sdk/Sdk/README.md](sdk/Sdk/README.md): Added `AZFW0017 | Error | Duplicate function name` row to the Analyzers table.