### PR TITLE
Update WorkerExtension project generation to net10.0 in SDK

### DIFF
--- a/eng/build/extensionValidationProjectTemplate.txt
+++ b/eng/build/extensionValidationProjectTemplate.txt
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <OutputType>Library</OutputType>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>

--- a/sdk/Sdk/Constants.cs
+++ b/sdk/Sdk/Constants.cs
@@ -42,11 +42,11 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         internal const string IsBatchedKey = "IsBatched";
 
         // NetFramework
-        internal const string NetCoreApp31 = "netcoreapp3.1";
-        internal const string Net80 = "net8.0";
+        internal const string NetCoreApp3_1 = "netcoreapp3.1";
+        internal const string Net10_0 = "net10.0";
         internal const string NetCoreApp = ".NETCoreApp";
-        internal const string NetCoreVersion31 = "v3.1";
-        internal const string NetCoreVersion8 = "v8.0";
+        internal const string NetCoreVersion3_1 = "v3.1";
+        internal const string NetCoreVersion10_0 = "v10.0";
         internal const string AzureFunctionsVersion3 = "v3";
 
         // Binding directions

--- a/sdk/Sdk/ExtensionsCsprojGenerator.cs
+++ b/sdk/Sdk/ExtensionsCsprojGenerator.cs
@@ -46,13 +46,13 @@ namespace Microsoft.Azure.Functions.Worker.Sdk
         internal string GetCsProjContent()
         {
             string extensionReferences = GetExtensionReferences();
-            string targetFramework = Constants.Net80;
+            string targetFramework = Constants.Net10_0;
 
             if (_targetFrameworkIdentifier.Equals(Constants.NetCoreApp, StringComparison.OrdinalIgnoreCase))
             {
-                if (_azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) || _targetFrameworkVersion.Equals(Constants.NetCoreVersion31, StringComparison.OrdinalIgnoreCase))
+                if (_azureFunctionsVersion.StartsWith(Constants.AzureFunctionsVersion3, StringComparison.OrdinalIgnoreCase) || _targetFrameworkVersion.Equals(Constants.NetCoreVersion3_1, StringComparison.OrdinalIgnoreCase))
                 {
-                    targetFramework = Constants.NetCoreApp31;
+                    targetFramework = Constants.NetCoreApp3_1;
                 }
             }
 

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -7,6 +7,7 @@
 ### Microsoft.Azure.Functions.Worker.Sdk 2.0.7
 
 - Reversal of change to suppress generation of functions.metadata file
+- Updated the generated `WorkerExtensions` project to target `net10.0` instead of `net8.0` (#3444)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 

--- a/test/Sdk.Generator.Tests/FunctionMetadata/ExtensionsCsProjGeneratorTests.cs
+++ b/test/Sdk.Generator.Tests/FunctionMetadata/ExtensionsCsProjGeneratorTests.cs
@@ -204,8 +204,8 @@ namespace Microsoft.Azure.Functions.Sdk.Generator.FunctionMetadata.Tests
         {
             return version switch
             {
-                FuncVersion.V3 => new ExtensionsCsprojGenerator(extensions, outputPath, "v3", Constants.NetCoreApp, Constants.NetCoreVersion31),
-                FuncVersion.V4 => new ExtensionsCsprojGenerator(extensions, outputPath, "v4", Constants.NetCoreApp, Constants.NetCoreVersion8),
+                FuncVersion.V3 => new ExtensionsCsprojGenerator(extensions, outputPath, "v3", Constants.NetCoreApp, Constants.NetCoreVersion3_1),
+                FuncVersion.V4 => new ExtensionsCsprojGenerator(extensions, outputPath, "v4", Constants.NetCoreApp, Constants.NetCoreVersion10_0),
                 _ => throw new ArgumentOutOfRangeException(nameof(version)),
             };
         }
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.Functions.Sdk.Generator.FunctionMetadata.Tests
             return @"
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Functions.Sdk.Generator.FunctionMetadata.Tests
 
     <Target Name=""_VerifyTargetFramework"" BeforeTargets=""Build"">
         <!-- It is possible to override our TFM via global properties. This can lead to successful builds, but runtime errors due to incompatible dependencies being brought in. -->
-        <Error Condition=""'$(TargetFramework)' != 'net8.0'"" Text=""The target framework '$(TargetFramework)' must be 'net8.0'. Verify if target framework has been overridden by a global property."" />
+        <Error Condition=""'$(TargetFramework)' != 'net10.0'"" Text=""The target framework '$(TargetFramework)' must be 'net10.0'. Verify if target framework has been overridden by a global property."" />
     </Target>
 </Project>
 ";


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #3444

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

## Summary

Updates the SDK's generated `WorkerExtensions.csproj` to target **net10.0** instead of net8.0 for v4 function apps. .NET 8 reaches end-of-life on **November 10, 2026**.

### Changes

- **`sdk/Sdk/ExtensionsCsprojGenerator.cs`** — the generated `WorkerExtensions.csproj` (v4 apps) now defaults to `net10.0`.
- **`sdk/Sdk/Constants.cs`** — replaced the unused `Net80` constant with `Net100 = "net10.0"`.
- **`test/Sdk.Generator.Tests/FunctionMetadata/ExtensionsCsProjGeneratorTests.cs`** — updated the expected v4 csproj to `net10.0`.
- **`eng/build/extensionValidationProjectTemplate.txt`** — CI extension-validation template bumped net8.0 → net10.0 (matches the exact file called out in #3444).
- **`sdk/release_notes.md`** — added a release note under `Microsoft.Azure.Functions.Worker.Sdk`.

The v3 path (`netcoreapp3.1`) is unchanged.

## 🚫 Blocked

**This PR is blocked pending the rollout of the Functions host.** We must wait until the net10 version of the Functions host has rolled out broadly and customers have migrated, to ensure the generated extension project (net10) is compatible with the host environment they run on. Merging before then risks generating extension projects that customers' hosts cannot load.

Do not merge until host rollout is confirmed.

## Verification

- Built `sdk/Sdk/Sdk.csproj` cleanly (0 warnings/errors).
- Invoked the generator against the built assembly and confirmed v4 emits `<TargetFramework>net10.0</TargetFramework>` (plus the `_VerifyTargetFramework` guard), while v3 still emits `netcoreapp3.1`.

> Note: The full test project doesn't build in this environment due to a pre-existing `MSB3030` issue in two unrelated test resource projects (reproduces on a clean tree), so unit tests should be validated in CI.