### PR TITLE
ci: update to 1es-ubuntu-24.04-min

### DIFF
--- a/eng/ci/host/official-release.yml
+++ b/eng/ci/host/official-release.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -46,7 +46,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,18 +1,3 @@
-# Runtime parameters (visible in UI)
-parameters:
-- name: UseCoreToolsBuildFromIntegrationTests
-  displayName: UseCoreToolsBuildFromIntegrationTests
-  type: boolean
-  default: false
-- name: CORE_TOOLS_URL
-  displayName: CORE_TOOLS_URL
-  type: string
-  default: ' '
-- name: CORE_TOOLS_URL_LINUX
-  displayName: CORE_TOOLS_URL_LINUX
-  type: string
-  default: ' '
-
 trigger:
   batch: true
   branches:
@@ -38,8 +23,6 @@ variables:
   - template: ci/variables/build.yml@eng
   - template: ci/variables/cfs.yml@eng
   - template: /eng/ci/templates/variables/build.yml@self
-  - name: UseCoreToolsBuildFromIntegrationTests
-    value: ${{ parameters.UseCoreToolsBuildFromIntegrationTests }}
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es

--- a/eng/ci/official-release.yml
+++ b/eng/ci/official-release.yml
@@ -93,7 +93,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -47,7 +47,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -1,20 +1,3 @@
-# This build is used for public PR and CI builds.
-
-# Runtime parameters (visible in UI)
-parameters:
-- name: UseCoreToolsBuildFromIntegrationTests
-  displayName: UseCoreToolsBuildFromIntegrationTests
-  type: boolean
-  default: false
-- name: CORE_TOOLS_URL
-  displayName: CORE_TOOLS_URL
-  type: string
-  default: ' '
-- name: CORE_TOOLS_URL_LINUX
-  displayName: CORE_TOOLS_URL_LINUX
-  type: string
-  default: ' '
-
 trigger:
   batch: true
   branches:
@@ -39,8 +22,6 @@ resources:
 
 variables:
   - template: /eng/ci/templates/variables/build.yml@self
-  - name: UseCoreToolsBuildFromIntegrationTests
-    value: ${{ parameters.UseCoreToolsBuildFromIntegrationTests }}
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es

--- a/eng/ci/templates/jobs/run-integration-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-integration-tests-linux.yml
@@ -30,7 +30,6 @@ jobs:
   - template: /eng/ci/templates/steps/setup-e2e-tests.yml@self
     parameters:
       DotnetVersion: 'net8'
-      UseCoreToolsBuild: $(UseCoreToolsBuildFromIntegrationTests)
       SkipCosmosDBEmulator: true
       SkipBuildOnPack: true
 

--- a/eng/ci/templates/jobs/run-integration-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-integration-tests-linux.yml
@@ -8,7 +8,7 @@ jobs:
 
   pool:
     name: ${{ parameters.poolName }}
-    image: 1es-ubuntu-22.04
+    image: 1es-ubuntu-24.04-min
     os: linux
     ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
       demands:

--- a/eng/ci/templates/jobs/run-integration-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-integration-tests-windows.yml
@@ -22,10 +22,6 @@ jobs:
       - Priority -equals Low
 
   steps:
-
-  - pwsh: . "tools/start-emulators.ps1" -NoWait
-    displayName: "Start emulators (NoWait)"
-
   - template: /eng/ci/templates/steps/install-dotnet.yml@self
 
   - task: DotNetCoreCLI@2
@@ -40,7 +36,6 @@ jobs:
   - template: /eng/ci/templates/steps/setup-e2e-tests.yml@self
     parameters:
       DotnetVersion: $(dotnetVersion)
-      UseCoreToolsBuild: $(UseCoreToolsBuildFromIntegrationTests)
       SkipBuildOnPack: true
 
   - task: DotNetCoreCLI@2

--- a/eng/ci/templates/jobs/run-unit-tests.yml
+++ b/eng/ci/templates/jobs/run-unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
   strategy:
     matrix:
       linux:
-        imageName: '1es-ubuntu-22.04'
+        imageName: '1es-ubuntu-24.04-min'
         osName: 'linux'
       windows:
         imageName: '1es-windows-2022'

--- a/eng/ci/templates/jobs/run-unit-tests.yml
+++ b/eng/ci/templates/jobs/run-unit-tests.yml
@@ -44,7 +44,7 @@ jobs:
     displayName: Run Tests
     inputs:
       command: test
-      arguments: -v n
+      arguments: -v m
       projects: |
         **/DotNetWorker.Tests.csproj
         **/DotNetWorker.ApplicationInsights.Tests.csproj
@@ -57,7 +57,7 @@ jobs:
     displayName: Extension Tests
     inputs:
       command: test
-      arguments: -v n
+      arguments: -v m
       projects: |
         **/Worker.Extensions.Http.AspNetCore.Tests.csproj
         **/Worker.Extensions.Rpc.Tests.csproj

--- a/eng/ci/templates/pipelines/release-extension-packages.yml
+++ b/eng/ci/templates/pipelines/release-extension-packages.yml
@@ -24,7 +24,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/templates/steps/setup-e2e-tests.yml
+++ b/eng/ci/templates/steps/setup-e2e-tests.yml
@@ -2,9 +2,6 @@ parameters:
   - name: DotnetVersion
     type: string
     default: 'net7'
-  - name: UseCoreToolsBuild
-    type: string
-    default: 'False'
   - name: SkipStorageEmulator
     type: boolean
     default: false
@@ -23,6 +20,21 @@ steps:
 - ${{ if not(parameters.SkipCoreTools) }}:
   - template: /eng/ci/templates/steps/install-core-tools.yml@self
 
+- ${{ if not(parameters.SkipStorageEmulator) }}:
+  - task: UseNode@1
+    inputs:
+      version: 26.x
+
+  - script: |
+      start "" /B npx.cmd --yes azurite --silent --inMemoryPersistence
+    displayName: Start azurite (Windows)
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+  - script: |
+      npx --yes azurite --silent --inMemoryPersistence </dev/null >/dev/null 2>&1 &
+    displayName: Start azurite (Linux)
+    condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT'))
+
 - task: PowerShell@2
   displayName: 'Setup E2E tests'
   inputs:
@@ -30,9 +42,8 @@ steps:
     filePath: setup-e2e-tests.ps1
     arguments: >
       -DotnetVersion ${{ parameters.DotnetVersion }}
-      -SkipStorageEmulator:$${{ parameters.SkipStorageEmulator }}
       -SkipCosmosDBEmulator:$${{ parameters.SkipCosmosDBEmulator }}
-      -UseCoreToolsBuildFromIntegrationTests:$${{ parameters.UseCoreToolsBuild }}
       -SkipBuildOnPack:$${{ parameters.SkipBuildOnPack }}
+      -SkipStorageEmulator
       -SkipCoreTools
     pwsh: true

--- a/extensions/Worker.Extensions.Shared/Exceptions/InvalidBindingSourceException.cs
+++ b/extensions/Worker.Extensions.Shared/Exceptions/InvalidBindingSourceException.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
+++ b/extensions/Worker.Extensions.Shared/Reflection/ParameterBinder.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/extensions/Worker.Extensions.Shared/Reflection/TypeExtensions.cs
+++ b/extensions/Worker.Extensions.Shared/Reflection/TypeExtensions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/test/Azure.Functions.Sdk.Tests/Azure.Functions.Sdk.Tests.csproj
+++ b/test/Azure.Functions.Sdk.Tests/Azure.Functions.Sdk.Tests.csproj
@@ -25,12 +25,12 @@
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
     <PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSBuild.ProjectCreation" Version="16.1.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.15" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNetWorker.ApplicationInsights.Tests/DotNetWorker.ApplicationInsights.Tests.csproj
+++ b/test/DotNetWorker.ApplicationInsights.Tests/DotNetWorker.ApplicationInsights.Tests.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.71" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/test/DotNetWorker.OpenTelemetry.Tests/DotNetWorker.OpenTelemetry.Tests.csproj
+++ b/test/DotNetWorker.OpenTelemetry.Tests/DotNetWorker.OpenTelemetry.Tests.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.71" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNetWorker.Tests/DotNetWorker.Tests.csproj
+++ b/test/DotNetWorker.Tests/DotNetWorker.Tests.csproj
@@ -12,10 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.71" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!--The following packages are primarily needed to support the GrpcFunctionDefinitionTests-->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Tables" Version="1.4.2" />

--- a/test/E2ETests/E2ETests/E2ETests.csproj
+++ b/test/E2ETests/E2ETests/E2ETests.csproj
@@ -13,14 +13,11 @@
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.60.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
@@ -9,20 +9,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.6" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="SmartAnalyzers.RoslynTestKit" Version="5.0.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <!--Transitive packages promoted due to CVEs:-->

--- a/test/Sdk.E2ETests/Sdk.E2ETests.csproj
+++ b/test/Sdk.E2ETests/Sdk.E2ETests.csproj
@@ -21,12 +21,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
+++ b/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
@@ -15,10 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.0" />
@@ -38,7 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="Moq" Version="4.20.71" />
     <!--Transitive packages promoted due to CVEs:-->
@@ -47,10 +43,7 @@
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestUtility/TestFunctionContext.cs
+++ b/test/TestUtility/TestFunctionContext.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         {
         }
 
-        public TestFunctionContext(IReadOnlyDictionary<string, string>? baggage = null)
+        public TestFunctionContext(IReadOnlyDictionary<string, string> baggage = null)
             : this(new TestFunctionDefinition(), new TestFunctionInvocation(baggage: baggage), CancellationToken.None)
         {
         }

--- a/test/TestUtility/TestFunctionInvocation.cs
+++ b/test/TestUtility/TestFunctionInvocation.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -7,13 +8,11 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.Azure.Functions.Worker.Diagnostics;
 
-#nullable enable
-
 namespace Microsoft.Azure.Functions.Worker.Tests
 {
     public class TestFunctionInvocation : FunctionInvocation
     {
-        public TestFunctionInvocation(string id = null, string functionId = null, IReadOnlyDictionary<string, string>? baggage = null)
+        public TestFunctionInvocation(string? id = null, string? functionId = null, IReadOnlyDictionary<string, string>? baggage = null)
         {
             if (id is not null)
             {
@@ -27,18 +26,14 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
             // create/dispose activity to pull off its ID.
             using Activity activity = new Activity("Test").Start();
-            Dictionary<string, string> attributes = new Dictionary<string, string>
+            Dictionary<string, string> attributes = new()
             {
-                { TraceConstants.InternalKeys.FunctionInvocationId, Guid.NewGuid().ToString() },
-                { TraceConstants.InternalKeys.AzFuncLiveLogsSessionId, Guid.NewGuid().ToString() },
+                [TraceConstants.InternalKeys.FunctionInvocationId] = Guid.NewGuid().ToString(),
+                [TraceConstants.InternalKeys.AzFuncLiveLogsSessionId] = Guid.NewGuid().ToString(),
             };
 
-            if (baggage is null)
-            {
-                baggage = ImmutableDictionary<string, string>.Empty;
-            }
-
-            TraceContext = new DefaultTraceContext(activity.Id, Guid.NewGuid().ToString(), attributes, baggage);
+            baggage ??= ImmutableDictionary<string, string>.Empty;
+            TraceContext = new DefaultTraceContext(activity.Id!, Guid.NewGuid().ToString(), attributes, baggage);
         }
 
         public override string Id { get; } = Guid.NewGuid().ToString();

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/Worker.Extensions.Http.AspNetCore.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/Worker.Extensions.Http.AspNetCore.Tests.csproj
@@ -9,14 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
   </ItemGroup>

--- a/test/extensions/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.Rpc</RootNamespace>

--- a/test/extensions/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Rpc.Tests/Worker.Extensions.Rpc.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/extensions/Worker.Extensions.Shared.Tests/Worker.Extensions.Shared.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Shared.Tests/Worker.Extensions.Shared.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/extensions/Worker.Extensions.SignalRService.Tests/Worker.Extensions.SignalRService.Tests.csproj
+++ b/test/extensions/Worker.Extensions.SignalRService.Tests/Worker.Extensions.SignalRService.Tests.csproj
@@ -7,11 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/extensions/Worker.Extensions.Tests/Worker.Extensions.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Tests/Worker.Extensions.Tests.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/extensions/Worker.Extensions.Timer.Tests/Worker.Extensions.Timer.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Timer.Tests/Worker.Extensions.Timer.Tests.csproj
@@ -10,11 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This PR is entirely CI and some test focused changes. No product changes.

- update CI to use `1es-ubuntu-24.04-min`. This image has less dependencies pre-installed on it and more free space.
- refactored azurited in CI to be install/run via `npx` (and no longer via custom pwsh script)
- removed core-tools install params, they were entirely legacy/unused from what I can tell
- updated test sdk & xunit runner packages (was done while exploring test failures, decided to just keep it)
- remove unused coverlet package (part of the package upgrade changes)
- skip net48 unit tests on linux (we no longer have mono on the image)
- fix some build warnings (just misused nullable directives)

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

