### PR TITLE
Prioritize deployment environment set in OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -59,12 +59,13 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
                     {
                         attributes.Add(new(ResourceSemanticConventions.CloudResourceId, uri));
                     }
-
+                    
+                    // Priority: OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name or deployment.environment] > WEBSITE_SLOT_NAME
                     if (!IsResourceAttributeConfigured(ResourceSemanticConventions.DeploymentEnvironmentName, resourceAttributes) &&
                         !IsResourceAttributeConfigured(ResourceSemanticConventions.DeploymentEnvironment, resourceAttributes) &&
                         Environment.GetEnvironmentVariable(OpenTelemetryConstants.SlotNameEnvVar) is { Length: > 0 } slot)
                     {
-                        attributes.Add(new(ResourceSemanticConventions.DeploymentEnvironmentName, slot));                  
+                        attributes.Add(new(ResourceSemanticConventions.DeploymentEnvironmentName, slot));
                     }
 
                     if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.SiteUpdateIdEnvVar) is { Length: > 0 } siteUpdateId)

--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -61,12 +61,10 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
                     }
 
                     if (!IsResourceAttributeConfigured(ResourceSemanticConventions.DeploymentEnvironmentName, resourceAttributes) &&
-                        !IsResourceAttributeConfigured(ResourceSemanticConventions.DeploymentEnvironment, resourceAttributes))
+                        !IsResourceAttributeConfigured(ResourceSemanticConventions.DeploymentEnvironment, resourceAttributes) &&
+                        Environment.GetEnvironmentVariable(OpenTelemetryConstants.SlotNameEnvVar) is { Length: > 0 } slot)
                     {
-                        if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.SlotNameEnvVar) is { Length: > 0 } slot)
-                        {
-                            attributes.Add(new(ResourceSemanticConventions.DeploymentEnvironmentName, slot));
-                        }                        
+                        attributes.Add(new(ResourceSemanticConventions.DeploymentEnvironmentName, slot));                  
                     }
 
                     if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.SiteUpdateIdEnvVar) is { Length: > 0 } siteUpdateId)

--- a/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/DotNetWorker.OpenTelemetry/FunctionsResourceDetector.cs
@@ -60,9 +60,13 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
                         attributes.Add(new(ResourceSemanticConventions.CloudResourceId, uri));
                     }
 
-                    if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.SlotNameEnvVar) is { Length: > 0 } slot)
+                    if (!IsResourceAttributeConfigured(ResourceSemanticConventions.DeploymentEnvironmentName, resourceAttributes) &&
+                        !IsResourceAttributeConfigured(ResourceSemanticConventions.DeploymentEnvironment, resourceAttributes))
                     {
-                        attributes.Add(new(ResourceSemanticConventions.DeploymentEnvironmentName, slot));
+                        if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.SlotNameEnvVar) is { Length: > 0 } slot)
+                        {
+                            attributes.Add(new(ResourceSemanticConventions.DeploymentEnvironmentName, slot));
+                        }                        
                     }
 
                     if (Environment.GetEnvironmentVariable(OpenTelemetryConstants.SiteUpdateIdEnvVar) is { Length: > 0 } siteUpdateId)

--- a/src/DotNetWorker.OpenTelemetry/ResourceSemanticConventions.cs
+++ b/src/DotNetWorker.OpenTelemetry/ResourceSemanticConventions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.Functions.Worker.OpenTelemetry
 
         // Deployment
         internal const string DeploymentEnvironmentName = "deployment.environment.name";
+        internal const string DeploymentEnvironment = "deployment.environment";
 
         // Azure Functions
         internal const string SiteUpdateId = "azure.functions.site.update_id";

--- a/src/DotNetWorker.OpenTelemetry/release_notes.md
+++ b/src/DotNetWorker.OpenTelemetry/release_notes.md
@@ -2,4 +2,4 @@
 
 ### Microsoft.Azure.Functions.Worker.OpenTelemetry <version>
 
-- <entry>
+- `FunctionsResourceDetector` now favors `OTEL_RESOURCE_ATTRIBUTES` — when `deployment.environment` or `deployment.environment.name` is set, the detector skips adding the slot name to `deployment.environment.name` (#3404).

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -173,7 +173,7 @@ public class EndToEndTests
         {
             { "WEBSITE_SITE_NAME", null! },
             { "OTEL_SERVICE_NAME", null! },
-            { "OTEL_RESOURCE_ATTRIBUTES", "null!" }
+            { "OTEL_RESOURCE_ATTRIBUTES", null! }
         });
 
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
@@ -233,14 +233,8 @@ public class EndToEndTests
 
     public static IEnumerable<object[]> EnvironmentNameSkippedData =>
     [
-        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name] not set locally
-        [new Dictionary<string, string> { { "OTEL_RESOURCE_ATTRIBUTES", "other.key=value" } }],
-        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name] set locally
-        [new Dictionary<string, string> { { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=custom-name,other.key=value" } }],
         // OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name] set in Azure
         [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=custom-name,other.key=value" } }],
-        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment] set locally
-        [new Dictionary<string, string> { { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=custom-name,other.key=value" } }],
         // OTEL_RESOURCE_ATTRIBUTES[deployment.environment] set in Azure
         [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=custom-name,other.key=value" } }],
         // Leading/trailing whitespace around pair is trimmed
@@ -255,7 +249,8 @@ public class EndToEndTests
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
         Resource resource = detector.Detect();
 
-        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name");
     }
 
     [Fact]

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -173,7 +173,7 @@ public class EndToEndTests
         {
             { "WEBSITE_SITE_NAME", null! },
             { "OTEL_SERVICE_NAME", null! },
-            { "OTEL_RESOURCE_ATTRIBUTES", null! }
+            { "OTEL_RESOURCE_ATTRIBUTES", "null!" }
         });
 
         FunctionsResourceDetector detector = new FunctionsResourceDetector();
@@ -230,7 +230,34 @@ public class EndToEndTests
 
         Assert.Equal("staging", resource.Attributes.FirstOrDefault(a => a.Key == "deployment.environment.name").Value);
     }
+
+    public static IEnumerable<object[]> EnvironmentNameSkippedData =>
+    [
+        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name] not set locally
+        [new Dictionary<string, string> { { "OTEL_RESOURCE_ATTRIBUTES", "other.key=value" } }],
+        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name] set locally
+        [new Dictionary<string, string> { { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=custom-name,other.key=value" } }],
+        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name] set in Azure
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=custom-name,other.key=value" } }],
+        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment] set locally
+        [new Dictionary<string, string> { { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=custom-name,other.key=value" } }],
+        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment] set in Azure
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=custom-name,other.key=value" } }],
+        // Leading/trailing whitespace around pair is trimmed
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "OTEL_RESOURCE_ATTRIBUTES", "other.key=value, deployment.environment=custom-name" } }],
+    ];
     
+    [Theory]
+    [MemberData(nameof(EnvironmentNameSkippedData))]
+    public void ResourceDetector_EnvironmentName_SkippedWhenConfigured(Dictionary<string, string> envVars)
+    {
+        using var _ = new TestScopedEnvironmentVariable(envVars);
+        FunctionsResourceDetector detector = new FunctionsResourceDetector();
+        Resource resource = detector.Detect();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name");
+    }
+
     [Fact]
     public void ResourceDetector_SlotName_NotAddedWhenLocal()
     {

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -237,6 +237,10 @@ public class EndToEndTests
         [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=custom-name,other.key=value" } }],
         // OTEL_RESOURCE_ATTRIBUTES[deployment.environment] set in Azure
         [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=custom-name,other.key=value" } }],
+        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name] set to empty value in Azure
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=,other.key=value" } }],
+        // OTEL_RESOURCE_ATTRIBUTES[deployment.environment] set to empty value in Azure
+        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=,other.key=value" } }],
     ];
     
     [Theory]

--- a/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/test/DotNetWorker.OpenTelemetry.Tests/EndToEndTests.cs
@@ -237,8 +237,6 @@ public class EndToEndTests
         [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=custom-name,other.key=value" } }],
         // OTEL_RESOURCE_ATTRIBUTES[deployment.environment] set in Azure
         [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "WEBSITE_SLOT_NAME", "staging" }, { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=custom-name,other.key=value" } }],
-        // Leading/trailing whitespace around pair is trimmed
-        [new Dictionary<string, string> { { "WEBSITE_SITE_NAME", "appName" }, { "OTEL_RESOURCE_ATTRIBUTES", "other.key=value, deployment.environment=custom-name" } }],
     ];
     
     [Theory]


### PR DESCRIPTION
Further enhances the isolated worker's FunctionsResourceDetector and the changes made in https://github.com/Azure/azure-functions-dotnet-worker/pull/3362.

FunctionsResourceDetector

The attribute deployment.environment.name now follows priority order (Azure only): 

- OTEL_RESOURCE_ATTRIBUTES[deployment.environment.name] or OTEL_RESOURCE_ATTRIBUTES[deployment.environment] →
 WEBSITE_SLOT_NAME.
- When a higher-priority source is present the detector skips adding deployment.environment.name, letting the OTel SDK pick it up instead.

### Issue describing the changes in this PR

resolves #3404 

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [X] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)
