### PR TITLE
feat(sdk): improve implicit package reference behavior

### DIFF
--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.Analyzers.props
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.Analyzers.props
@@ -20,14 +20,14 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk.Analyzers" Version="1.2.2" IsImplicitlyDefined="true">
+    <_FuncSdkPackageReference Include="Microsoft.Azure.Functions.Worker.Sdk.Analyzers" Version="1.2.2" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk.Generators" Version="1.3.6" IsImplicitlyDefined="true">
+    </_FuncSdkPackageReference>
+    <_FuncSdkPackageReference Include="Microsoft.Azure.Functions.Worker.Sdk.Generators" Version="1.3.6" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    </_FuncSdkPackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.props
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.props
@@ -27,7 +27,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" IsImplicitlyDefined="true" />
+    <_FuncSdkPackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.props
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.props
@@ -27,7 +27,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </ItemGroup>
 
   <ItemGroup>
-    <_FuncSdkPackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <_FuncSdkPackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
@@ -24,6 +24,12 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
   </PropertyGroup>
 
+  <ItemGroup>
+    <_FuncSdkPackageReferenceToAdd Include="@(_FuncSdkPackageReference)" />
+    <_FuncSdkPackageReferenceToAdd Remove="@(PackageReference)" />
+    <PackageReference Include="@(_FuncSdkPackageReferenceToAdd)" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)Azure.Functions.Sdk.Analyzers.targets" />
   <Import Project="$(MSBuildThisFileDirectory)extensions/Azure.Functions.Sdk.Extensions.targets" />
   <Import Project="$(MSBuildThisFileDirectory)publish/Azure.Functions.Sdk.Publish.targets" />

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
@@ -27,6 +27,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <ItemGroup>
     <_FuncSdkPackageReferenceToAdd Include="@(_FuncSdkPackageReference)" />
     <_FuncSdkPackageReferenceToAdd Remove="@(PackageReference)" />
+    <_FuncSdkPackageReferenceToAdd Update="@(PackageVersion)" Version="%(PackageVersion.Version)"
+      Condition="'$(ManagePackageVersionsCentrally)' == 'true'" />
     <PackageReference Include="@(_FuncSdkPackageReferenceToAdd)" IsImplicitlyDefined="true" />
   </ItemGroup>
 

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -4,17 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Azure.Functions.Sdk 0.4.0
+### Azure.Functions.Sdk <version>
 
-- Initial SDK preview
-- A replacement for `Microsoft.Azure.Functions.Worker.Sdk`
-- Now an MSBuild SDK (and not a `PackageReference`)
-- Overhauls the extension project generation and restore flow
-  - Generated project renamed to `azure_functions.g.csproj`
-  - Will now make best-effort to generate and restore as part of `dotnet restore` phase
-- Removes dependencies on generated project
-  - `Microsoft.NET.Sdk.Functions` removed
-- No longer fully builds the extension project, only restores and directly collects extension files
-- Extension trimming behavior has been removed
-  - `Microsoft.Azure.Functions.Worker.Sdk` would previously only include extensions which had actual usage (determined by examining built code)
-  - New SDK no longer takes this step. All referenced extensions are included, regardless of actual code usage
+- feat: improve implicit package reference behavior (#3409)
+  - now respects central package management
+  - no longer emits a warning when manually overriding
+  - update `Microsoft.Azure.Functions.Worker` to `2.52.0`

--- a/test/Azure.Functions.Sdk.Tests/Assertions/ProjectItemAssertions.cs
+++ b/test/Azure.Functions.Sdk.Tests/Assertions/ProjectItemAssertions.cs
@@ -77,14 +77,13 @@ internal class ProjectItemAssertions(ProjectItem subject, AssertionChain asserti
     public AndConstraint<ProjectItemAssertions> NotHaveMetadata(
         string name, string because = "", params object[] becauseArgs)
     {
-        string? actual = Subject.GetMetadataValue(name);
         _chain
-            .ForCondition(actual is null)
+            .ForCondition(!Subject.HasMetadata(name))
             .BecauseOf(because, becauseArgs)
             .FailWith(
                 "Expected {context:ProjectItem} to not have metadata {0}{reason}, but found value {1}.",
                 name,
-                actual ?? "<null>");
+                Subject.GetMetadataValue(name) ?? "<null>");
 
         return new AndConstraint<ProjectItemAssertions>(this);
     }

--- a/test/Azure.Functions.Sdk.Tests/Assertions/ProjectItemAssertions.cs
+++ b/test/Azure.Functions.Sdk.Tests/Assertions/ProjectItemAssertions.cs
@@ -73,6 +73,22 @@ internal class ProjectItemAssertions(ProjectItem subject, AssertionChain asserti
         return new AndConstraint<ProjectItemAssertions>(this);
     }
 
+    [CustomAssertion]
+    public AndConstraint<ProjectItemAssertions> NotHaveMetadata(
+        string name, string because = "", params object[] becauseArgs)
+    {
+        string? actual = Subject.GetMetadataValue(name);
+        _chain
+            .ForCondition(actual is null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith(
+                "Expected {context:ProjectItem} to not have metadata {0}{reason}, but found value {1}.",
+                name,
+                actual ?? "<null>");
+
+        return new AndConstraint<ProjectItemAssertions>(this);
+    }
+
     private class Formatter : IValueFormatter
     {
         public bool CanHandle(object value) => value is ProjectItem;

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Utilities.ProjectCreation;
 
 namespace Azure.Functions.Sdk.Tests.Integration;
@@ -60,8 +61,10 @@ public partial class SdkEndToEndTests
     public void Build_Success(string tfm)
     {
         // Arrange
+        using ProjectCollection col = TestHelpers.CreateBinaryLoggerCollection();
+
         ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
-            GetTempCsproj(), targetFramework: tfm)
+            GetTempCsproj(), targetFramework: tfm, projectCollection: col)
             .Property("AssemblyName", "MyFunctionApp")
             .Property("LangVersion", "latest")
             .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Items.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Items.cs
@@ -79,6 +79,50 @@ public partial class SdkEndToEndTests
     }
 
     [Fact]
+    public void Item_ExplicitPackageReference_OverridesImplicit()
+    {
+        // Arrange
+        string explicitVersion = "99.0.0";
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            GetTempCsproj())
+            .ItemPackageReference("Microsoft.Azure.Functions.Worker", explicitVersion);
+
+        // Act
+        project.TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem>? items);
+
+        // Assert - only one entry for Worker (no duplicate = no warning), using explicit version
+        items.Where(x => x.EvaluatedInclude == "Microsoft.Azure.Functions.Worker")
+            .Should().ContainSingle()
+            .Which.Should()
+            .HaveMetadata("Version", explicitVersion)
+            .And.NotHaveMetadata("IsImplicitlyDefined");
+    }
+
+    [Fact]
+    public void Item_CpmPackageVersion_OverridesImplicitVersion()
+    {
+        // Arrange
+        string cpmVersion = "99.0.0";
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            GetTempCsproj(),
+            globalProperties: new Dictionary<string, string>
+            {
+                { "ManagePackageVersionsCentrally", "true" },
+            })
+            .ItemInclude("PackageVersion", "Microsoft.Azure.Functions.Worker",
+                metadata: new Dictionary<string, string?> { { "Version", cpmVersion } });
+
+        // Act
+        project.TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem>? items);
+
+        // Assert
+        items.Should().ContainSingle(x => x.EvaluatedInclude == "Microsoft.Azure.Functions.Worker")
+            .Which.Should()
+            .HaveMetadata("IsImplicitlyDefined", "true")
+            .And.HaveMetadata("Version", cpmVersion);
+    }
+
+    [Fact]
     public void Item_CompilerVisibleProperty_AreIncluded()
     {
         // Arrange

--- a/test/Azure.Functions.Sdk.Tests/ModuleInitializer.cs
+++ b/test/Azure.Functions.Sdk.Tests/ModuleInitializer.cs
@@ -20,6 +20,11 @@ internal static class ModuleInitializer
     internal static void Initialize()
     {
         Environment.SetEnvironmentVariable("MSBUILDADDITIONALSDKRESOLVERSFOLDER", ResolverPath);
+
+        // Signature verification does not work in tests. NuGet wants to load a trusted root store off disk
+        // that is shipped with the dotnet SDK. However, it loads via relative path assumptions that won't
+        // work here.
+        Environment.SetEnvironmentVariable("DOTNET_NUGET_SIGNATURE_VERIFICATION", "false");
         MSBuildAssemblyResolver.Register();
         FormatterResolver.Initialize();
     }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #3392 

This pull request refactors how implicit package references are handled in the Azure Functions SDK MSBuild targets to improve compatibility with central package management and to avoid duplicate package references. It introduces a new mechanism for collecting and injecting implicit package references, updates the version of the `Microsoft.Azure.Functions.Worker` package, and adds new tests to ensure correct behavior when explicit or centrally managed package versions are specified.

**MSBuild Target Refactoring and Package Reference Handling:**

* Refactored implicit package references to use a new `_FuncSdkPackageReference` item group instead of direct `PackageReference` items in `Azure.Functions.Sdk.props` and `Azure.Functions.Sdk.Analyzers.props`. This change helps prevent duplicate references and enables more flexible manipulation of package references. [[1]](diffhunk://#diff-1710a10151f44174593382efcde14f8ac18e3432e66f4889aa8508dca68d8c51L30-R30) [[2]](diffhunk://#diff-d07a3bc5435f6a18b8d1f08c8fa67361da500c77aa2dbb1b4558e3ba97eeeb56L23-R30)
* Added a new MSBuild item group in `Azure.Functions.Sdk.targets` that collects all `_FuncSdkPackageReference` items, removes any duplicates from existing `PackageReference` items, updates versions if central package management is enabled, and finally injects them as `PackageReference` items.

**Package Version Updates:**

* Updated the version of `Microsoft.Azure.Functions.Worker` from `2.51.0` to `2.52.0` in the implicit package reference.

**Testing Enhancements:**

* Added new assertion method `NotHaveMetadata` in `ProjectItemAssertions` to verify that a project item does not have a specific metadata entry.
* Introduced new integration tests to verify that:
  - An explicit `PackageReference` for `Microsoft.Azure.Functions.Worker` overrides the implicit one and does not set the `IsImplicitlyDefined` metadata.
  - A centrally managed package version (`PackageVersion` item) for `Microsoft.Azure.Functions.Worker` properly overrides the implicit version and retains the `IsImplicitlyDefined` metadata.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)