### PR TITLE
Remove LeaderEpoch from KafkaRecord and update host extension to 4.3.2

### DIFF
--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -4,6 +4,11 @@
 - My change description (#PR/#issue)
 -->
 
+### Microsoft.Azure.Functions.Worker.Extensions.Kafka 4.3.0
+
+- **Breaking**: Remove `LeaderEpoch` from `KafkaRecord` — it is consumer fetch metadata, not stored record data (azure-functions-kafka-extension#639)
+- Update `Microsoft.Azure.WebJobs.Extensions.Kafka` dependency from 4.3.1 to 4.3.2
+
 ### Microsoft.Azure.Functions.Worker.Extensions.Kafka 4.2.0
 
 - Add `KafkaRecord` type for raw Apache Kafka record binding with full metadata access (topic, partition, offset, key/value as raw bytes, headers, timestamp, leader epoch) via Protobuf deserialization (#3356)

--- a/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/KafkaRecordFunctions.cs
+++ b/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/KafkaRecordFunctions.cs
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace KafkaRecordSample
+{
+    public static class KafkaRecordFunctions
+    {
+        private static readonly ConcurrentQueue<ReceivedRecord> ReceivedRecords = new();
+
+        /// <summary>
+        /// HTTP trigger that produces a message to Kafka.
+        /// GET/POST /api/produce?message=hello
+        /// </summary>
+        [Function("Produce")]
+        [KafkaOutput("LocalBroker", "%KafkaRecordSampleTopic%")]
+        public static string Produce(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "produce")] HttpRequestData req,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger("Produce");
+            var message = req.Query["message"] ?? $"kafkarecord-sample-{System.Guid.NewGuid():N}";
+            logger.LogInformation("Producing message: {Message}", message);
+            return message;
+        }
+
+        /// <summary>
+        /// Kafka trigger that receives a KafkaRecord (deferred binding with Protobuf transport).
+        /// </summary>
+        [Function("Consume")]
+        public static void Consume(
+            [KafkaTrigger("LocalBroker", "%KafkaRecordSampleTopic%",
+                ConsumerGroup = "%KafkaRecordSampleConsumerGroup%")] KafkaRecord record,
+            FunctionContext context)
+        {
+            var logger = context.GetLogger("Consume");
+            var value = record.Value != null ? Encoding.UTF8.GetString(record.Value) : "(null)";
+            var key = record.Key != null ? Encoding.UTF8.GetString(record.Key) : "(null)";
+
+            var received = new ReceivedRecord
+            {
+                Topic = record.Topic,
+                Partition = record.Partition,
+                Offset = record.Offset,
+                Key = key,
+                Value = value,
+                TimestampMs = record.Timestamp?.UnixTimestampMs,
+                TimestampType = record.Timestamp?.Type.ToString(),
+                HeaderCount = record.Headers?.Length ?? 0,
+            };
+
+            ReceivedRecords.Enqueue(received);
+            while (ReceivedRecords.Count > 100 && ReceivedRecords.TryDequeue(out _)) { }
+
+            logger.LogInformation(
+                "Received KafkaRecord: topic={Topic}, partition={Partition}, offset={Offset}, value={Value}",
+                received.Topic, received.Partition, received.Offset, received.Value);
+        }
+
+        /// <summary>
+        /// HTTP trigger that returns the latest received records.
+        /// GET /api/status?message=hello
+        /// </summary>
+        [Function("Status")]
+        public static HttpResponseData Status(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "status")] HttpRequestData req,
+            FunctionContext context)
+        {
+            var message = req.Query["message"];
+            var records = ReceivedRecords.ToArray();
+            var match = string.IsNullOrEmpty(message)
+                ? records.LastOrDefault()
+                : records.LastOrDefault(r => r.Value == message);
+
+            var response = req.CreateResponse(System.Net.HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "application/json");
+            response.WriteString(System.Text.Json.JsonSerializer.Serialize(new
+            {
+                count = records.Length,
+                matched = match != null,
+                record = match,
+            }));
+            return response;
+        }
+    }
+
+    public class ReceivedRecord
+    {
+        public string Topic { get; set; }
+        public int Partition { get; set; }
+        public long Offset { get; set; }
+        public string Key { get; set; }
+        public string Value { get; set; }
+        public long? TimestampMs { get; set; }
+        public string TimestampType { get; set; }
+        public int HeaderCount { get; set; }
+    }
+}

--- a/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/KafkaRecordSample.csproj
+++ b/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/KafkaRecordSample.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>KafkaRecordSample</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Worker.Extensions.Kafka.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/Program.cs
+++ b/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/Program.cs
@@ -1,0 +1,7 @@
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .Build();
+
+host.Run();

--- a/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/README.md
+++ b/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/README.md
@@ -1,0 +1,32 @@
+# KafkaRecord Isolated Worker Sample
+
+Demonstrates `KafkaRecord` deferred-binding in a .NET isolated worker function.
+
+## Prerequisites
+
+- .NET 8 SDK
+- Azure Functions Core Tools v4
+- Local Kafka broker on `localhost:9092` with topic `test-topic`
+
+## Run
+
+```bash
+dotnet build
+func start
+```
+
+## Test
+
+```bash
+# Produce a message
+curl "http://localhost:7071/api/produce?message=hello-kafkarecord"
+
+# Check received records
+curl "http://localhost:7071/api/status?message=hello-kafkarecord"
+```
+
+## What this validates
+
+- `KafkaRecord` type binds via Protobuf deferred binding (`AzureKafkaRecord`)
+- Record metadata (topic, partition, offset, key, value, timestamp, headers) round-trips correctly
+- `LeaderEpoch` is NOT present on `KafkaRecord` (removed per issue #639)

--- a/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/host.json
+++ b/extensions/Worker.Extensions.Kafka/samples/KafkaRecordSample/host.json
@@ -1,0 +1,8 @@
+{
+    "version": "2.0",
+    "logging": {
+        "logLevel": {
+            "default": "Information"
+        }
+    }
+}

--- a/extensions/Worker.Extensions.Kafka/src/KafkaRecord.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaRecord.cs
@@ -43,10 +43,5 @@ namespace Microsoft.Azure.Functions.Worker
         /// Gets or sets the record headers.
         /// </summary>
         public KafkaHeader[] Headers { get; set; }
-
-        /// <summary>
-        /// Gets or sets the leader epoch, if available. Null if not provided by the broker.
-        /// </summary>
-        public int? LeaderEpoch { get; set; }
     }
 }

--- a/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaRecordConverter.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Azure.Functions.Worker
                 Offset = proto.Offset,
                 Key = proto.HasKey ? proto.Key.ToByteArray() : null,
                 Value = proto.HasValue ? proto.Value.ToByteArray() : null,
-                LeaderEpoch = proto.HasLeaderEpoch ? proto.LeaderEpoch : (int?)null,
                 Timestamp = proto.Timestamp != null
                     ? new KafkaTimestamp
                     {

--- a/extensions/Worker.Extensions.Kafka/src/Proto/KafkaRecordProto.proto
+++ b/extensions/Worker.Extensions.Kafka/src/Proto/KafkaRecordProto.proto
@@ -16,7 +16,11 @@ message KafkaRecordProto {
     optional bytes value = 5;
     KafkaTimestampProto timestamp = 6;
     repeated KafkaHeaderProto headers = 7;
-    optional int32 leader_epoch = 8;
+
+    // leader_epoch was removed per customer feedback (issue #639).
+    // It represents consumer fetch metadata, not stored record data.
+    reserved 8;
+    reserved "leader_epoch";
 
     // Reserved for future fields. Do not reuse field numbers.
     reserved 9 to 15;

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -6,7 +6,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.2.0</VersionPrefix>
+    <VersionPrefix>4.3.0</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Kafka" Version="4.3.1" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Kafka" Version="4.3.2" />
   </ItemGroup>
 
 </Project>

--- a/test/extensions/Worker.Extensions.Tests/Kafka/KafkaRecordConverterTests.cs
+++ b/test/extensions/Worker.Extensions.Tests/Kafka/KafkaRecordConverterTests.cs
@@ -212,47 +212,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Kafka
         }
 
         [Fact]
-        public async Task ConvertAsync_PreservesLeaderEpoch()
-        {
-            var proto = CreateTestKafkaRecordProto();
-            proto.LeaderEpoch = 42;
-
-            var data = CreateGrpcModelBindingData(proto);
-            var context = new TestConverterContext(typeof(KafkaRecord), data);
-            var converter = new KafkaRecordConverter();
-            var result = await converter.ConvertAsync(context);
-
-            Assert.Equal(ConversionStatus.Succeeded, result.Status);
-            var output = result.Value as KafkaRecord;
-            Assert.NotNull(output);
-            Assert.Equal(42, output.LeaderEpoch);
-        }
-
-        [Fact]
-        public async Task ConvertAsync_NoLeaderEpoch_ReturnsNull()
-        {
-            var proto = new KafkaRecordProto
-            {
-                Topic = "test-topic",
-                Partition = 0,
-                Offset = 0,
-                Value = ByteString.CopyFromUtf8("test"),
-                Timestamp = new KafkaTimestampProto { UnixTimestampMs = 0, Type = 0 },
-            };
-            // LeaderEpoch deliberately not set
-
-            var data = CreateGrpcModelBindingData(proto);
-            var context = new TestConverterContext(typeof(KafkaRecord), data);
-            var converter = new KafkaRecordConverter();
-            var result = await converter.ConvertAsync(context);
-
-            Assert.Equal(ConversionStatus.Succeeded, result.Status);
-            var output = result.Value as KafkaRecord;
-            Assert.NotNull(output);
-            Assert.Null(output.LeaderEpoch);
-        }
-
-        [Fact]
         public async Task ConvertAsync_ReturnsUnhandled_NullSource()
         {
             var context = new TestConverterContext(typeof(KafkaRecord), source: null);
@@ -333,7 +292,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Kafka
                     UnixTimestampMs = 1700000000000,
                     Type = 1, // CreateTime
                 },
-                LeaderEpoch = 7,
             };
             proto.Headers.Add(new KafkaHeaderProto
             {
@@ -363,7 +321,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Kafka
             Assert.Equal("{\"name\":\"test\"}", Encoding.UTF8.GetString(record.Value));
             Assert.Equal(1700000000000, record.Timestamp.UnixTimestampMs);
             Assert.Equal(KafkaTimestampType.CreateTime, record.Timestamp.Type);
-            Assert.Equal(7, record.LeaderEpoch);
             Assert.Single(record.Headers);
             Assert.Equal("trace-id", record.Headers[0].Key);
             Assert.Equal("trace-abc", record.Headers[0].GetValueAsString());


### PR DESCRIPTION
## Summary

Remove `LeaderEpoch` from `KafkaRecord` and update host extension dependency to 4.3.2, aligning with host-side changes in [azure-functions-kafka-extension#640](https://github.com/Azure/azure-functions-kafka-extension/pull/640).

`LeaderEpoch` represents consumer fetch/offset metadata (from `ConsumeResult.LeaderEpoch` in Confluent.Kafka), not stored Kafka record data. Per customer feedback in [azure-functions-kafka-extension#639](https://github.com/Azure/azure-functions-kafka-extension/issues/639), it does not belong on the `KafkaRecord` user-facing type.

## Changes

### Proto schema
- Removed `leader_epoch` (field 8) from `KafkaRecordProto`
- Reserved field number 8 and name `leader_epoch` to prevent future reuse
- Schema now matches the host-side copy in azure-functions-kafka-extension 4.3.2

### KafkaRecord POCO
- Removed `public int? LeaderEpoch { get; set; }` property

### KafkaRecordConverter
- Removed `LeaderEpoch` mapping from Protobuf deserialization

### Tests
- Removed `ConvertAsync_PreservesLeaderEpoch` and `ConvertAsync_NoLeaderEpoch_ReturnsNull` tests
- Removed `LeaderEpoch` from test helper `CreateTestKafkaRecordProto()` and assertion helper `AssertKafkaRecord()`

### Dependencies
- Updated `WebJobsExtension` reference from 4.3.1 to 4.3.2

### Sample
- Added `KafkaRecordSample` isolated worker sample under `extensions/Worker.Extensions.Kafka/samples/`
- Demonstrates KafkaRecord deferred binding with Produce, Consume, and Status endpoints

## Testing
- Unit tests: 10/10 passed
- E2E manual test: `func start` with local Kafka broker, produce/consume/status flow verified
- `KafkaRecord` correctly binds with topic, partition, offset, key, value, timestamp, headers — no `LeaderEpoch`

## Related
- azure-functions-kafka-extension#639
- azure-functions-kafka-extension#640
