### PR TITLE
test: disable nuget sign verify in e2e tests

### DIFF
--- a/test/Azure.Functions.Sdk.Tests/ModuleInitializer.cs
+++ b/test/Azure.Functions.Sdk.Tests/ModuleInitializer.cs
@@ -16,9 +16,15 @@ internal static class ModuleInitializer
     /// We cannot include MSBuild assemblies in our output, because they will interfere with
     /// MSBuilds assembly scanning. Instead we use the MSBuildLocator to resolve them at runtime.
     /// </summary>
+#pragma warning disable CA2255 // The 'ModuleInitializer' attribute should not be used in libraries -- this isn't a library.
     [ModuleInitializer]
+#pragma warning restore CA2255 // The 'ModuleInitializer' attribute should not be used in libraries -- this isn't a library.
     internal static void Initialize()
     {
+        // Signature verification does not work in tests. NuGet wants to load a trusted root store off disk
+        // that is shipped with the dotnet SDK. However, it loads via relative path assumptions that won't
+        // work here.
+        Environment.SetEnvironmentVariable("DOTNET_NUGET_SIGNATURE_VERIFICATION", "false");
         Environment.SetEnvironmentVariable("MSBUILDADDITIONALSDKRESOLVERSFOLDER", ResolverPath);
         MSBuildAssemblyResolver.Register();
         FormatterResolver.Initialize();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Fix failing unit tests. _Something_ recently enable nuget signature verification for our E2E tests on Linux. This breaks all of those tests as the verification fails to load a trusted roots bundle. Typically, nuget would load a bundle shipped with the dotnet SDK. However, it does so via relative path assumption that breaks when ran via our tests.

This PR re-disables the sign verification **for the tests only**. Regular dotnet restore still verifies.
