### PR TITLE
build(app-insights): Bump Microsoft.Azure.Functions.Worker.ApplicationInsights to 2.51.0

### DIFF
--- a/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
+++ b/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.ApplicationInsights</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.ApplicationInsights</RootNamespace>
     <MajorProductVersion>2</MajorProductVersion>
-    <MinorProductVersion>50</MinorProductVersion>
+    <MinorProductVersion>51</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>    
     <BeforePack>$(BeforePack);GetReleaseNotes</BeforePack>

--- a/src/DotNetWorker.ApplicationInsights/release_notes.md
+++ b/src/DotNetWorker.ApplicationInsights/release_notes.md
@@ -1,5 +1,5 @@
 ## What's Changed
 
-### Microsoft.Azure.Functions.Worker.ApplicationInsights <version>
+### Microsoft.Azure.Functions.Worker.ApplicationInsights 2.51.0
 
 - Improved idempotency of service registration calls (#3273)

--- a/src/DotNetWorker.ApplicationInsights/release_notes.md
+++ b/src/DotNetWorker.ApplicationInsights/release_notes.md
@@ -2,6 +2,4 @@
 
 ### Microsoft.Azure.Functions.Worker.ApplicationInsights <version>
 
-- Updating `Azure.Identity` from 1.12.0 to 1.17.0
-- Updating `Microsoft.ApplicationInsights.PerfCounterCollector` from 2.22.0 to 2.23.0
 - Improved idempotency of service registration calls (#3273)


### PR DESCRIPTION
Bumps `Microsoft.Azure.Functions.Worker.ApplicationInsights` to 2.51.0 to publish the following changes:

- Improved idempotency of service registration calls (#3273)