### PR TITLE
build(cosmos): update Microsoft.Azure.Cosmos to 3.60.0

### DIFF
--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -7,5 +7,5 @@
 ### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.16.0
 
 - feat: support `AllVersionsAndDeletes` changefeed mode (#3420)
-- build: update `Microsoft.Azure.WebJobs.Extensions.CosmosDB` to 4.16.0 (#3420)
+- build: update `Microsoft.Azure.WebJobs.Extensions.CosmosDB` to 4.16.1 (#3421)
 - build: update `Microsoft.Azure.Cosmos` to 3.60.0 (#3421)

--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -6,5 +6,6 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.16.0
 
-- chore: updates dependency `Microsoft.Azure.WebJobs.Extensions.CosmosDB` to version 4.16.0 (#3420)
 - feat: support `AllVersionsAndDeletes` changefeed mode (#3420)
+- build: update `Microsoft.Azure.WebJobs.Extensions.CosmosDB` to 4.16.0 (#3420)
+- build: update `Microsoft.Azure.Cosmos` to 3.60.0 (#3421)

--- a/extensions/Worker.Extensions.CosmosDB/release_notes.md
+++ b/extensions/Worker.Extensions.CosmosDB/release_notes.md
@@ -4,7 +4,7 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.16.0
+### Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.16.1
 
 - feat: support `AllVersionsAndDeletes` changefeed mode (#3420)
 - build: update `Microsoft.Azure.WebJobs.Extensions.CosmosDB` to 4.16.1 (#3421)

--- a/extensions/Worker.Extensions.CosmosDB/src/CosmosDBChangeFeedMode.cs
+++ b/extensions/Worker.Extensions.CosmosDB/src/CosmosDBChangeFeedMode.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Azure.Functions.Worker
         /// <summary>
         /// All intermediate versions and delete tombstones are included.
         /// </summary>
+        /// <remarks>
+        /// When using <see cref="AllVersionsAndDeletes"/> the item type must be wrapped with <see cref="Microsoft.Azure.Cosmos.ChangeFeedItem{T}"/>.
+        /// </remarks>
         AllVersionsAndDeletes = 1
     }
 }

--- a/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
+++ b/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Cosmos DB extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.16.0</VersionPrefix>
+    <VersionPrefix>4.16.1</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.16.0" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.16.1" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
+++ b/extensions/Worker.Extensions.CosmosDB/src/Worker.Extensions.CosmosDB.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.60.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.19.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <!-- Transitive dependency promoted to address CVE:-->

--- a/test/E2ETests/E2EApps/E2EApp/Cosmos/CosmosAllVersionsAndDeletesFunction.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Cosmos/CosmosAllVersionsAndDeletesFunction.cs
@@ -40,7 +40,10 @@ namespace Microsoft.Azure.Functions.Worker.E2EApp
             return input.Select(change =>
             {
                 string operation = change.Metadata?.OperationType.ToString() ?? "Unknown";
-                string sourceId = change.Current?.Id ?? change.Previous?.Id;
+                // Prefer Current/Previous payload id; fall back to Metadata.Id which is populated
+                // even for Delete events on accounts where Previous is not retained
+                // (e.g. continuous backup mode).
+                string sourceId = change.Current?.Id ?? change.Previous?.Id ?? change.Metadata?.Id;
                 logger.LogInformation("AllVersionsAndDeletes change: operation={Operation}, id={Id}", operation, sourceId);
 
                 return new

--- a/test/E2ETests/E2EApps/E2EApp/Cosmos/CosmosAllVersionsAndDeletesFunction.cs
+++ b/test/E2ETests/E2EApps/E2EApp/Cosmos/CosmosAllVersionsAndDeletesFunction.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Functions.Worker.E2EApp
+{
+    public class CosmosAllVersionsAndDeletesFunction
+    {
+        // The output document id encodes the change feed operation so the E2E test
+        // can verify the trigger fired and observed the expected operation type.
+        // For Delete events, Current is null and Previous carries the document.
+        [Function(nameof(CosmosAllVersionsAndDeletesTrigger))]
+        [CosmosDBOutput(
+            databaseName: "%CosmosDb%",
+            containerName: "%CosmosCollOut%",
+            Connection = "CosmosConnection",
+            CreateIfNotExists = true)]
+        public IEnumerable<object> CosmosAllVersionsAndDeletesTrigger(
+            [CosmosDBTrigger(
+                databaseName: "%CosmosDb%",
+                containerName: "%CosmosCollAvad%",
+                Connection = "CosmosConnection",
+                LeaseContainerName = "leases",
+                LeaseContainerPrefix = "avad",
+                CreateLeaseContainerIfNotExists = true,
+                ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] IReadOnlyList<ChangeFeedItem<AvadDocument>> input,
+                FunctionContext context)
+        {
+            if (input == null || input.Count == 0)
+            {
+                return null;
+            }
+
+            ILogger logger = context.GetLogger("Function.CosmosAllVersionsAndDeletesTrigger");
+
+            return input.Select(change =>
+            {
+                string operation = change.Metadata?.OperationType.ToString() ?? "Unknown";
+                string sourceId = change.Current?.Id ?? change.Previous?.Id;
+                logger.LogInformation("AllVersionsAndDeletes change: operation={Operation}, id={Id}", operation, sourceId);
+
+                return new
+                {
+                    id = $"avad-{operation}-{sourceId}"
+                };
+            }).ToArray();
+        }
+
+        public class AvadDocument
+        {
+            public string Id { get; set; }
+
+            public string Text { get; set; }
+        }
+    }
+}

--- a/test/E2ETests/E2EApps/E2EApp/local.settings.json
+++ b/test/E2ETests/E2EApps/E2EApp/local.settings.json
@@ -7,6 +7,7 @@
     "CosmosDb": "ItemDb",
     "CosmosCollIn": "ItemCollectionIn",
     "CosmosCollOut": "ItemCollectionOut",
-    "CosmosCollAvad": "ItemCollectionAvad"
+    "CosmosCollAvad": "ItemCollectionAvad",
+    "AzureWebJobs.CosmosAllVersionsAndDeletesTrigger.Disabled": "true"
   }
 }

--- a/test/E2ETests/E2EApps/E2EApp/local.settings.json
+++ b/test/E2ETests/E2EApps/E2EApp/local.settings.json
@@ -6,6 +6,7 @@
     "CosmosConnection": "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
     "CosmosDb": "ItemDb",
     "CosmosCollIn": "ItemCollectionIn",
-    "CosmosCollOut": "ItemCollectionOut"
+    "CosmosCollOut": "ItemCollectionOut",
+    "CosmosCollAvad": "ItemCollectionAvad"
   }
 }

--- a/test/E2ETests/E2ETests/Constants.cs
+++ b/test/E2ETests/E2ETests/Constants.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests
             public const string InputCollectionName = "ItemCollectionIn";
             public const string OutputCollectionName = "ItemCollectionOut";
             public const string LeaseCollectionName = "leases";
+            public const string AllVersionsAndDeletesCollectionName = "ItemCollectionAvad";
         }
 
         // EventHubs

--- a/test/E2ETests/E2ETests/Cosmos/CosmosDBEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/Cosmos/CosmosDBEndToEndTests.cs
@@ -27,7 +27,12 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests.Cosmos
         // updated Worker.Extensions.CosmosDB / WebJobs.Extensions.CosmosDB packages. Re-skipped
         // because the Cosmos emulator does not reliably support AllVersionsAndDeletes change
         // feed mode — host indexing hangs ~36s on Account Read and returns 503 (Substatus 20003,
-        // GatewayStoreClient Request Timeout). Flip Skip when running against a real account.
+        // GatewayStoreClient Request Timeout). The trigger is also disabled by default in the
+        // E2EApp's local.settings.json (AzureWebJobs.CosmosAllVersionsAndDeletesTrigger.Disabled)
+        // so host startup stays clean against the emulator for the rest of the Cosmos test suite.
+        // To run this test against a real Cosmos account: (1) flip Skip below, (2) point
+        // CosmosConnection / CosmosDBConnectionStringSetting at the real account, (3) remove or
+        // set the Disabled setting to "false".
         [Fact(Skip = "Emulator doesn't reliably support AllVersionsAndDeletes change feed mode.")]
         public async Task CosmosDBTrigger_AllVersionsAndDeletes_Succeeds()
         {

--- a/test/E2ETests/E2ETests/Cosmos/CosmosDBEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/Cosmos/CosmosDBEndToEndTests.cs
@@ -23,6 +23,48 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests.Cosmos
             _disposeLog = _fixture.TestLogs.UseTestLogger(testOutput);
         }
 
+        // Mirrors the equivalent WebJobs E2E test, which is also skipped: the Cosmos emulator
+        // does not reliably support the AllVersionsAndDeletes change feed mode. When run against
+        // a real Cosmos account (set CosmosDBConnectionStringSetting), the trigger should fire
+        // for both the create and the delete event and emit a document per change to the output
+        // container, allowing the assertions below to succeed.
+        [Fact(Skip = "Emulator doesn't reliably support AllVersionsAndDeletes change feed mode.")]
+        public async Task CosmosDBTrigger_AllVersionsAndDeletes_Succeeds()
+        {
+            string sourceDocId = Guid.NewGuid().ToString();
+            string createdMarkerId = $"avad-Create-{sourceDocId}";
+            string deletedMarkerId = $"avad-Delete-{sourceDocId}";
+
+            try
+            {
+                // Create then delete a document in the AllVersionsAndDeletes-enabled container
+                // to produce two change feed events.
+                await CosmosDBHelpers.CreateAvadDocument(sourceDocId, sourceDocId);
+                await CosmosDBHelpers.DeleteAvadDocument(sourceDocId);
+
+                // The function writes one output document per change feed event, with the id
+                // encoding the operation type. Wait for both to appear.
+                string observedCreatedId = null;
+                string observedDeletedId = null;
+                await TestUtility.RetryAsync(async () =>
+                {
+                    observedCreatedId ??= await CosmosDBHelpers.ReadDocument(createdMarkerId);
+                    observedDeletedId ??= await CosmosDBHelpers.ReadDocument(deletedMarkerId);
+                    return observedCreatedId is not null && observedDeletedId is not null;
+                });
+
+                Assert.Equal(createdMarkerId, observedCreatedId);
+                Assert.Equal(deletedMarkerId, observedDeletedId);
+            }
+            finally
+            {
+                // Best-effort cleanup of any docs written by the trigger and any leftover source doc.
+                await CosmosDBHelpers.DeleteAvadDocument(sourceDocId);
+                await CosmosDBHelpers.DeleteTestDocuments(createdMarkerId);
+                await CosmosDBHelpers.DeleteTestDocuments(deletedMarkerId);
+            }
+        }
+
         [Fact]
         public async Task CosmosDBTriggerAndOutput_Succeeds()
         {

--- a/test/E2ETests/E2ETests/Cosmos/CosmosDBEndToEndTests.cs
+++ b/test/E2ETests/E2ETests/Cosmos/CosmosDBEndToEndTests.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests.Cosmos
             _disposeLog = _fixture.TestLogs.UseTestLogger(testOutput);
         }
 
-        // Mirrors the equivalent WebJobs E2E test, which is also skipped: the Cosmos emulator
-        // does not reliably support the AllVersionsAndDeletes change feed mode. When run against
-        // a real Cosmos account (set CosmosDBConnectionStringSetting), the trigger should fire
-        // for both the create and the delete event and emit a document per change to the output
-        // container, allowing the assertions below to succeed.
+        // Verified passing 2026-05-21 against a real Cosmos account (continuous backup) with the
+        // updated Worker.Extensions.CosmosDB / WebJobs.Extensions.CosmosDB packages. Re-skipped
+        // because the Cosmos emulator does not reliably support AllVersionsAndDeletes change
+        // feed mode — host indexing hangs ~36s on Account Read and returns 503 (Substatus 20003,
+        // GatewayStoreClient Request Timeout). Flip Skip when running against a real account.
         [Fact(Skip = "Emulator doesn't reliably support AllVersionsAndDeletes change feed mode.")]
         public async Task CosmosDBTrigger_AllVersionsAndDeletes_Succeeds()
         {

--- a/test/E2ETests/E2ETests/E2ETests.csproj
+++ b/test/E2ETests/E2ETests/E2ETests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.60.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/test/E2ETests/E2ETests/Helpers/CosmosDBHelpers.cs
+++ b/test/E2ETests/E2ETests/Helpers/CosmosDBHelpers.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests
         private static readonly Container _inputContainer;
         private static readonly Container _outputContainer;
         private static readonly Container _leaseContainer;
+        private static readonly Container _avadContainer;
 
         static CosmosDBHelpers()
         {
@@ -24,6 +25,7 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests
             _inputContainer = database.GetContainer(Constants.CosmosDB.InputCollectionName);
             _outputContainer = database.GetContainer(Constants.CosmosDB.OutputCollectionName);
             _leaseContainer = database.GetContainer(Constants.CosmosDB.LeaseCollectionName);
+            _avadContainer = database.GetContainer(Constants.CosmosDB.AllVersionsAndDeletesCollectionName);
         }
 
         // keep
@@ -31,6 +33,19 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests
         {
             var documentToTest = new { id = docId, Text = docText };
             await _inputContainer.CreateItemAsync(documentToTest, new PartitionKey(docId));
+        }
+
+        // Creates a document in the container monitored by the AllVersionsAndDeletes trigger.
+        public async static Task CreateAvadDocument(string docId, string docText = "test")
+        {
+            var documentToTest = new { id = docId, Text = docText };
+            await _avadContainer.CreateItemAsync(documentToTest, new PartitionKey(docId));
+        }
+
+        // Deletes a document from the container monitored by the AllVersionsAndDeletes trigger.
+        public async static Task DeleteAvadDocument(string docId)
+        {
+            await DeleteDocument(_avadContainer, docId);
         }
 
         // keep
@@ -94,7 +109,8 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests
             await Task.WhenAll(
                 CreateCollection(database, Constants.CosmosDB.InputCollectionName),
                 CreateCollection(database, Constants.CosmosDB.OutputCollectionName),
-                CreateCollection(database, Constants.CosmosDB.LeaseCollectionName));
+                CreateCollection(database, Constants.CosmosDB.LeaseCollectionName),
+                CreateAvadCollection(database, Constants.CosmosDB.AllVersionsAndDeletesCollectionName));
 
             return true;
         }
@@ -105,7 +121,8 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests
             await Task.WhenAll(
                 DeleteCollection(database, Constants.CosmosDB.InputCollectionName),
                 DeleteCollection(database, Constants.CosmosDB.OutputCollectionName),
-                DeleteCollection(database, Constants.CosmosDB.LeaseCollectionName));
+                DeleteCollection(database, Constants.CosmosDB.LeaseCollectionName),
+                DeleteCollection(database, Constants.CosmosDB.AllVersionsAndDeletesCollectionName));
         }
 
         private async static Task DeleteCollection(Database database, string collectionName)
@@ -127,6 +144,20 @@ namespace Microsoft.Azure.Functions.Worker.E2ETests
             {
                 Id = collectionName,
                 PartitionKeyPath = "/id"
+            };
+
+            await database.CreateContainerIfNotExistsAsync(containerProperties, throughput: 400);
+        }
+
+        // Creates a container with a full-fidelity change feed retention policy, which is required
+        // for the AllVersionsAndDeletes change feed mode.
+        private async static Task CreateAvadCollection(Database database, string collectionName)
+        {
+            var containerProperties = new ContainerProperties
+            {
+                Id = collectionName,
+                PartitionKeyPath = "/id",
+                ChangeFeedPolicy = new ChangeFeedPolicy { FullFidelityRetention = TimeSpan.FromMinutes(5) }
             };
 
             await database.CreateContainerIfNotExistsAsync(containerProperties, throughput: 400);

--- a/test/extensions/Worker.Extensions.Tests/Cosmos/CosmosDBConverterTests.cs
+++ b/test/extensions/Worker.Extensions.Tests/Cosmos/CosmosDBConverterTests.cs
@@ -503,6 +503,146 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Cosmos
                 Times.Once);
         }
 
+        [Fact]
+        public async Task ConvertAsync_ValidModelBindingData_IEnumerableChangeFeedItem_ReturnsSuccess()
+        {
+            // Bind to IEnumerable<ChangeFeedItem<T>> - represents the AllVersionsAndDeletes trigger payload shape:
+            // a collection of change feed items containing Current/Previous/Metadata.
+            var query = "SELECT * FROM TodoItems t";
+            var grpcModelBindingData = GrpcTestHelper.GetTestGrpcModelBindingData(GetTestBinaryData(query: query), "CosmosDB");
+            var context = new TestConverterContext(typeof(IEnumerable<ChangeFeedItem<ToDoItem>>), grpcModelBindingData);
+
+            // operationType uses numeric values so System.Text.Json (the default serializer) can deserialize the enum.
+            var json = @"{""Documents"":[
+                {""current"":{""id"":""1"",""description"":""Created""},""previous"":null,""metadata"":{""operationType"":0,""lsn"":1,""crts"":1700000000,""previousImageLSN"":0,""timeToLiveExpired"":false}},
+                {""current"":null,""previous"":{""id"":""2"",""description"":""Deleted""},""metadata"":{""operationType"":2,""lsn"":2,""crts"":1700000001,""previousImageLSN"":1,""timeToLiveExpired"":false}}
+            ],""_rid"":""ltwyAJGNSgs="",""_count"":2}";
+            var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var mockFeedResponse = new Mock<ResponseMessage>();
+            mockFeedResponse.Setup(x => x.StatusCode).Returns(HttpStatusCode.OK);
+            mockFeedResponse.Setup(x => x.Content).Returns(expectedStream);
+
+            var mockFeedIterator = new Mock<FeedIterator>();
+            mockFeedIterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            mockFeedIterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(mockFeedResponse.Object);
+
+            var mockContainer = new Mock<Container>();
+            mockContainer
+                .Setup(m => m.GetItemQueryStreamIterator(It.IsAny<QueryDefinition>(), default, It.IsAny<QueryRequestOptions>()))
+                .Returns(mockFeedIterator.Object);
+
+            _mockCosmosClient
+                .Setup(m => m.GetContainer(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(mockContainer.Object);
+
+            var conversionResult = await _cosmosDBConverter.ConvertAsync(context);
+            var result = conversionResult.Value as IList<ChangeFeedItem<ToDoItem>>;
+
+            Assert.Equal(ConversionStatus.Succeeded, conversionResult.Status);
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+
+            // Create event: Current populated, Previous null.
+            Assert.NotNull(result[0].Current);
+            Assert.Equal("1", result[0].Current.Id);
+            Assert.Equal("Created", result[0].Current.Description);
+            Assert.Null(result[0].Previous);
+            Assert.Equal(ChangeFeedOperationType.Create, result[0].Metadata.OperationType);
+
+            // Delete event: Current null, Previous populated.
+            Assert.Null(result[1].Current);
+            Assert.NotNull(result[1].Previous);
+            Assert.Equal("2", result[1].Previous.Id);
+            Assert.Equal("Deleted", result[1].Previous.Description);
+            Assert.Equal(ChangeFeedOperationType.Delete, result[1].Metadata.OperationType);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_ValidModelBindingData_ChangeFeedItemArray_ReturnsSuccess()
+        {
+            // Same as above but binding target is an array of ChangeFeedItem<T>.
+            var query = "SELECT * FROM TodoItems t";
+            var grpcModelBindingData = GrpcTestHelper.GetTestGrpcModelBindingData(GetTestBinaryData(query: query), "CosmosDB");
+            var context = new TestConverterContext(typeof(ChangeFeedItem<ToDoItem>[]), grpcModelBindingData);
+
+            var json = @"{""Documents"":[
+                {""current"":{""id"":""1"",""description"":""Original""},""previous"":null,""metadata"":{""operationType"":0,""lsn"":1,""crts"":1700000000,""previousImageLSN"":0,""timeToLiveExpired"":false}},
+                {""current"":{""id"":""1"",""description"":""Updated""},""previous"":{""id"":""1"",""description"":""Original""},""metadata"":{""operationType"":1,""lsn"":2,""crts"":1700000001,""previousImageLSN"":1,""timeToLiveExpired"":false}}
+            ],""_rid"":""ltwyAJGNSgs="",""_count"":2}";
+            var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var mockFeedResponse = new Mock<ResponseMessage>();
+            mockFeedResponse.Setup(x => x.StatusCode).Returns(HttpStatusCode.OK);
+            mockFeedResponse.Setup(x => x.Content).Returns(expectedStream);
+
+            var mockFeedIterator = new Mock<FeedIterator>();
+            mockFeedIterator.SetupSequence(x => x.HasMoreResults).Returns(true).Returns(false);
+            mockFeedIterator.Setup(x => x.ReadNextAsync(default)).ReturnsAsync(mockFeedResponse.Object);
+
+            var mockContainer = new Mock<Container>();
+            mockContainer
+                .Setup(m => m.GetItemQueryStreamIterator(It.IsAny<QueryDefinition>(), default, It.IsAny<QueryRequestOptions>()))
+                .Returns(mockFeedIterator.Object);
+
+            _mockCosmosClient
+                .Setup(m => m.GetContainer(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(mockContainer.Object);
+
+            var conversionResult = await _cosmosDBConverter.ConvertAsync(context);
+            var result = conversionResult.Value as ChangeFeedItem<ToDoItem>[];
+
+            Assert.Equal(ConversionStatus.Succeeded, conversionResult.Status);
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Length);
+
+            Assert.Equal(ChangeFeedOperationType.Create, result[0].Metadata.OperationType);
+            Assert.Equal("Original", result[0].Current.Description);
+            Assert.Null(result[0].Previous);
+
+            // Replace event carries both current and previous snapshots.
+            Assert.Equal(ChangeFeedOperationType.Replace, result[1].Metadata.OperationType);
+            Assert.Equal("Updated", result[1].Current.Description);
+            Assert.NotNull(result[1].Previous);
+            Assert.Equal("Original", result[1].Previous.Description);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_ValidModelBindingData_SingleChangeFeedItem_ReturnsSuccess()
+        {
+            // Binding a single ChangeFeedItem<T> exercises the POCO read path. Not a typical scenario for
+            // change feed (the trigger always delivers a collection), but verifies the converter can
+            // deserialize the ChangeFeedItem<T> JSON shape end-to-end via ReadItemStreamAsync.
+            var grpcModelBindingData = GrpcTestHelper.GetTestGrpcModelBindingData(
+                GetTestBinaryData(id: "1", partitionKey: "1"), "CosmosDB");
+            var context = new TestConverterContext(typeof(ChangeFeedItem<ToDoItem>), grpcModelBindingData);
+
+            var json = @"{""current"":{""id"":""1"",""description"":""Take out the rubbish""},""previous"":null,""metadata"":{""operationType"":0,""lsn"":1,""crts"":1700000000,""previousImageLSN"":0,""timeToLiveExpired"":false}}";
+            var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var mockResponse = new Mock<ResponseMessage>();
+            mockResponse.Setup(x => x.StatusCode).Returns(HttpStatusCode.OK);
+            mockResponse.Setup(x => x.Content).Returns(expectedStream);
+
+            var mockContainer = new Mock<Container>();
+            mockContainer
+                .Setup(m => m.ReadItemStreamAsync(It.IsAny<string>(), It.IsAny<PartitionKey>(), null, CancellationToken.None))
+                .ReturnsAsync(mockResponse.Object);
+
+            _mockCosmosClient
+                .Setup(m => m.GetContainer(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(mockContainer.Object);
+
+            var conversionResult = await _cosmosDBConverter.ConvertAsync(context);
+            var result = conversionResult.Value as ChangeFeedItem<ToDoItem>;
+
+            Assert.Equal(ConversionStatus.Succeeded, conversionResult.Status);
+            Assert.NotNull(result);
+            Assert.Equal("1", result.Current.Id);
+            Assert.Equal("Take out the rubbish", result.Current.Description);
+            Assert.Equal(ChangeFeedOperationType.Create, result.Metadata.OperationType);
+        }
+
         private BinaryData GetTestBinaryData(string db = "testDb", string container = "testContainer", string connection = "cosmosConnection", string id = "", string partitionKey = "", string query = "", string location = "", string queryParams = "{}")
         {
             string jsonData = $@"{{


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Due to how bindings are constructed on the host-side with out-of-proc workers, the safeguard logic in the CosmosDB webjobs package would block the binding as it was not the expected type format of `ChangeFeedItem<T>`. `Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1` has an out-of-proc specific handling to unblock that scenario.

- Update `Microsoft.Azure.Cosmos` to 3.60.0
- Update `Microsoft.Azure.WebJobs.Extensions.CosmosDB` to 4.16.1
- Update version to 4.16.1
- Add tests for the new changefeed mode.
