### PR TITLE
fix(sdk): avoid zip-file conflicts

### DIFF
--- a/src/Azure.Functions.Sdk/Targets/Publish/Azure.Functions.Sdk.Publish.ZipDeploy.targets
+++ b/src/Azure.Functions.Sdk/Targets/Publish/Azure.Functions.Sdk.Publish.ZipDeploy.targets
@@ -10,7 +10,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 -->
 
 <Project>
-  <UsingTask TaskName="$(AzureFunctionsTaskNamespace).Publish.CreateZipFile" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
+  <UsingTask TaskName="$(AzureFunctionsTaskNamespace).Publish.CreateFuncZipFile" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
   <UsingTask TaskName="$(AzureFunctionsTaskNamespace).Publish.ZipDeploy" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
 
   <PropertyGroup>
@@ -20,14 +20,14 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <PublishAllowInsecureRemoteConnections Condition="'$(PublishAllowInsecureRemoteConnections)' == ''">false</PublishAllowInsecureRemoteConnections>
   </PropertyGroup>
 
-  <Target Name="CreateZipFile" DependsOnTargets="_ResolveFunctionExecutable">
-    <CreateZipFile SourceFolder="$(PublishIntermediateOutputPath)" ZipName="$(MSBuildProjectName)"
+  <Target Name="CreateFuncZipFile" DependsOnTargets="_ResolveFunctionExecutable">
+    <CreateFuncZipFile SourceFolder="$(PublishIntermediateOutputPath)" ZipName="$(MSBuildProjectName)"
       PublishIntermediateTempPath="$(PublishIntermediateTempPath)" Executable="$(_FunctionsExecutable)">
       <Output TaskParameter="CreatedZipPath" PropertyName="ZippedPublishContentsPath"/>
-    </CreateZipFile>
+    </CreateFuncZipFile>
   </Target>
 
-  <Target Name="ZipDeploy" DependsOnTargets="CreateZipFile">
+  <Target Name="ZipDeploy" DependsOnTargets="CreateFuncZipFile">
     <PropertyGroup>
       <_ZipPublishUrl>$(PublishUrl)</_ZipPublishUrl>
       <_ZipPublishUrl Condition="'$(_ZipPublishUrl)' == ''">https://$(DeployIisAppPath).scm.azurewebsites.net/</_ZipPublishUrl>

--- a/src/Azure.Functions.Sdk/Targets/Publish/Azure.Functions.Sdk.Publish.ZipDeploy.targets
+++ b/src/Azure.Functions.Sdk/Targets/Publish/Azure.Functions.Sdk.Publish.ZipDeploy.targets
@@ -21,7 +21,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </PropertyGroup>
 
   <Target Name="CreateFuncZipFile" DependsOnTargets="_ResolveFunctionExecutable">
-    <CreateFuncZipFile SourceFolder="$(PublishIntermediateOutputPath)" ZipName="$(MSBuildProjectName)"
+    <CreateFuncZipFile SourceFolder="$(PublishIntermediateOutputPath)" ProjectName="$(MSBuildProjectName)"
       PublishIntermediateTempPath="$(PublishIntermediateTempPath)" Executable="$(_FunctionsExecutable)">
       <Output TaskParameter="CreatedZipPath" PropertyName="ZippedPublishContentsPath"/>
     </CreateFuncZipFile>

--- a/src/Azure.Functions.Sdk/Tasks/Publish/CreateFuncZipFile.cs
+++ b/src/Azure.Functions.Sdk/Tasks/Publish/CreateFuncZipFile.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Sdk.Tasks.Publish;
 /// <summary>
 /// Creates a zip file for a folder.
 /// </summary>
-public sealed class CreateZipFile : Microsoft.Build.Utilities.Task
+public sealed class CreateFuncZipFile : Microsoft.Build.Utilities.Task
 {
     /***
     * This class does not use IFileSystem abstraction because it does not support ZipArchive creation.

--- a/src/Azure.Functions.Sdk/Tasks/Publish/CreateFuncZipFile.cs
+++ b/src/Azure.Functions.Sdk/Tasks/Publish/CreateFuncZipFile.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Sdk.Tasks.Publish;
 /// <summary>
 /// Creates a zip file for a folder.
 /// </summary>
-public sealed class CreateFuncZipFile : Microsoft.Build.Utilities.Task
+public sealed class CreateFuncZipFile(TimeProvider time) : Microsoft.Build.Utilities.Task
 {
     /***
     * This class does not use IFileSystem abstraction because it does not support ZipArchive creation.
@@ -27,11 +27,18 @@ public sealed class CreateFuncZipFile : Microsoft.Build.Utilities.Task
     // Unix file permissions for -rwxrwxrwx
     internal static readonly int UnixExecutablePermissions = Convert.ToInt32("777", 8);
 
+    private readonly TimeProvider _time = Throw.IfNull(time);
+
+    public CreateFuncZipFile()
+        : this(TimeProvider.System)
+    {
+    }
+
     [Required]
     public string SourceFolder { get; set; } = string.Empty;
 
     [Required]
-    public string ZipName { get; set; } = string.Empty;
+    public string ProjectName { get; set; } = string.Empty;
 
     [Required]
     public string PublishIntermediateTempPath { get; set; } = string.Empty;
@@ -69,7 +76,7 @@ public sealed class CreateFuncZipFile : Microsoft.Build.Utilities.Task
 
     internal string CreateZipFileFromDirectory()
     {
-        string zipFileName = ZipName + ".zip";
+        string zipFileName = ProjectName + _time.GetLocalNow().ToString("yyyyMMddHHmmssFFF") + ".zip";
         string destination = Path.Combine(PublishIntermediateTempPath, zipFileName);
         ZipFile.CreateFromDirectory(SourceFolder, destination);
 

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -4,17 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Azure.Functions.Sdk 0.4.0
+### Azure.Functions.Sdk <version>
 
-- Initial SDK preview
-- A replacement for `Microsoft.Azure.Functions.Worker.Sdk`
-- Now an MSBuild SDK (and not a `PackageReference`)
-- Overhauls the extension project generation and restore flow
-  - Generated project renamed to `azure_functions.g.csproj`
-  - Will now make best-effort to generate and restore as part of `dotnet restore` phase
-- Removes dependencies on generated project
-  - `Microsoft.NET.Sdk.Functions` removed
-- No longer fully builds the extension project, only restores and directly collects extension files
-- Extension trimming behavior has been removed
-  - `Microsoft.Azure.Functions.Worker.Sdk` would previously only include extensions which had actual usage (determined by examining built code)
-  - New SDK no longer takes this step. All referenced extensions are included, regardless of actual code usage
+- fix: avoid zip-file conflicts (#3406)

--- a/test/Azure.Functions.Sdk.Tests/Tasks/Publish/CreateFuncZipFileTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/Publish/CreateFuncZipFileTests.cs
@@ -111,7 +111,7 @@ public sealed class CreateFuncZipFileTests : IDisposable
         {
             BuildEngine = _buildEngine.Object,
             SourceFolder = FolderToZip,
-            ZipName = ProjectName,
+            ProjectName = ProjectName,
             PublishIntermediateTempPath = IntermediatePath,
             Executable = executable,
         };

--- a/test/Azure.Functions.Sdk.Tests/Tasks/Publish/CreateFuncZipFileTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/Publish/CreateFuncZipFileTests.cs
@@ -8,13 +8,13 @@ using NuGet.Common;
 
 namespace Azure.Functions.Sdk.Tasks.Publish.Tests;
 
-public sealed class CreateZipFileTests : IDisposable
+public sealed class CreateFuncZipFileTests : IDisposable
 {
     private readonly TempDirectory _temp = new();
 
     private readonly Mock<IBuildEngine> _buildEngine = new();
 
-    public CreateZipFileTests()
+    public CreateFuncZipFileTests()
     {
         FolderToZip = _temp.GetRandomFile();
         IntermediatePath = _temp.GetRandomFile();
@@ -37,7 +37,7 @@ public sealed class CreateZipFileTests : IDisposable
     {
         // arrange
         FolderToZip = "not-rooted";
-        CreateZipFile task = CreateTask();
+        CreateFuncZipFile task = CreateTask();
 
         // act
         bool result = task.Execute();
@@ -48,7 +48,7 @@ public sealed class CreateZipFileTests : IDisposable
             LogLevel.Error,
             Strings.Zip_PathNotRooted,
             "not-rooted",
-            nameof(CreateZipFile.SourceFolder));
+            nameof(CreateFuncZipFile.SourceFolder));
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public sealed class CreateZipFileTests : IDisposable
     {
         // arrange
         IntermediatePath = "not-rooted-2";
-        CreateZipFile task = CreateTask();
+        CreateFuncZipFile task = CreateTask();
 
         // act
         bool result = task.Execute();
@@ -67,7 +67,7 @@ public sealed class CreateZipFileTests : IDisposable
             LogLevel.Error,
             Strings.Zip_PathNotRooted,
             "not-rooted-2",
-            nameof(CreateZipFile.PublishIntermediateTempPath));
+            nameof(CreateFuncZipFile.PublishIntermediateTempPath));
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public sealed class CreateZipFileTests : IDisposable
     {
         // arrange
         SetupZipFolder();
-        CreateZipFile task = CreateTask();
+        CreateFuncZipFile task = CreateTask();
 
         // act
         bool result = task.Execute();
@@ -94,7 +94,7 @@ public sealed class CreateZipFileTests : IDisposable
         SetupZipFolder();
         File.WriteAllText(Path.Combine(FolderToZip, name), string.Empty);
 
-        CreateZipFile task = CreateTask($"{{WorkerRoot}}{Path.GetFileNameWithoutExtension(name)}");
+        CreateFuncZipFile task = CreateTask($"{{WorkerRoot}}{Path.GetFileNameWithoutExtension(name)}");
 
         // act
         bool result = task.Execute();
@@ -104,10 +104,10 @@ public sealed class CreateZipFileTests : IDisposable
         VerifyZipFile(task.CreatedZipPath, name);
     }
 
-    private CreateZipFile CreateTask(string? executable  = null)
+    private CreateFuncZipFile CreateTask(string? executable  = null)
     {
         executable ??= "dotnet";
-        return new CreateZipFile()
+        return new CreateFuncZipFile()
         {
             BuildEngine = _buildEngine.Object,
             SourceFolder = FolderToZip,
@@ -135,7 +135,7 @@ public sealed class CreateZipFileTests : IDisposable
 
             int externalAttributes = entry.ExternalAttributes;
             int unixPermissions = (externalAttributes >> 16) & 0xFFFF;
-            unixPermissions.Should().Be(CreateZipFile.UnixExecutablePermissions);
+            unixPermissions.Should().Be(CreateFuncZipFile.UnixExecutablePermissions);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #3390 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

1. Renames the `CreateZipFile` task to avoid conflicts with any existing `CreateZipFile` tasks (it is an existing task from Microsoft.NET.Sdk.Publish).
2. Adds timestamp suffix to created zip file, avoiding conflicts with previous publish attempts.
