### PR TITLE
Improve handling of cancelled HTTP requests

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/ContextReference.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/ContextReference.cs
@@ -1,8 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
@@ -34,9 +34,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
                     throw new OperationCanceledException($"HTTP context for invocation id '{invocationId}' was cancelled.");
                 }
                 
-                return contextRef.FunctionContextValueSource.Task.IsCompletedSuccessfully
-                    ? await contextRef.FunctionContextValueSource.Task
-                    : throw new InvalidOperationException($"Failed to set HTTP context for invocation id '{invocationId}'.");
+                if (contextRef.FunctionContextValueSource.Task.IsCompleted)
+                {
+                    return await contextRef.FunctionContextValueSource.Task;
+                }
+                
+                throw new InvalidOperationException($"Failed to set HTTP context for invocation id '{invocationId}'.");
             }
 
             _logger.HttpContextSet(invocationId, context.TraceIdentifier);
@@ -66,9 +69,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
                     throw new OperationCanceledException($"Function context for invocation id '{invocationId}' was cancelled.");
                 }
 
-                return contextRef.HttpContextValueSource.Task.IsCompletedSuccessfully
-                    ? await contextRef.HttpContextValueSource.Task
-                    : throw new InvalidOperationException($"Failed to set function context for invocation id '{invocationId}'.");
+                if(contextRef.HttpContextValueSource.Task.IsCompleted)
+                {
+                    return await contextRef.HttpContextValueSource.Task;
+                }
+
+                throw new InvalidOperationException($"Failed to set function context for invocation id '{invocationId}'.");
             }
 
             _logger.FunctionContextSet(invocationId);

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
@@ -27,13 +27,27 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
         public async Task<FunctionContext> SetHttpContextAsync(string invocationId, HttpContext context)
         {
             var contextRef = _contextReferenceList.GetOrAdd(invocationId, static id => new ContextReference(id));
-            contextRef.HttpContextValueSource.SetResult(context);
+            if(!contextRef.HttpContextValueSource.TrySetResult(context))
+            {
+                if (contextRef.HttpContextValueSource.Task.IsCanceled)
+                {
+                    throw new OperationCanceledException($"HTTP context for invocation id '{invocationId}' was cancelled.");
+                }
+                
+                return contextRef.FunctionContextValueSource.Task.IsCompletedSuccessfully
+                    ? await contextRef.FunctionContextValueSource.Task
+                    : throw new InvalidOperationException($"Failed to set HTTP context for invocation id '{invocationId}'.");
+            }
 
             _logger.HttpContextSet(invocationId, context.TraceIdentifier);
 
             try
             {
-                return await contextRef.FunctionContextValueSource.Task.WaitAsync(TimeSpan.FromSeconds(FunctionContextTimeoutInSeconds));
+                return await contextRef.FunctionContextValueSource.Task.WaitAsync(TimeSpan.FromSeconds(FunctionContextTimeoutInSeconds), context.RequestAborted);
+            }
+            catch (OperationCanceledException e)
+            {
+                throw new OperationCanceledException($"HTTP request was cancelled while waiting for the function context to be set. Invocation: '{invocationId}'.", e);
             }
             catch (TimeoutException e)
             {
@@ -44,7 +58,18 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
         public async Task<HttpContext> SetFunctionContextAsync(string invocationId, FunctionContext context)
         {
             var contextRef = _contextReferenceList.GetOrAdd(invocationId, static id => new ContextReference(id));
-            contextRef.FunctionContextValueSource.SetResult(context);
+
+            if(!contextRef.FunctionContextValueSource.TrySetResult(context))
+            {
+                if (contextRef.FunctionContextValueSource.Task.IsCanceled)
+                {
+                    throw new OperationCanceledException($"Function context for invocation id '{invocationId}' was cancelled.");
+                }
+
+                return contextRef.HttpContextValueSource.Task.IsCompletedSuccessfully
+                    ? await contextRef.HttpContextValueSource.Task
+                    : throw new InvalidOperationException($"Failed to set function context for invocation id '{invocationId}'.");
+            }
 
             _logger.FunctionContextSet(invocationId);
 
@@ -52,10 +77,18 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             try
             {
                 // block here until it's time to start the function
-                _ = await contextRef.FunctionStartTask.Task.WaitAsync(TimeSpan.FromSeconds(FunctionStartTimeoutInSeconds));
+                _ = await contextRef.FunctionStartTask.Task.WaitAsync(TimeSpan.FromSeconds(FunctionStartTimeoutInSeconds), context.CancellationToken);
 
                 waitStep = 1;
-                return await contextRef.HttpContextValueSource.Task.WaitAsync(TimeSpan.FromSeconds(HttpContextTimeoutInSeconds));
+                return await contextRef.HttpContextValueSource.Task.WaitAsync(TimeSpan.FromSeconds(HttpContextTimeoutInSeconds), context.CancellationToken);
+            }
+            catch (OperationCanceledException e)
+            {
+                string message = waitStep == 0
+                    ? $"Function invocation cancelled while waiting for start call. Invocation: '{invocationId}'."
+                    : $"Function invocation cancelled while waiting for HTTP context. Invocation: '{invocationId}'.";
+
+                throw new OperationCanceledException(message, e);
             }
             catch (TimeoutException e)
             {

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             }
             catch (TimeoutException e)
             {
-                throw new TimeoutException($"Timed out waiting for the HTTP context to be set. Invocation: '{invocationId}'.", e);
+                throw new TimeoutException($"Timed out waiting for the function context to be set. Invocation: '{invocationId}'.", e);
             }
         }
 

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
         public async Task<FunctionContext> SetHttpContextAsync(string invocationId, HttpContext context)
         {
             var contextRef = _contextReferenceList.GetOrAdd(invocationId, static id => new ContextReference(id));
-            if(!contextRef.HttpContextValueSource.TrySetResult(context))
+            if (!contextRef.HttpContextValueSource.TrySetResult(context))
             {
                 if (contextRef.HttpContextValueSource.Task.IsCanceled)
                 {
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
         {
             var contextRef = _contextReferenceList.GetOrAdd(invocationId, static id => new ContextReference(id));
 
-            if(!contextRef.FunctionContextValueSource.TrySetResult(context))
+            if (!contextRef.FunctionContextValueSource.TrySetResult(context))
             {
                 if (contextRef.FunctionContextValueSource.Task.IsCanceled)
                 {

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
@@ -29,16 +29,21 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             var contextRef = _contextReferenceList.GetOrAdd(invocationId, static id => new ContextReference(id));
             if (!contextRef.HttpContextValueSource.TrySetResult(context))
             {
-                if (contextRef.HttpContextValueSource.Task.IsCanceled)
+                var httpContextTask = contextRef.HttpContextValueSource.Task;
+                if (httpContextTask.IsCanceled)
                 {
-                    throw new OperationCanceledException($"HTTP context for invocation id '{invocationId}' was cancelled.");
+                    // We throw our own exception rather than awaiting the cancelled task because a TaskCanceledException
+                    // from the TCS would not include the invocation ID needed for diagnostics.
+                    throw new OperationCanceledException($"HTTP context for invocation id '{invocationId}' was cancelled.", httpContextTask.Exception);
+                }
+
+                if (httpContextTask.IsFaulted)
+                {
+                    // Task has an exception — await to let it propagate naturally.
+                    await httpContextTask;
                 }
                 
-                if (contextRef.FunctionContextValueSource.Task.IsCompleted)
-                {
-                    return await contextRef.FunctionContextValueSource.Task;
-                }
-                
+                // Task already ran to completion (a concurrent double-set) — there is no exception to rethrow.
                 throw new InvalidOperationException($"Failed to set HTTP context for invocation id '{invocationId}'.");
             }
 
@@ -50,10 +55,14 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             }
             catch (OperationCanceledException e)
             {
+                // WaitAsync throws a generic OperationCanceledException without invocation context.
+                // We wrap it to include the invocation ID for diagnostics.
                 throw new OperationCanceledException($"HTTP request was cancelled while waiting for the function context to be set. Invocation: '{invocationId}'.", e);
             }
             catch (TimeoutException e)
             {
+                // WaitAsync throws a generic TimeoutException without invocation context.
+                // We wrap it to include the invocation ID for diagnostics.
                 throw new TimeoutException($"Timed out waiting for the function context to be set. Invocation: '{invocationId}'.", e);
             }
         }
@@ -64,16 +73,21 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 
             if (!contextRef.FunctionContextValueSource.TrySetResult(context))
             {
-                if (contextRef.FunctionContextValueSource.Task.IsCanceled)
+                var funcContextTask = contextRef.FunctionContextValueSource.Task;
+                if (funcContextTask.IsCanceled)
                 {
-                    throw new OperationCanceledException($"Function context for invocation id '{invocationId}' was cancelled.");
+                    // We throw our own exception rather than awaiting the cancelled task because a TaskCanceledException
+                    // from the TCS would not include the invocation ID needed for diagnostics.
+                    throw new OperationCanceledException($"Function context for invocation id '{invocationId}' was cancelled.", funcContextTask.Exception);
                 }
 
-                if(contextRef.HttpContextValueSource.Task.IsCompleted)
+                if (funcContextTask.IsFaulted)
                 {
-                    return await contextRef.HttpContextValueSource.Task;
+                    // Task has an exception — await to let it propagate naturally.
+                    await funcContextTask;
                 }
 
+                // Task already ran to completion (a concurrent double-set) — there is no exception to rethrow.
                 throw new InvalidOperationException($"Failed to set function context for invocation id '{invocationId}'.");
             }
 
@@ -90,6 +104,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             }
             catch (OperationCanceledException e)
             {
+                // WaitAsync throws a generic OperationCanceledException without invocation context.
+                // We wrap it to include the invocation ID and which wait step failed for diagnostics.
                 string message = waitStep == 0
                     ? $"Function invocation cancelled while waiting for start call. Invocation: '{invocationId}'."
                     : $"Function invocation cancelled while waiting for HTTP context. Invocation: '{invocationId}'.";
@@ -98,6 +114,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             }
             catch (TimeoutException e)
             {
+                // WaitAsync throws a generic TimeoutException without invocation context.
+                // We wrap it to include the invocation ID and which wait step failed for diagnostics.
                 string message = waitStep == 0
                     ? $"Timed out waiting for the function start call. Invocation: '{invocationId}'."
                     : $"Timed out waiting for the HTTP context to be set. Invocation: '{invocationId}'.";

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -41,16 +41,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 
             var invocationId = context.InvocationId;
 
-            // this call will block until the ASP.NET middleware pipeline has signaled that it's ready to run the function
-            var httpContext = await _coordinator.SetFunctionContextAsync(invocationId, context);
-
-            AddHttpContextToFunctionContext(context, httpContext);
-
-            // Register additional context features
-            context.Features.Set<IFromBodyConversionFeature>(FromBodyConversionFeature.Instance);
-
             try
             {
+                // this call will block until the ASP.NET middleware pipeline has signaled that it's ready to run the function
+                var httpContext = await _coordinator.SetFunctionContextAsync(invocationId, context);
+
+                AddHttpContextToFunctionContext(context, httpContext);
+
+                // Register additional context features
+                context.Features.Set<IFromBodyConversionFeature>(FromBodyConversionFeature.Instance);
+
                 await next(context);
 
                 var responseHandled = await TryHandleHttpResult(context.GetInvocationResult().Value, context, httpContext, true)

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore;
@@ -235,7 +236,7 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task SetHttpContextAsync_WhenCalledConcurrently_AndFunctionContextAlreadySet_ReturnsIt()
+        public async Task SetHttpContextAsync_WhenCalledConcurrently_AndFunctionContextAlreadySet_ThrowsInvalidOperationException()
         {
             // Arrange
             string invocationId = Guid.NewGuid().ToString();
@@ -251,14 +252,14 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
             await setHttpTask1;
             await setFunctionTask;
 
-            // Now call SetHttpContextAsync again - TrySetResult fails, but FunctionContextValueSource
-            // is already completed so it returns the function context directly.
-            var result = await _coordinator.SetHttpContextAsync(invocationId, httpContext2);
+            // Now call SetHttpContextAsync again - TrySetResult fails (double-set), should throw
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _coordinator.SetHttpContextAsync(invocationId, httpContext2));
 
             _coordinator.CompleteFunctionInvocation(invocationId);
 
             // Assert
-            Assert.Same(functionContext, result);
+            Assert.Contains($"Failed to set HTTP context for invocation id '{invocationId}'", exception.Message);
         }
 
         [Fact]
@@ -288,7 +289,7 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task SetFunctionContextAsync_WhenCalledConcurrently_AndHttpContextAlreadySet_ReturnsIt()
+        public async Task SetFunctionContextAsync_WhenCalledConcurrently_AndHttpContextAlreadySet_ThrowsInvalidOperationException()
         {
             // Arrange
             string invocationId = Guid.NewGuid().ToString();
@@ -304,14 +305,14 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
             await setHttpTask;
             await setFunctionTask;
 
-            // Now call SetFunctionContextAsync again - TrySetResult fails, but HttpContextValueSource
-            // is already completed so it returns the HTTP context directly.
-            var result = await _coordinator.SetFunctionContextAsync(invocationId, functionContext2);
+            // Now call SetFunctionContextAsync again - TrySetResult fails (double-set), should throw
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _coordinator.SetFunctionContextAsync(invocationId, functionContext2));
 
             _coordinator.CompleteFunctionInvocation(invocationId);
 
             // Assert
-            Assert.Same(httpContext, result);
+            Assert.Contains($"Failed to set function context for invocation id '{invocationId}'", exception.Message);
         }
 
         [Fact]
@@ -370,6 +371,54 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
             mockContext.Setup(c => c.CancellationToken).Returns(cancellationToken);
             mockContext.Setup(c => c.InvocationId).Returns(Guid.NewGuid().ToString());
             return mockContext.Object;
+        }
+
+        [Fact]
+        public async Task SetHttpContextAsync_WhenHttpContextTaskFaulted_PropagatesOriginalException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var expectedException = new InvalidOperationException("Something went wrong");
+
+            // Pre-create the context reference and fault the TCS
+            var contextRef = new ContextReference(invocationId);
+            contextRef.HttpContextValueSource.TrySetException(expectedException);
+
+            // Use reflection to insert the faulted context reference
+            var field = typeof(DefaultHttpCoordinator)
+                .GetField("_contextReferenceList", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var dict = (ConcurrentDictionary<string, ContextReference>)field.GetValue(_coordinator)!;
+            dict[invocationId] = contextRef;
+
+            // Act & Assert - Should propagate the original exception
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _coordinator.SetHttpContextAsync(invocationId, httpContext));
+            Assert.Same(expectedException, exception);
+        }
+
+        [Fact]
+        public async Task SetFunctionContextAsync_WhenFunctionContextTaskFaulted_PropagatesOriginalException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var functionContext = CreateTestFunctionContext();
+            var expectedException = new InvalidOperationException("Something went wrong");
+
+            // Pre-create the context reference and fault the TCS
+            var contextRef = new ContextReference(invocationId);
+            contextRef.FunctionContextValueSource.TrySetException(expectedException);
+
+            // Use reflection to insert the faulted context reference
+            var field = typeof(DefaultHttpCoordinator)
+                .GetField("_contextReferenceList", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var dict = (ConcurrentDictionary<string, ContextReference>)field.GetValue(_coordinator)!;
+            dict[invocationId] = contextRef;
+
+            // Act & Assert - Should propagate the original exception
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _coordinator.SetFunctionContextAsync(invocationId, functionContext));
+            Assert.Same(expectedException, exception);
         }
     }
 }

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
@@ -1,0 +1,269 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore;
+using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Worker.Extensions.Http.AspNetCore.Tests
+{
+    public class DefaultHttpCoordinatorTests
+    {
+        private readonly DefaultHttpCoordinator _coordinator;
+        private readonly ExtensionTrace _logger;
+
+        public DefaultHttpCoordinatorTests()
+        {
+            var loggerFactory = new NullLoggerFactory();
+            _logger = new ExtensionTrace(loggerFactory);
+            _coordinator = new DefaultHttpCoordinator(_logger);
+        }
+
+        [Fact]
+        public async Task SetHttpContextAsync_WhenFunctionContextSetFirst_ReturnsSuccessfully()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+
+            // Act
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            _ = _coordinator.RunFunctionInvocationAsync(invocationId);
+
+            var resultFunctionContext = await setHttpTask;
+            var resultHttpContext = await setFunctionTask;
+
+            // Assert
+            Assert.Same(functionContext, resultFunctionContext);
+            Assert.Same(httpContext, resultHttpContext);
+        }
+
+        [Fact]
+        public async Task SetHttpContextAsync_WhenRequestCancelled_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var cts = new CancellationTokenSource();
+            var httpContext = new DefaultHttpContext
+            {
+                RequestAborted = cts.Token
+            };
+
+            // Act
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            cts.Cancel();
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () => await setHttpTask);
+            Assert.Contains($"HTTP request was cancelled while waiting for the function context to be set. Invocation: '{invocationId}'", exception.Message);
+        }
+
+        [Fact]
+        public async Task SetHttpContextAsync_WhenFunctionContextTimesOut_ThrowsTimeoutException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+
+            // Act - Don't set the function context, causing timeout
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<TimeoutException>(async () => await setHttpTask);
+            Assert.Contains($"Timed out waiting for the HTTP context to be set. Invocation: '{invocationId}'", exception.Message);
+        }
+
+        [Fact]
+        public async Task SetFunctionContextAsync_WhenHttpContextSetFirst_ReturnsSuccessfully()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+
+            // Act
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            _ = _coordinator.RunFunctionInvocationAsync(invocationId);
+
+            var resultFunctionContext = await setHttpTask;
+            var resultHttpContext = await setFunctionTask;
+
+            // Assert
+            Assert.Same(functionContext, resultFunctionContext);
+            Assert.Same(httpContext, resultHttpContext);
+        }
+
+        [Fact]
+        public async Task SetFunctionContextAsync_WhenInvocationCancelled_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var cts = new CancellationTokenSource();
+            var functionContext = CreateTestFunctionContext(cts.Token);
+
+            // Act
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            cts.Cancel();
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () => await setFunctionTask);
+            Assert.Contains($"Function invocation cancelled while waiting for start call. Invocation: '{invocationId}'", exception.Message);
+        }
+
+        [Fact]
+        public async Task SetFunctionContextAsync_WhenFunctionStartTimesOut_ThrowsTimeoutException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var functionContext = CreateTestFunctionContext();
+
+            // Act - Don't call RunFunctionInvocationAsync, causing timeout
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<TimeoutException>(async () => await setFunctionTask);
+            Assert.Contains($"Timed out waiting for the function start call. Invocation: '{invocationId}'", exception.Message);
+        }
+
+        [Fact]
+        public async Task SetFunctionContextAsync_WhenHttpContextTimesOut_ThrowsTimeoutException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var functionContext = CreateTestFunctionContext();
+
+            // Act
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            _ = _coordinator.RunFunctionInvocationAsync(invocationId);
+            // Don't set HTTP context, causing timeout
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<TimeoutException>(async () => await setFunctionTask);
+            Assert.Contains($"Timed out waiting for the HTTP context to be set. Invocation: '{invocationId}'", exception.Message);
+        }
+
+        [Fact]
+        public async Task SetFunctionContextAsync_WhenHttpContextCancelled_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var cts = new CancellationTokenSource();
+            var functionContext = CreateTestFunctionContext(cts.Token);
+
+            // Act
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            _ = _coordinator.RunFunctionInvocationAsync(invocationId);
+            cts.Cancel();
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () => await setFunctionTask);
+            Assert.Contains($"Function invocation cancelled while waiting for HTTP context. Invocation: '{invocationId}'", exception.Message);
+        }
+
+        [Fact]
+        public async Task RunFunctionInvocationAsync_WhenContextExists_CompletesSuccessfully()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+
+            // Act
+            var invocationTask = _coordinator.RunFunctionInvocationAsync(invocationId);
+
+            // Assert - Tasks should complete after invocation is run
+            await setHttpTask;
+            await setFunctionTask;
+
+            _coordinator.CompleteFunctionInvocation(invocationId);
+            await invocationTask;
+        }
+
+        [Fact]
+        public async Task RunFunctionInvocationAsync_WhenContextDoesNotExist_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _coordinator.RunFunctionInvocationAsync(invocationId));
+            Assert.Contains($"Context for invocation id '{invocationId}' does not exist", exception.Message);
+        }
+
+        [Fact]
+        public async Task CompleteFunctionInvocation_WhenContextExists_RemovesContext()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            var invocationTask = _coordinator.RunFunctionInvocationAsync(invocationId);
+
+            await setHttpTask;
+            await setFunctionTask;
+
+            // Act
+            _coordinator.CompleteFunctionInvocation(invocationId);
+            await invocationTask;
+
+            // Assert - Trying to run invocation again should fail since context was removed
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _coordinator.RunFunctionInvocationAsync(invocationId));
+        }
+
+        [Fact]
+        public void CompleteFunctionInvocation_WhenContextDoesNotExist_DoesNotThrow()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+
+            // Act & Assert - Should not throw
+            _coordinator.CompleteFunctionInvocation(invocationId);
+        }
+
+        [Fact]
+        public async Task FullWorkflow_WithCorrectOrder_CompletesSuccessfully()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+
+            // Act - Simulate the full workflow
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            var invocationTask = _coordinator.RunFunctionInvocationAsync(invocationId);
+
+            var resultFunctionContext = await setHttpTask;
+            var resultHttpContext = await setFunctionTask;
+
+            _coordinator.CompleteFunctionInvocation(invocationId);
+            await invocationTask;
+
+            // Assert
+            Assert.Same(functionContext, resultFunctionContext);
+            Assert.Same(httpContext, resultHttpContext);
+        }
+
+        private static FunctionContext CreateTestFunctionContext(CancellationToken cancellationToken = default)
+        {
+            var mockContext = new Mock<FunctionContext>();
+            mockContext.Setup(c => c.CancellationToken).Returns(cancellationToken);
+            mockContext.Setup(c => c.InvocationId).Returns(Guid.NewGuid().ToString());
+            return mockContext.Object;
+        }
+    }
+}

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
@@ -235,6 +235,100 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task SetHttpContextAsync_WhenCalledConcurrently_AndFunctionContextAlreadySet_ReturnsIt()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext1 = new DefaultHttpContext();
+            var httpContext2 = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+
+            // Act - Set both contexts via normal flow first
+            var setHttpTask1 = _coordinator.SetHttpContextAsync(invocationId, httpContext1);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            _ = _coordinator.RunFunctionInvocationAsync(invocationId);
+
+            await setHttpTask1;
+            await setFunctionTask;
+
+            // Now call SetHttpContextAsync again - TrySetResult fails, but FunctionContextValueSource
+            // is already completed so it returns the function context directly.
+            var result = await _coordinator.SetHttpContextAsync(invocationId, httpContext2);
+
+            _coordinator.CompleteFunctionInvocation(invocationId);
+
+            // Assert
+            Assert.Same(functionContext, result);
+        }
+
+        [Fact]
+        public async Task SetHttpContextAsync_WhenCalledConcurrently_AndFunctionContextNotSet_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext1 = new DefaultHttpContext();
+            var httpContext2 = new DefaultHttpContext();
+
+            // Act - Set HTTP context but don't set function context
+            _ = _coordinator.SetHttpContextAsync(invocationId, httpContext1);
+
+            // Second call - TrySetResult fails and FunctionContextValueSource is not complete
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _coordinator.SetHttpContextAsync(invocationId, httpContext2));
+
+            // Assert
+            Assert.Contains($"Failed to set HTTP context for invocation id '{invocationId}'", exception.Message);
+        }
+
+        [Fact]
+        public async Task SetFunctionContextAsync_WhenCalledConcurrently_AndHttpContextAlreadySet_ReturnsIt()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext1 = CreateTestFunctionContext();
+            var functionContext2 = CreateTestFunctionContext();
+
+            // Act - Set both contexts via normal flow first
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext1);
+            _ = _coordinator.RunFunctionInvocationAsync(invocationId);
+
+            await setHttpTask;
+            await setFunctionTask;
+
+            // Now call SetFunctionContextAsync again - TrySetResult fails, but HttpContextValueSource
+            // is already completed so it returns the HTTP context directly.
+            var result = await _coordinator.SetFunctionContextAsync(invocationId, functionContext2);
+
+            _coordinator.CompleteFunctionInvocation(invocationId);
+
+            // Assert
+            Assert.Same(httpContext, result);
+        }
+
+        [Fact]
+        public async Task SetFunctionContextAsync_WhenCalledConcurrently_AndHttpContextNotSet_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var functionContext1 = CreateTestFunctionContext();
+            var functionContext2 = CreateTestFunctionContext();
+
+            // Act - Set function context but don't set HTTP context
+            _ = _coordinator.SetFunctionContextAsync(invocationId, functionContext1);
+
+            // Second call - TrySetResult fails and HttpContextValueSource is not complete
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _coordinator.SetFunctionContextAsync(invocationId, functionContext2));
+
+            // Assert
+            Assert.Contains($"Failed to set function context for invocation id '{invocationId}'", exception.Message);
+        }
+
+
+
+        [Fact]
         public async Task FullWorkflow_WithCorrectOrder_CompletesSuccessfully()
         {
             // Arrange

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
@@ -75,7 +75,7 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
 
             // Assert
             var exception = await Assert.ThrowsAsync<TimeoutException>(async () => await setHttpTask);
-            Assert.Contains($"Timed out waiting for the HTTP context to be set. Invocation: '{invocationId}'", exception.Message);
+            Assert.Contains($"Timed out waiting for the function context to be set. Invocation: '{invocationId}'", exception.Message);
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
             var httpContext2 = new DefaultHttpContext();
 
             // Act - Set HTTP context but don't set function context
-            _ = _coordinator.SetHttpContextAsync(invocationId, httpContext1);
+            var firstSetHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext1);
 
             // Second call - TrySetResult fails and FunctionContextValueSource is not complete
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -278,6 +278,13 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
 
             // Assert
             Assert.Contains($"Failed to set HTTP context for invocation id '{invocationId}'", exception.Message);
+
+            // Cleanup: unblock the first task to avoid unobserved timeout exceptions
+            var functionContext = CreateTestFunctionContext();
+            _ = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            _ = _coordinator.RunFunctionInvocationAsync(invocationId);
+            await firstSetHttpTask;
+            _coordinator.CompleteFunctionInvocation(invocationId);
         }
 
         [Fact]
@@ -316,7 +323,7 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
             var functionContext2 = CreateTestFunctionContext();
 
             // Act - Set function context but don't set HTTP context
-            _ = _coordinator.SetFunctionContextAsync(invocationId, functionContext1);
+            var firstSetFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext1);
 
             // Second call - TrySetResult fails and HttpContextValueSource is not complete
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -324,9 +331,14 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
 
             // Assert
             Assert.Contains($"Failed to set function context for invocation id '{invocationId}'", exception.Message);
+
+            // Cleanup: unblock the first task to avoid unobserved timeout exceptions
+            var httpContext = new DefaultHttpContext();
+            _ = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            _ = _coordinator.RunFunctionInvocationAsync(invocationId);
+            await firstSetFunctionTask;
+            _coordinator.CompleteFunctionInvocation(invocationId);
         }
-
-
 
         [Fact]
         public async Task FullWorkflow_WithCorrectOrder_CompletesSuccessfully()


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #3348 , resolves #2485

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Unable to reproduce #2485 but #3348 was easily reproducible with a load test that sends and cancels requests immediately. The new behavior is that instead of getting a timeout exception, an `OperationCanceledException` is thrown.

 Changes:

   - Replace SetResult with TrySetResult in both SetHttpContextAsync and SetFunctionContextAsync, with proper handling
   when the TCS is already completed or cancelled
   - Pass cancellation tokens (RequestAborted / CancellationToken) through to WaitAsync calls so cancelled HTTP
  requests propagate promptly instead of waiting for timeout
   - Wrap SetFunctionContextAsync call in FunctionsHttpProxyingMiddleware inside the existing try block so
  cancellation exceptions are handled consistently
   - Add unit tests covering normal flow, cancellation, and timeout scenarios