### PR TITLE
fix(sdk): perform atomic write in WriteExtensionProject

### DIFF
--- a/src/Azure.Functions.Sdk/FileSystemExtensions.cs
+++ b/src/Azure.Functions.Sdk/FileSystemExtensions.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO.Abstractions;
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Extension methods for <see cref="IFileSystem"/>.
+/// </summary>
+internal static class FileSystemExtensions
+{
+    extension(IFile file)
+    {
+        /// <summary>
+        /// Moves a file to a new location, optionally overwriting an existing file.
+        /// </summary>
+        /// <param name="sourceFileName">The source file to move.</param>
+        /// <param name="destFileName">The destination file path.</param>
+        /// <param name="overwrite">Whether to overwrite the destination file if it exists.</param>
+        public void Move(string sourceFileName, string destFileName, bool overwrite)
+        {
+            Throw.IfNull(file);
+            Throw.IfNullOrWhitespace(sourceFileName);
+            Throw.IfNullOrWhitespace(destFileName);
+
+            if (overwrite && file.Exists(destFileName))
+            {
+                file.Replace(sourceFileName, destFileName, null);
+                return;
+            }
+
+            file.Move(sourceFileName, destFileName);
+        }
+
+        /// <summary>
+        /// Attempts to delete a file, swallowing any IO exceptions that may occur.
+        /// </summary>
+        /// <param name="path">The path of the file to delete.</param>
+        public void TryDelete(string path)
+        {
+            Throw.IfNull(file);
+            Throw.IfNullOrWhitespace(path);
+
+            try
+            {
+                file.Delete(path);
+            }
+            catch (IOException)
+            {
+                // Ignore IO exceptions when deleting a file.
+            }
+        }
+    }
+}

--- a/src/Azure.Functions.Sdk/Tasks/Extensions/WriteExtensionProject.cs
+++ b/src/Azure.Functions.Sdk/Tasks/Extensions/WriteExtensionProject.cs
@@ -87,37 +87,54 @@ public class WriteExtensionProject(IFileSystem fileSystem, TimeProvider time)
             return true;
         }
 
-        if (_fileSystem.Path.GetDirectoryName(project.Path) is string directory
-            && !_fileSystem.Directory.Exists(directory))
+        string? directory = _fileSystem.Path.GetDirectoryName(project.Path);
+        if (directory is not null && !_fileSystem.Directory.Exists(directory))
         {
             _fileSystem.Directory.CreateDirectory(directory);
         }
 
-        _fileSystem.File.Delete(project.Path);
-        using Stream stream = _fileSystem.File.OpenWrite(project.Path);
-        using XmlWriter writer = XmlWriter.Create(stream, _xmlSettings);
-        writer.WriteComment(string.Format(CultureInfo.InvariantCulture, Disclaimer, _time.GetUtcNow(), hash));
-        writer.WriteStartElement("Project");
-
-        // Omit version so the outer projects version is implicitly used.
-        writer.WriteAttributeString("Sdk", ThisAssembly.Name);
-
-        if (packages.Any())
+        // Write to a temp file first, then atomically replace the target.
+        // This prevents corrupted state if the build is killed mid-write.
+        string tempPath = _fileSystem.Path.Combine(
+            directory ?? ".", _fileSystem.Path.GetRandomFileName());    
+        try
         {
-            writer.WriteStartElement("ItemGroup");
-
-            foreach (ITaskItem package in packages)
+            using (Stream stream = _fileSystem.File.Create(tempPath))
+            using (XmlWriter writer = XmlWriter.Create(stream, _xmlSettings))
             {
-                writer.WriteStartElement("PackageReference");
-                writer.WriteAttributeString("Include", package.ItemSpec);
-                writer.WriteAttributeString("Version", package.Version);
+                writer.WriteComment(string.Format(CultureInfo.InvariantCulture, Disclaimer, _time.GetUtcNow(), hash));
+                writer.WriteStartElement("Project");
+
+                // Omit version so the outer projects version is implicitly used.
+                writer.WriteAttributeString("Sdk", ThisAssembly.Name);
+
+                if (packages.Any())
+                {
+                    writer.WriteStartElement("ItemGroup");
+
+                    foreach (ITaskItem package in packages)
+                    {
+                        writer.WriteStartElement("PackageReference");
+                        writer.WriteAttributeString("Include", package.ItemSpec);
+                        writer.WriteAttributeString("Version", package.Version);
+                        writer.WriteEndElement();
+                    }
+
+                    writer.WriteEndElement();
+                }
+
                 writer.WriteEndElement();
             }
 
-            writer.WriteEndElement();
+            _fileSystem.File.Move(tempPath, project.Path, overwrite: true);
+        }
+        catch
+        {
+            _fileSystem.File.TryDelete(project.Path);
+            _fileSystem.File.TryDelete(tempPath);
+            throw;
         }
 
-        writer.WriteEndElement();
         UpdateHash(project, hash);
         return true;
     }

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -4,17 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Azure.Functions.Sdk 0.4.0
+### Azure.Functions.Sdk <version>
 
-- Initial SDK preview
-- A replacement for `Microsoft.Azure.Functions.Worker.Sdk`
-- Now an MSBuild SDK (and not a `PackageReference`)
-- Overhauls the extension project generation and restore flow
-  - Generated project renamed to `azure_functions.g.csproj`
-  - Will now make best-effort to generate and restore as part of `dotnet restore` phase
-- Removes dependencies on generated project
-  - `Microsoft.NET.Sdk.Functions` removed
-- No longer fully builds the extension project, only restores and directly collects extension files
-- Extension trimming behavior has been removed
-  - `Microsoft.Azure.Functions.Worker.Sdk` would previously only include extensions which had actual usage (determined by examining built code)
-  - New SDK no longer takes this step. All referenced extensions are included, regardless of actual code usage
+- fix: Perform atomic write in WriteExtensionProject (#3407)

--- a/test/Azure.Functions.Sdk.Tests/Tasks/Extensions/WriteExtensionProjectTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/Extensions/WriteExtensionProjectTests.cs
@@ -68,7 +68,7 @@ public sealed class WriteExtensionProjectTests
     }
 
     [Fact]
-    public void ProjectFileExists_DeletesAndRecreatesFile()
+    public void ProjectFileExists_OverwritesFile()
     {
         // Arrange
         _fileSystem.AddFile(ProjectPath, new MockFileData("existing content"));
@@ -85,6 +85,25 @@ public sealed class WriteExtensionProjectTests
 
         string content = _fileSystem.File.ReadAllText(ProjectPath);
         ValidateProject(content, [package]);
+    }
+
+    [Fact]
+    public void Execute_NoTempFilesRemain()
+    {
+        // Arrange
+        TaskItem package = CreatePackage("TestPackage", "1.0.0");
+        WriteExtensionProject task = CreateTask(packages: [package]);
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();
+        string directory = _fileSystem.Path.GetDirectoryName(ProjectPath)!;
+        _fileSystem.Directory.GetFiles(directory)
+            .Should().OnlyContain(f =>
+                f.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
+                || f.EndsWith(".csproj.hash", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Addresses #3391. Performs an atomic write of the generated `.csproj` in `WriteExtensionProject` to prevent incrementality corruption.

## Problem

If the build is killed after the hash file is written but before the `.csproj` stream is fully flushed/closed, future builds see a current hash and skip regeneration — leaving a truncated/invalid generated project.

## Changes

- Write the `.csproj` to a temp file (same directory, random name) via `Path.GetRandomFileName()`
- Close/flush the `XmlWriter` and stream completely
- `Delete` existing target + `Move` temp file onto the target path
- Update the hash file only **after** the move succeeds
- Clean up temp file on failure

**Note:** Uses `Delete` + `Move` (2-arg) rather than `Move(overwrite: true)` because the SDK targets `netstandard2.0`/`net472` which don't have the 3-arg overload.

## Testing

- All existing tests pass
- Added `Execute_NoTempFilesRemain` test to verify no temp artifacts are left behind
- Renamed `ProjectFileExists_DeletesAndRecreatesFile` → `ProjectFileExists_OverwritesFile` to reflect new behavior

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)