### PR TITLE
fix(sdk): redact sensitive info from ZipDeploy logs

### DIFF
--- a/src/Azure.Functions.Sdk/Tasks/Publish/ZipDeploy.cs
+++ b/src/Azure.Functions.Sdk/Tasks/Publish/ZipDeploy.cs
@@ -96,7 +96,7 @@ public sealed class ZipDeploy(IFileSystem fileSystem, DeploymentClient? client =
     private async Task<bool> DeployAsync(DeploymentClient client, CancellationToken cancellation)
     {
         Log.LogMessageFromResources(
-            MessageImportance.High, nameof(Strings.Deploy_BeginPublish), ZipContentsPath, PublishUrl);
+            MessageImportance.High, nameof(Strings.Deploy_BeginPublish), ZipContentsPath, PublishUrl.ToLogSafeString());
 
         using FileSystemStream content = _fileSystem.File.OpenRead(ZipContentsPath);
         ZipDeployRequest request = new(DeploymentUsername, DeploymentPassword, content)
@@ -110,19 +110,19 @@ public sealed class ZipDeploy(IFileSystem fileSystem, DeploymentClient? client =
             DeployStatus state = await client.ZipDeployAsync(request, cancellation);
             if (state is DeployStatus.Success or DeployStatus.PartialSuccess)
             {
-                Log.LogMessageFromResources(nameof(Strings.Deploy_CompletedSuccess), ZipContentsPath, uri, state);
+                Log.LogMessageFromResources(nameof(Strings.Deploy_CompletedSuccess), ZipContentsPath, uri.ToLogSafeString(), state);
                 return true;
             }
             else
             {
-                Log.LogErrorFromResources(nameof(Strings.Deploy_CompletedFailure), ZipContentsPath, uri, state);
+                Log.LogErrorFromResources(nameof(Strings.Deploy_CompletedFailure), ZipContentsPath, uri.ToLogSafeString(), state);
                 return false;
             }
         }
         catch (DeploymentException ex)
         {
             Log.LogErrorFromResources(
-                nameof(Strings.Deploy_Failed), ex.Message, uri, ex.StatusCode, ex.DeployStatus);
+                nameof(Strings.Deploy_Failed), ex.Message, uri.ToLogSafeString(), ex.StatusCode, ex.DeployStatus);
             return false;
         }
     }
@@ -154,13 +154,13 @@ public sealed class ZipDeploy(IFileSystem fileSystem, DeploymentClient? client =
 
         if (!Uri.TryCreate(PublishUrl, UriKind.Absolute, out uri) || !IsHttp(uri))
         {
-            Log.LogErrorFromResources(nameof(Strings.Deploy_InvalidPublishUrl), PublishUrl);
+            Log.LogErrorFromResources(nameof(Strings.Deploy_InvalidPublishUrl), PublishUrl.ToLogSafeString());
             return false;
         }
 
         if (!AllowInsecureRemoteConnections && uri.Scheme == Uri.UriSchemeHttp)
         {
-            Log.LogErrorFromResources(nameof(Strings.Deploy_InsecurePublishUrl), PublishUrl);
+            Log.LogErrorFromResources(nameof(Strings.Deploy_InsecurePublishUrl), PublishUrl.ToLogSafeString());
             return false;
         }
 

--- a/src/Azure.Functions.Sdk/UriLogExtensions.cs
+++ b/src/Azure.Functions.Sdk/UriLogExtensions.cs
@@ -71,7 +71,8 @@ internal static class UriLogExtensions
 
     /// <summary>
     /// Best-effort redaction for values that do not parse as an absolute URI. Removes any
-    /// query string or fragment (which may contain secrets) and any user info component.
+    /// query string or fragment (which may contain secrets) and any user info component
+    /// within an authority.
     /// </summary>
     private static string RedactRawUrl(string url)
     {
@@ -79,13 +80,22 @@ internal static class UriLogExtensions
         int queryOrFragment = url.IndexOfAny(['?', '#']);
         string result = queryOrFragment >= 0 ? url[..queryOrFragment] : url;
 
-        // Strip user info (anything between the "//" authority marker and the "@").
+        // Strip user info only when it appears in the authority.
         int authorityStart = result.IndexOf("//", StringComparison.Ordinal);
-        int start = authorityStart >= 0 ? authorityStart + 2 : 0;
-        int at = result.IndexOf('@', start);
-        if (at >= 0)
+        if (authorityStart >= 0)
         {
-            result = result[..start] + result[(at + 1)..];
+            int start = authorityStart + 2;
+            int authorityEnd = result.IndexOf('/', start);
+            if (authorityEnd < 0)
+            {
+                authorityEnd = result.Length;
+            }
+
+            int at = result.IndexOf('@', start);
+            if (at >= start && at < authorityEnd)
+            {
+                result = result[..start] + result[(at + 1)..];
+            }
         }
 
         return result;

--- a/src/Azure.Functions.Sdk/UriLogExtensions.cs
+++ b/src/Azure.Functions.Sdk/UriLogExtensions.cs
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Azure.Functions.Sdk;
+
+/// <summary>
+/// Extensions for producing log-safe representations of URLs.
+/// </summary>
+/// <remarks>
+/// Deployment/publish URLs can carry secrets - credentials embedded as user info
+/// (<c>https://user:password@host</c>) or tokens in the query string (for example a
+/// SAS <c>?sig=...</c>). Build logs are frequently captured by CI systems and shared,
+/// so those components are stripped before a URL is written to the log.
+/// </remarks>
+internal static class UriLogExtensions
+{
+    extension(Uri? uri)
+    {
+        /// <summary>
+        /// Gets a representation of the URI that is safe to write to build logs. The user
+        /// info (credentials), query string, and fragment are removed because they may
+        /// contain secrets; only the scheme, host, optional port, and path are retained.
+        /// </summary>
+        /// <returns>A redacted URI string, or an empty string when <paramref name="uri"/> is <c>null</c>.</returns>
+        public string ToLogSafeString()
+        {
+            if (uri is null)
+            {
+                return string.Empty;
+            }
+
+            if (!uri.IsAbsoluteUri)
+            {
+                // Relative URIs have no authority, but may still carry a query or fragment;
+                // redact them best-effort so nothing after the path is logged.
+                return RedactRawUrl(uri.ToString());
+            }
+
+            UriBuilder builder = new()
+            {
+                Scheme = uri.Scheme,
+                Host = uri.Host,
+                Port = uri.IsDefaultPort ? -1 : uri.Port,
+                Path = uri.AbsolutePath,
+            };
+
+            return builder.Uri.ToString();
+        }
+    }
+
+    extension(string? url)
+    {
+        /// <summary>
+        /// Gets a representation of the URL string that is safe to write to build logs.
+        /// When the value is an absolute URI the user info, query string, and fragment are
+        /// removed; otherwise a best-effort redaction strips any user info and query/fragment.
+        /// </summary>
+        /// <returns>A redacted URL string.</returns>
+        public string ToLogSafeString()
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return url ?? string.Empty;
+            }
+
+            return Uri.TryCreate(url, UriKind.Absolute, out Uri? uri)
+                ? uri.ToLogSafeString()
+                : RedactRawUrl(url!);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort redaction for values that do not parse as an absolute URI. Removes any
+    /// query string or fragment (which may contain secrets) and any user info component.
+    /// </summary>
+    private static string RedactRawUrl(string url)
+    {
+        // Drop the query and/or fragment, which are the most likely places for secrets.
+        int queryOrFragment = url.IndexOfAny(['?', '#']);
+        string result = queryOrFragment >= 0 ? url[..queryOrFragment] : url;
+
+        // Strip user info (anything between the "//" authority marker and the "@").
+        int authorityStart = result.IndexOf("//", StringComparison.Ordinal);
+        int start = authorityStart >= 0 ? authorityStart + 2 : 0;
+        int at = result.IndexOf('@', start);
+        if (at >= 0)
+        {
+            result = result[..start] + result[(at + 1)..];
+        }
+
+        return result;
+    }
+}

--- a/src/Azure.Functions.Sdk/UriLogExtensions.cs
+++ b/src/Azure.Functions.Sdk/UriLogExtensions.cs
@@ -91,8 +91,10 @@ internal static class UriLogExtensions
                 authorityEnd = result.Length;
             }
 
-            int at = result.IndexOf('@', start);
-            if (at >= start && at < authorityEnd)
+            // The user info ends at the last '@' in the authority; scanning from the end
+            // ensures a password that itself contains an '@' is fully redacted.
+            int at = result.LastIndexOf('@', authorityEnd - 1);
+            if (at >= start)
             {
                 result = result[..start] + result[(at + 1)..];
             }

--- a/src/Azure.Functions.Sdk/ZipDeploy/DeploymentClient.cs
+++ b/src/Azure.Functions.Sdk/ZipDeploy/DeploymentClient.cs
@@ -30,7 +30,7 @@ public partial class DeploymentClient(HttpClient client, Logger? logger = null)
         if (response.Headers.Location is Uri location)
         {
             // If the response contains a location header, we can assume the deployment is asynchronous
-            _logger?.LogMessageFromResources(nameof(Strings.Deploy_AsyncDeployment), location);
+            _logger?.LogMessageFromResources(nameof(Strings.Deploy_AsyncDeployment), location.ToLogSafeString());
             return await PollDeploymentStatusAsync(location, httpRequest.Headers.Authorization, cancellation);
         }
 
@@ -83,7 +83,7 @@ public partial class DeploymentClient(HttpClient client, Logger? logger = null)
 
                 _logger?.LogWarningFromResources(
                     nameof(Strings.Deploy_PollFailure),
-                    location,
+                    location.ToLogSafeString(),
                     ex.StatusCode,
                     retry,
                     RetryCount);

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -7,6 +7,7 @@
 ### Azure.Functions.Sdk <version>
 
 - feat: emit `AZFW0110` warning when the deprecated `FunctionsEnableWorkerIndexing` property is set (#3395)
+- fix: redact sensitive information (credentials and query strings) from ZipDeploy publish logs (#3398)
 - feat: improve implicit package reference behavior (#3409)
   - now respects central package management
   - no longer emits a warning when manually overriding

--- a/test/Azure.Functions.Sdk.Tests/Tasks/Publish/ZipDeployTaskTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/Publish/ZipDeployTaskTests.cs
@@ -164,7 +164,7 @@ public sealed class ZipDeployTaskTests
             LogLevel.Error,
             Strings.Deploy_CompletedFailure,
             TestZipPath,
-            "https://functionapp.scm.test/api/zipdeploy?isAsync=true",
+            "https://functionapp.scm.test/api/zipdeploy",
             status);
     }
 
@@ -193,7 +193,7 @@ public sealed class ZipDeployTaskTests
             LogLevel.Error,
             Strings.Deploy_Failed,
             "Deployment failed: internal error",
-            "https://functionapp.scm.test/api/zipdeploy?isAsync=true",
+            "https://functionapp.scm.test/api/zipdeploy",
             HttpStatusCode.InternalServerError,
             DeployStatus.Failed);
     }
@@ -237,6 +237,36 @@ public sealed class ZipDeployTaskTests
         {
             capturedUri!.PathAndQuery.Should().Contain("api/zipdeploy");
         }
+    }
+
+    #endregion
+
+    #region Execute - Sensitive URL redaction
+
+    [Fact]
+    public void Execute_PublishUrlWithCredentialsAndQuery_RedactsUserInfoAndQueryInLog()
+    {
+        // Arrange - a publish url that embeds credentials as user info and a secret in the query string.
+        const string secretPublishUrl = "https://deployUser:PLACEHOLDER@functionapp.scm.test/?sig=PLACEHOLDER";
+        _fileSystem.AddFile(TestZipPath, new MockFileData("fake zip content"));
+        Mock<DeploymentClient> mockClient = new(MockBehavior.Strict, new HttpClient(), (Microsoft.Build.Utilities.TaskLoggingHelper?)null);
+        mockClient
+            .Setup(c => c.ZipDeployAsync(It.IsAny<ZipDeployRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeployStatus.Failed);
+        using ZipDeploy task = CreateTask(mockClient.Object);
+        task.PublishUrl = secretPublishUrl;
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert - the logged url retains only scheme, host, and path; credentials and query are gone.
+        result.Should().BeFalse();
+        _buildEngine.VerifyLog(
+            LogLevel.Error,
+            Strings.Deploy_CompletedFailure,
+            TestZipPath,
+            "https://functionapp.scm.test/api/zipdeploy",
+            DeployStatus.Failed);
     }
 
     #endregion

--- a/test/Azure.Functions.Sdk.Tests/UriLogExtensionsTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/UriLogExtensionsTests.cs
@@ -191,6 +191,18 @@ public class UriLogExtensionsTests
         result.Should().NotContain("PLACEHOLDER");
     }
 
+    [Fact]
+    public void RedactRawUrl_AuthorityUserInfoWithAtSignInPassword_StripsEntireUserInfo()
+    {
+        // A password containing an '@' must not defeat redaction; the user info ends at
+        // the last '@' in the authority, so nothing before "host" should remain.
+        string result = InvokeRedactRawUrl("//user:P@SSPLACEHOLDER@host/path");
+
+        result.Should().Be("//host/path");
+        result.Should().NotContain("PLACEHOLDER");
+        result.Should().NotContain("P@SS");
+    }
+
     #endregion
 
     private static string InvokeRedactRawUrl(string url)

--- a/test/Azure.Functions.Sdk.Tests/UriLogExtensionsTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/UriLogExtensionsTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Azure.Functions.Sdk.Tests;
+
+public class UriLogExtensionsTests
+{
+    #region Uri overload
+
+    [Fact]
+    public void ToLogSafeString_Uri_StripsUserInfo()
+    {
+        Uri uri = new("https://user:PLACEHOLDER@functionapp.scm.test/api/zipdeploy");
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("https://functionapp.scm.test/api/zipdeploy");
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_StripsQueryString()
+    {
+        Uri uri = new("https://functionapp.scm.test/api/zipdeploy?isAsync=true&sig=PLACEHOLDER");
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("https://functionapp.scm.test/api/zipdeploy");
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_StripsFragment()
+    {
+        Uri uri = new("https://functionapp.scm.test/api/zipdeploy#PLACEHOLDER");
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("https://functionapp.scm.test/api/zipdeploy");
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_StripsUserInfoAndQueryAndFragment()
+    {
+        Uri uri = new("https://user:PLACEHOLDER@functionapp.scm.test/api/zipdeploy?sig=PLACEHOLDER#frag");
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("https://functionapp.scm.test/api/zipdeploy");
+        result.Should().NotContain("PLACEHOLDER");
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_PreservesNonDefaultPort()
+    {
+        Uri uri = new("https://functionapp.scm.test:8443/api/zipdeploy?token=PLACEHOLDER");
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("https://functionapp.scm.test:8443/api/zipdeploy");
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_OmitsDefaultPort()
+    {
+        Uri uri = new("https://functionapp.scm.test:443/api/zipdeploy");
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("https://functionapp.scm.test/api/zipdeploy");
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_PreservesRootPath()
+    {
+        Uri uri = new("https://functionapp.scm.test/");
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("https://functionapp.scm.test/");
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_PreservesHttpScheme()
+    {
+        Uri uri = new("http://user:PLACEHOLDER@functionapp.scm.test/api/zipdeploy?sig=PLACEHOLDER");
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("http://functionapp.scm.test/api/zipdeploy");
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_Null_ReturnsEmpty()
+    {
+        Uri? uri = null;
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToLogSafeString_Uri_Relative_StripsQuery()
+    {
+        Uri uri = new("api/zipdeploy?isAsync=true&sig=PLACEHOLDER", UriKind.Relative);
+
+        string result = uri.ToLogSafeString();
+
+        result.Should().Be("api/zipdeploy");
+        result.Should().NotContain("PLACEHOLDER");
+    }
+
+    #endregion
+
+    #region string overload
+
+    [Fact]
+    public void ToLogSafeString_String_AbsoluteUrl_StripsUserInfoAndQuery()
+    {
+        string url = "https://deployUser:PLACEHOLDER@functionapp.scm.test/?sig=PLACEHOLDER";
+
+        string result = url.ToLogSafeString();
+
+        result.Should().Be("https://functionapp.scm.test/");
+        result.Should().NotContain("PLACEHOLDER");
+    }
+
+    [Fact]
+    public void ToLogSafeString_String_Null_ReturnsEmpty()
+    {
+        string? url = null;
+
+        string result = url.ToLogSafeString();
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToLogSafeString_String_Empty_ReturnsEmpty()
+    {
+        string result = string.Empty.ToLogSafeString();
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToLogSafeString_String_NotAUrl_ReturnedUnchanged()
+    {
+        string url = "not-an-url";
+
+        string result = url.ToLogSafeString();
+
+        result.Should().Be("not-an-url");
+    }
+
+    [Fact]
+    public void ToLogSafeString_String_NonAbsoluteWithCredentialsAndQuery_BestEffortRedaction()
+    {
+        // Missing scheme so it does not parse as an absolute URI; redaction is best-effort.
+        string url = "//user:PLACEHOLDER@functionapp.scm.test/path?sig=PLACEHOLDER";
+
+        string result = url.ToLogSafeString();
+
+        result.Should().Be("//functionapp.scm.test/path");
+        result.Should().NotContain("PLACEHOLDER");
+    }
+
+    #endregion
+}

--- a/test/Azure.Functions.Sdk.Tests/UriLogExtensionsTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/UriLogExtensionsTests.cs
@@ -164,5 +164,41 @@ public class UriLogExtensionsTests
         result.Should().NotContain("PLACEHOLDER");
     }
 
+    [Theory]
+    [InlineData("mailto:user@example.com")]
+    [InlineData("api/@me")]
+    public void RedactRawUrl_NoAuthority_PreservesAtSign(string url)
+    {
+        string result = InvokeRedactRawUrl(url);
+
+        result.Should().Be(url);
+    }
+
+    [Fact]
+    public void RedactRawUrl_AuthorityAtSignInPath_PreservesAtSign()
+    {
+        string result = InvokeRedactRawUrl("//host/api/@me");
+
+        result.Should().Be("//host/api/@me");
+    }
+
+    [Fact]
+    public void RedactRawUrl_AuthorityUserInfo_StripsUserInfo()
+    {
+        string result = InvokeRedactRawUrl("//user:PLACEHOLDER@host/path");
+
+        result.Should().Be("//host/path");
+        result.Should().NotContain("PLACEHOLDER");
+    }
+
     #endregion
+
+    private static string InvokeRedactRawUrl(string url)
+    {
+        System.Reflection.MethodInfo method = typeof(UriLogExtensions).GetMethod(
+            "RedactRawUrl",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+        return (string)method.Invoke(null, new object[] { url })!;
+    }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #3398

Follow-up to the review question on #3387 ([discussion](https://github.com/Azure/azure-functions-dotnet-worker/pull/3387#discussion_r3179482832)): _"Could this potentially log sensitive information? Do we need to sanitize this URL or ensure we're not logging query strings?"_

The concern is valid. Publish/deployment URLs can carry secrets:
- **Credentials** embedded as user info (`https://user:password@host`).
- **Tokens** in the query string (e.g. a SAS `?sig=...`), notably for blob-container / pre-signed scenarios.

These were being written verbatim to build logs (frequently captured by CI systems and shared). I also confirmed that `new Uri(baseUri, relativePath)` **preserves the base URI's user info**, so the resolved deployment URI logged on success/failure would leak embedded credentials even though the query is replaced.

**Fix:** Added `UriLogExtensions.ToLogSafeString()` (`Uri` and `string` overloads) that retains only scheme, host, optional port, and path — stripping user info, query, and fragment (best-effort for values that don't parse as an absolute URI, and for relative URIs). Applied it to every URL log site:
- `ZipDeploy.cs`: `Deploy_BeginPublish`, `Deploy_CompletedSuccess`, `Deploy_CompletedFailure`, `Deploy_Failed`, `Deploy_InvalidPublishUrl`, `Deploy_InsecurePublishUrl`.
- `DeploymentClient.cs`: `Deploy_AsyncDeployment`, `Deploy_PollFailure` (server-provided `Location` header).

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

- New `UriLogExtensionsTests` unit tests cover user-info/query/fragment stripping, non-default vs default ports, http scheme, relative URIs, null/empty, and best-effort redaction of non-absolute strings.
- Added a regression test in `ZipDeployTaskTests` proving credentials and query in `PublishUrl` are redacted from the logged deployment URL.
- Updated two existing `ZipDeployTaskTests` expectations (the logged URL no longer includes the `?isAsync=true` query).
- Test secret placeholders use `PLACEHOLDER` to avoid secret scanning.
- Builds clean on `netstandard2.0` and `net472`; full `Azure.Functions.Sdk.Tests` suite passes on `net472` and `net10.0`.