### PR TITLE
feat(kafka): add OidcManaged enum value to OAuthBearerMethod

### DIFF
--- a/extensions/Worker.Extensions.Kafka/src/OAuthBearerMethod.cs
+++ b/extensions/Worker.Extensions.Kafka/src/OAuthBearerMethod.cs
@@ -13,6 +13,15 @@ namespace Microsoft.Azure.Functions.Worker
     public enum OAuthBearerMethod
     {
         Default,
-        Oidc
+        Oidc,
+
+        /// <summary>
+        /// OIDC client-credentials flow performed in managed .NET code rather than
+        /// delegated to librdkafka's libcurl-based token fetch. Requires a host
+        /// extension (Microsoft.Azure.WebJobs.Extensions.Kafka) that supports this
+        /// mode; avoids the platform-specific CA-bundle issue that affects
+        /// librdkafka's OIDC path on some Linux images (e.g. Azure Functions Flex).
+        /// </summary>
+        OidcManaged
     }
 }


### PR DESCRIPTION
## Summary

Adds `OAuthBearerMethod.OidcManaged` to the Kafka extension's `OAuthBearerMethod` enum so the isolated-worker `[KafkaTrigger]` / `[Kafka]` attributes can carry the new value through to the host extension. Existing `Default` and `Oidc` values are unchanged.

This is the worker-side companion to the host extension change in [Azure/azure-functions-kafka-extension#635](https://github.com/Azure/azure-functions-kafka-extension/pull/635). The host extension is where the runtime behavior lives.

## Motivation

On some Linux images (notably Azure Functions Flex Consumption), librdkafka's built-in OIDC path uses libcurl with a hardcoded CA-bundle path (`/etc/pki/tls/certs/ca-bundle.crt`) that doesn't exist, producing:

```
error setting certificate file: /etc/pki/tls/certs/ca-bundle.crt (-1)
```

The natural fix would be `https.ca.location` in `ProducerConfig` / `ConsumerConfig`, but that property was only added in **librdkafka 2.11**. `Confluent.Kafka 2.4.0` (the host extension's pinned version) ships an older librdkafka that doesn't expose it. Bumping that dependency is a non-trivial cascade through `Confluent.SchemaRegistry` and serializers.

The host extension solves this without changing the librdkafka pin: it adds `OAuthBearerMethod.OidcManaged`, which performs OIDC client-credentials token acquisition in managed .NET code (`HttpClient`) and pushes the token onto librdkafka via `SetOAuthBearerTokenRefreshHandler` plus a synchronous `OAuthBearerSetToken` call right after `Build()`. `HttpClient` uses the OS trust store on every supported platform, so the CA-bundle problem disappears.

This PR is the **worker-side** part: it adds the new enum value to the attribute surface so users can write:

```csharp
[Function("Heartbeat")]
public Task Run([KafkaTrigger(
    brokerList: "...", topic: "...",
    AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
    OAuthBearerMethod = OAuthBearerMethod.OidcManaged,                 // <-- new
    OAuthBearerClientId = "%...%", OAuthBearerClientSecret = "%...%",
    OAuthBearerTokenEndpointUrl = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
    OAuthBearerScope = "...",
    OAuthBearerExtensions = "logicalCluster=lkc-...,identityPoolId=pool-...")] byte[][] events,
    FunctionContext context) { /* ... */ }
```

The trigger metadata serializes the enum value into `function.json`, and the host extension picks it up at binding time. There is no runtime logic in this package — it is purely the attribute surface.

## Operational note for Flex Consumption

The host PR documents this in detail, but for cross-reference: end-to-end auto-scaling on Flex Consumption with `OidcManaged` currently requires `alwaysReady` to be set on the Kafka function group(s).

Per [Architecture.md § Scale Controller Integration](https://github.com/Azure/azure-functions-kafka-extension/blob/dev/Architecture.md#scale-controller-integration), Azure's Functions Scale Controller embeds a pinned reference to `Microsoft.Azure.WebJobs.Extensions.Kafka` and uses reflection-based delegation for scaling decisions. Until the Scale Controller's pinned version contains the host change that ships alongside this PR, it can't deserialize `OAuthBearerMethod: "OidcManaged"` from function metadata, so it can't compute lag for these triggers and won't scale them out from zero.

The listener still works correctly with `alwaysReady=1`. Once the Scale Controller's pinned reference is bumped, dynamic scale-from-zero will work without `alwaysReady`.

## Backwards compatibility

- Purely additive: `Default = 0`, `Oidc = 1`, `OidcManaged = 2`. No reordering.
- Existing code using `Default` or `Oidc` is unaffected.
- Older host extension versions that don't recognise `OidcManaged` will silently fall back to library default behavior on the metadata cast, so this enum value is only meaningful when paired with the matching host extension release. Recommended: gate user-facing code on the host extension version that contains the corresponding host change.

## Test plan

- [x] Build clean (the existing nullable-reference-types warning in `Worker.Extensions.Shared` is pre-existing on `main`)
- [x] No tests added or modified — this is a one-line enum addition with no runtime behavior
- [ ] Reviewer to confirm CI passes against the worker SDK version pinned in `global.json`

## Companion PR

Host-side runtime behavior: [Azure/azure-functions-kafka-extension#635](https://github.com/Azure/azure-functions-kafka-extension/pull/635) — adds the `OidcManaged` runtime path, `OidcTokenProvider`, eager `PrimeToken`, and Schema Registry auth-provider integration.

Both PRs need to ship for users to opt in. Recommended merge order: host PR first, this one after.

## Files

```
extensions/Worker.Extensions.Kafka/src/OAuthBearerMethod.cs   +10/-1   (new enum value + XML doc)
```
