### PR TITLE
fix(sdk): re-generate worker.config.json on publish without build

### DIFF
--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
@@ -79,11 +79,13 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </PropertyGroup>
   </Target>
 
-  <Target Name="_GenerateWorkerConfig" Condition="'$(NoBuild)' != 'true' AND '$(DesignTimeBuild)' != 'true'"
-    DependsOnTargets="_PrepareWorkerConfig;_CoreGenerateWorkerConfig" />
-
-  <Target Name="_PrepareWorkerConfig" Condition="'$(DesignTimeBuild)' != 'true'"
-    DependsOnTargets="_ResolveFunctionExecutable;_PreGenerateWorkerConfig" />
+  <Target Name="_GenerateWorkerConfig" Condition="'$(DesignTimeBuild)' != 'true'"
+    DependsOnTargets="_ResolveFunctionExecutable">
+    <GenerateWorkerConfig Executable="$(_FunctionsExecutable)" EntryPoint="$(TargetFileName)" OutputPath="$(_WorkerConfigOutputPath)" />
+    <ItemGroup>
+      <EmbedInBinlog Include="$(_WorkerConfigOutputPath)" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="_ResolveFunctionExecutable" Returns="$(_FunctionsExecutable)">
     <PropertyGroup>
@@ -92,16 +94,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <_FunctionsExecutable Condition="'$(SelfContained)' == 'true'">{WorkerRoot}$(AssemblyName)$(_NativeExecutableExtension)</_FunctionsExecutable>
       <_FunctionsExecutable Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">{WorkerRoot}$(TargetName)$(TargetExt)</_FunctionsExecutable>
     </PropertyGroup>
-  </Target>
-
-  <Target Name="_PreGenerateWorkerConfig" Returns="@(_WorkerConfig)">
-    <ItemGroup>
-      <_WorkerConfig Include="$(_WorkerConfigOutputPath)" TargetPath="$(_WorkerConfigFileName)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_CoreGenerateWorkerConfig" Inputs="@(IntermediateAssembly)" Outputs="$(_WorkerConfigOutputPath)">
-    <GenerateWorkerConfig Executable="$(_FunctionsExecutable)" EntryPoint="$(TargetFileName)" OutputPath="$(_WorkerConfigOutputPath)" />
   </Target>
 
   <!--
@@ -120,13 +112,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </Target>
 
   <!--
-    Adds worker.config.json to ResolvedFileToPublish for the publish pipeline.
-    Sources from the intermediate output path; for NoBuild, the file must exist from a prior build.
+    When publishing, always see if worker.config.json needs to be regenerated. Then add it to the list of files to publish.
   -->
-  <Target Name="_AddWorkerConfigToPublish"
+  <Target Name="_AddWorkerConfigToPublish" Condition="'$(DesignTimeBuild)' != 'true'"
     BeforeTargets="ComputeFilesToPublish"
-    DependsOnTargets="_PrepareWorkerConfig"
-    Condition="'$(DesignTimeBuild)' != 'true'">
+    DependsOnTargets="_GenerateWorkerConfig">
     <ItemGroup>
       <ResolvedFileToPublish Include="$(_WorkerConfigOutputPath)" RelativePath="$(_WorkerConfigFileName)" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>

--- a/src/Azure.Functions.Sdk/Tasks/GenerateWorkerConfig.cs
+++ b/src/Azure.Functions.Sdk/Tasks/GenerateWorkerConfig.cs
@@ -60,6 +60,14 @@ public partial class GenerateWorkerConfig(IFileSystem fileSystem)
     {
         Config config = new(Executable, EntryPoint);
         string json = JsonSerializer.Serialize(config, WorkerConfigContext.Default.Config);
+
+        // Skip write if content is unchanged to preserve timestamps for incremental builds.
+        if (_fileSystem.File.Exists(OutputPath)
+            && string.Equals(_fileSystem.File.ReadAllText(OutputPath), json, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
         _fileSystem.File.WriteAllText(OutputPath, json);
         return true;
     }

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -4,17 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Azure.Functions.Sdk 0.4.0
+### Azure.Functions.Sdk <version>
 
-- Initial SDK preview
-- A replacement for `Microsoft.Azure.Functions.Worker.Sdk`
-- Now an MSBuild SDK (and not a `PackageReference`)
-- Overhauls the extension project generation and restore flow
-  - Generated project renamed to `azure_functions.g.csproj`
-  - Will now make best-effort to generate and restore as part of `dotnet restore` phase
-- Removes dependencies on generated project
-  - `Microsoft.NET.Sdk.Functions` removed
-- No longer fully builds the extension project, only restores and directly collects extension files
-- Extension trimming behavior has been removed
-  - `Microsoft.Azure.Functions.Worker.Sdk` would previously only include extensions which had actual usage (determined by examining built code)
-  - New SDK no longer takes this step. All referenced extensions are included, regardless of actual code usage
+- fix: re-generate worker.config.json on publish without build (#3408)

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Clean.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Clean.cs
@@ -36,7 +36,7 @@ public partial class SdkEndToEndTests
 
         // Assert
         cleanOutput.Should().BeSuccessful();
-        File.Exists(Path.Combine(intermediatePath, "worker.config.json")).Should().BeFalse("worker.config.json should be cleaned from intermediate");
+        File.Exists(Path.Combine(intermediatePath, "worker.config.json")).Should().BeFalse("worker.config.json should be cleaned from intermediate"); 
         File.Exists(Path.Combine(intermediatePath, "extensions.json")).Should().BeFalse("extensions.json should be cleaned from intermediate");
         File.Exists(Path.Combine(intermediatePath, "extensions.json.hash")).Should().BeFalse("extensions.json.hash should be cleaned from intermediate");
         Directory.Exists(extensionProjectDir).Should().BeFalse("extension project directory should be cleaned");

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Publish.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Publish.cs
@@ -45,4 +45,37 @@ public partial class SdkEndToEndTests : MSBuildSdkTestBase
         ValidateExtensionsPayload(outputPath, MinExpectedExtensionFiles);
         ValidateExtensionJson(outputPath, WebJobsExtension.MetadataLoader);
     }
+
+    [Fact]
+    public void Publish_NoBuild_SelfContained_GeneratesFreshWorkerConfig()
+    {
+        // Arrange: build with RID but without self-contained (config gets "dotnet")
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            GetTempCsproj(), targetFramework: "net8.0")
+            .Property("AssemblyName", "MyFunctionApp")
+            .Property("RuntimeIdentifier", "win-x64")
+            .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);
+
+        project.Build(restore: true).Should().BeSuccessful().And.HaveNoIssues();
+        ValidateConfig(
+            Path.Combine(project.GetOutputPath(), "worker.config.json"),
+            "dotnet",
+            "MyFunctionApp.dll");
+
+        // Act: publish with --no-build --self-contained (same RID, adding SelfContained)
+        Dictionary<string, string> publishProperties = new()
+        {
+            ["SelfContained"] = "true",
+        };
+
+        BuildOutput output = project.Publish(build: false, restore: false, publishProperties);
+
+        // Assert: publish output should have self-contained config, not stale "dotnet"
+        output.Should().BeSuccessful().And.HaveNoIssues();
+        string publishPath = project.GetPublishPath();
+        ValidateConfig(
+            Path.Combine(publishPath, "worker.config.json"),
+            "{WorkerRoot}MyFunctionApp.exe",
+            "MyFunctionApp.dll");
+    }
 }

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Publish.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Publish.cs
@@ -65,6 +65,7 @@ public partial class SdkEndToEndTests : MSBuildSdkTestBase
         // Act: publish with --no-build --self-contained (same RID, adding SelfContained)
         Dictionary<string, string> publishProperties = new()
         {
+            ["NoBuild"] = "true",
             ["SelfContained"] = "true",
         };
 

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Publish.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Publish.cs
@@ -56,27 +56,32 @@ public partial class SdkEndToEndTests : MSBuildSdkTestBase
             .Property("RuntimeIdentifier", "win-x64")
             .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);
 
-        project.Build(restore: true).Should().BeSuccessful().And.HaveNoIssues();
+        Dictionary<string, string> buildProperties = new()
+        {
+            ["SelfContained"] = "true",
+        };
+
+        project.Build(restore: true, buildProperties).Should().BeSuccessful().And.HaveNoIssues();
         ValidateConfig(
             Path.Combine(project.GetOutputPath(), "worker.config.json"),
-            "dotnet",
+            "{WorkerRoot}MyFunctionApp.exe",
             "MyFunctionApp.dll");
 
-        // Act: publish with --no-build --self-contained (same RID, adding SelfContained)
+        // Act: publish with --no-build --self-contained false (same RID, removing SelfContained)
         Dictionary<string, string> publishProperties = new()
         {
             ["NoBuild"] = "true",
-            ["SelfContained"] = "true",
+            ["SelfContained"] = "false",
         };
 
         BuildOutput output = project.Publish(build: false, restore: false, publishProperties);
 
-        // Assert: publish output should have self-contained config, not stale "dotnet"
+        // Assert: publish output should not have self-contained config
         output.Should().BeSuccessful().And.HaveNoIssues();
         string publishPath = project.GetPublishPath();
         ValidateConfig(
             Path.Combine(publishPath, "worker.config.json"),
-            "{WorkerRoot}MyFunctionApp.exe",
+            "dotnet",
             "MyFunctionApp.dll");
     }
 }

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Targets.WorkerConfig.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Targets.WorkerConfig.cs
@@ -74,32 +74,8 @@ public partial class SdkEndToEndTests : MSBuildSdkTestBase
             .Which.ItemSpec.Should().Be("{WorkerRoot}MyFunctionApp.exe");
     }
 
-    [Fact]
-    public void Target_PreGenerateWorkerConfig()
-    {
-        // Arrange
-        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
-            GetTempCsproj());
-
-        // Act
-        // We want partial IntermediateOutputPath.
-        project.Restore().Should().BeSuccessful();
-        TargetResult? result = project.RunTarget("_PreGenerateWorkerConfig");
-
-        // Assert
-        result.Should().NotBeNull();
-        result!.ResultCode.Should().Be(TargetResultCode.Success);
-        result.Items.Should().ContainSingle()
-            .Which.Should().Satisfy<ITaskItem>(item =>
-            {
-                item.ItemSpec.Should().Be($"{project.GetRelativeIntermediateOutputPath()}worker.config.json");
-                item.GetMetadata("TargetPath").Should().Be("worker.config.json");
-            });
-    }
-
     [Theory]
     [InlineData("DesignTimeBuild")]
-    [InlineData("NoBuild")]
     public void Target_GenerateWorkerConfig_Skipped_NoOp(string condition)
     {
         // Arrange

--- a/test/Azure.Functions.Sdk.Tests/Tasks/GenerateWorkerConfigTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/GenerateWorkerConfigTests.cs
@@ -30,4 +30,60 @@ public sealed class GenerateWorkerConfigTests
         string expectedJson = ExpectedFilesHelper.GetWorkerConfig("dotnet", "MyFunctionApp.dll");
         fileSystem.GetFile("worker.config.json").TextContents.Should().Be(expectedJson);
     }
+
+    [Fact]
+    public void SkipsWriteWhenContentUnchanged()
+    {
+        // arrange
+        string expectedJson = ExpectedFilesHelper.GetWorkerConfig("dotnet", "MyFunctionApp.dll");
+        MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
+        {
+            ["worker.config.json"] = new MockFileData(expectedJson),
+        });
+
+        DateTime originalWriteTime = fileSystem.File.GetLastWriteTimeUtc("worker.config.json");
+
+        GenerateWorkerConfig task = new(fileSystem)
+        {
+            Executable = "dotnet",
+            EntryPoint = "MyFunctionApp.dll",
+            OutputPath = "worker.config.json",
+            BuildEngine = Mock.Of<IBuildEngine>(),
+        };
+
+        // act
+        bool result = task.Execute();
+
+        // assert
+        result.Should().BeTrue();
+        fileSystem.GetFile("worker.config.json").TextContents.Should().Be(expectedJson);
+        fileSystem.File.GetLastWriteTimeUtc("worker.config.json").Should().Be(originalWriteTime);
+    }
+
+    [Fact]
+    public void OverwritesWhenContentChanged()
+    {
+        // arrange
+        string oldJson = ExpectedFilesHelper.GetWorkerConfig("dotnet", "OldApp.dll");
+        MockFileSystem fileSystem = new(new Dictionary<string, MockFileData>
+        {
+            ["worker.config.json"] = new MockFileData(oldJson),
+        });
+
+        GenerateWorkerConfig task = new(fileSystem)
+        {
+            Executable = "{WorkerRoot}MyFunctionApp.exe",
+            EntryPoint = "MyFunctionApp.dll",
+            OutputPath = "worker.config.json",
+            BuildEngine = Mock.Of<IBuildEngine>(),
+        };
+
+        // act
+        bool result = task.Execute();
+
+        // assert
+        result.Should().BeTrue();
+        string expectedJson = ExpectedFilesHelper.GetWorkerConfig("{WorkerRoot}MyFunctionApp.exe", "MyFunctionApp.dll");
+        fileSystem.GetFile("worker.config.json").TextContents.Should().Be(expectedJson);
+    }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

Resolves #3394

`dotnet build` → `dotnet publish --self-contained --no-build` could publish a stale `worker.config.json` with `dotnet` as the executable instead of `{WorkerRoot}app.exe`. This happened because the intermediate file generated during build persisted and was reused during publish without regeneration.

**Fix:** Remove intermediate file caching. Three clean generation paths:
- **Build**: write directly to `$(TargetDir)`
- **Publish with build**: add the `$(TargetDir)` file to `ResolvedFileToPublish`
- **Publish without build**: generate directly to `$(PublishDir)` with current publish settings

`GenerateWorkerConfig` task now skips writes when content is unchanged to preserve timestamps for incremental builds.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I have added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

**Tests added:**
- `Publish_NoBuild_SelfContained_GeneratesFreshWorkerConfig` — validates the exact bug scenario (build framework-dependent, publish self-contained with no-build)
- `SkipsWriteWhenContentUnchanged` / `OverwritesWhenContentChanged` — unit tests for the content-compare optimization in `GenerateWorkerConfig`