### PR TITLE
docs: Update Kafka extension release notes for KafkaRecord feature

### DIFF
--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -4,6 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Kafka <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Kafka 4.2.0
 
-- <entry>
+- Add `KafkaRecord` type for raw Apache Kafka record binding with full metadata access (topic, partition, offset, key/value as raw bytes, headers, timestamp, leader epoch) via Protobuf deserialization (#3356)
+- Update `WebJobsExtension` dependency from 4.1.4 to 4.3.1
+- Add `KafkaRecordConverter` with `SupportsDeferredBinding` following EventHubs/ServiceBus pattern
+- Use shared `InvalidBindingSourceException`/`InvalidContentTypeException` from `Worker.Extensions.Shared`

--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -7,6 +7,5 @@
 ### Microsoft.Azure.Functions.Worker.Extensions.Kafka 4.2.0
 
 - Add `KafkaRecord` type for raw Apache Kafka record binding with full metadata access (topic, partition, offset, key/value as raw bytes, headers, timestamp, leader epoch) via Protobuf deserialization (#3356)
-- Update `WebJobsExtension` dependency from 4.1.4 to 4.3.1
-- Add `KafkaRecordConverter` with `SupportsDeferredBinding` following EventHubs/ServiceBus pattern
-- Use shared `InvalidBindingSourceException`/`InvalidContentTypeException` from `Worker.Extensions.Shared`
+- Update `Microsoft.Azure.WebJobs.Extensions.Kafka` dependency from 4.1.4 to 4.3.1 (#3356)
+- Add `KafkaRecordConverter` with `SupportsDeferredBinding` following EventHubs/ServiceBus pattern (#3356)

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -6,7 +6,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.1.3</VersionPrefix>
+    <VersionPrefix>4.2.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
+++ b/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Tables" Version="1.4.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.6" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Kafka" Version="4.1.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.SignalRService" Version="2.0.1" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
@@ -61,6 +60,7 @@
     <ProjectReference Include="..\Resources\Projects\DependentAssemblyWithFunctions.NetStandard\DependentAssemblyWithFunctions.NetStandard.csproj" />
     <ProjectReference Include="..\Resources\Projects\DependentAssemblyWithFunctions\DependentAssemblyWithFunctions.csproj" />
     <ProjectReference Include="..\TestUtility\TestUtility.csproj" />
+    <ProjectReference Include="..\..\extensions\Worker.Extensions.Kafka\src\Worker.Extensions.Kafka.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
+++ b/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Tables" Version="1.4.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.6" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Kafka" Version="4.1.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.SignalRService" Version="2.0.1" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
@@ -60,7 +61,6 @@
     <ProjectReference Include="..\Resources\Projects\DependentAssemblyWithFunctions.NetStandard\DependentAssemblyWithFunctions.NetStandard.csproj" />
     <ProjectReference Include="..\Resources\Projects\DependentAssemblyWithFunctions\DependentAssemblyWithFunctions.csproj" />
     <ProjectReference Include="..\TestUtility\TestUtility.csproj" />
-    <ProjectReference Include="..\..\extensions\Worker.Extensions.Kafka\src\Worker.Extensions.Kafka.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update release notes for \Microsoft.Azure.Functions.Worker.Extensions.Kafka\ to document the KafkaRecord feature added in #3356.

Relates to [Azure/azure-functions-kafka-extension#612](https://github.com/Azure/azure-functions-kafka-extension/issues/612)