### PR TITLE
[SignalR] Add serverless auth-refresh binding and ServerlessHub refresh APIs

### DIFF
--- a/extensions/Worker.Extensions.SignalRService/release_notes.md
+++ b/extensions/Worker.Extensions.SignalRService/release_notes.md
@@ -6,4 +6,5 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.SignalRService <version>
 
-- <entry>
+- Added serverless authentication refresh support. Use the new `[SignalRRefreshInput]` binding to refresh a live SignalR client connection's authentication (and application claims) without reconnecting; it binds a `SignalRConnectionInfo` carrying the refreshed access token and `TokenLifetimeSeconds`. .NET isolated hubs can also call `ServerlessHub.RefreshConnectionAuthenticationAsync`/`GetConnectionClaimsAsync` directly.
+- `SignalRConnectionInfo` now includes `TokenLifetimeSeconds` so a refresh-aware client can schedule its refresh before the token expires.

--- a/extensions/Worker.Extensions.SignalRService/src/Hubs/ServerlessHub.cs
+++ b/extensions/Worker.Extensions.SignalRService/src/Hubs/ServerlessHub.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Functions.Worker.SignalRService
         /// <summary>
         /// Gets the current claims for an active connection.
         /// </summary>
-        protected virtual Task<ConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, CancellationToken cancellationToken = default)
+        protected virtual Task<ConnectionClaims> GetConnectionClaimsAsync(string connectionToken, CancellationToken cancellationToken = default)
         {
             return HubContext.GetConnectionClaimsAsync(connectionToken, cancellationToken);
         }

--- a/extensions/Worker.Extensions.SignalRService/src/Hubs/ServerlessHub.cs
+++ b/extensions/Worker.Extensions.SignalRService/src/Hubs/ServerlessHub.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Security.Claims;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Serialization;
 using Microsoft.AspNetCore.SignalR;
@@ -74,6 +77,22 @@ namespace Microsoft.Azure.Functions.Worker.SignalRService
                 Url = negotiateResponse.Url,
                 AccessToken = negotiateResponse.AccessToken,
             });
+        }
+
+        /// <summary>
+        /// Refreshes auth expiration and optional claims for an active connection, then returns a refreshed service access token.
+        /// </summary>
+        protected virtual Task<RefreshConnectionAuthenticationResult> RefreshConnectionAuthenticationAsync(string connectionToken, DateTimeOffset expireTime, IEnumerable<Claim>? claims = null, CancellationToken cancellationToken = default)
+        {
+            return HubContext.RefreshConnectionAuthenticationAsync(connectionToken, expireTime, claims, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the current claims for an active connection.
+        /// </summary>
+        protected virtual Task<ConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, CancellationToken cancellationToken = default)
+        {
+            return HubContext.GetConnectionClaimsAsync(connectionToken, cancellationToken);
         }
 
         [AttributeUsage(AttributeTargets.Class)]

--- a/extensions/Worker.Extensions.SignalRService/src/Models/SignalRConnectionInfo.cs
+++ b/extensions/Worker.Extensions.SignalRService/src/Models/SignalRConnectionInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 namespace Microsoft.Azure.Functions.Worker
@@ -17,5 +17,10 @@ namespace Microsoft.Azure.Functions.Worker
         /// The access token for a client to connect to SignalR service.
         /// </summary>
         public string AccessToken { get; set; }
+
+        /// <summary>
+        /// The access token lifetime in seconds. A refresh-aware client can use this to schedule its next authentication refresh.
+        /// </summary>
+        public int? TokenLifetimeSeconds { get; set; }
     }
 }

--- a/extensions/Worker.Extensions.SignalRService/src/SignalRRefreshInputAttribute.cs
+++ b/extensions/Worker.Extensions.SignalRService/src/SignalRRefreshInputAttribute.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// Refreshes the authentication of a live SignalR client connection without reconnecting and provides a
+    /// <see cref="SignalRConnectionInfo"/> carrying the refreshed access token and its remaining lifetime.
+    /// </summary>
+    public sealed class SignalRRefreshInputAttribute : InputBindingAttribute
+    {
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Azure SignalR connection string.
+        /// </summary>
+        public string? ConnectionStringSetting { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the hub to which the SignalR client is connected.
+        /// </summary>
+        public string? HubName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the connection token of the live client connection to refresh.
+        /// </summary>
+        public string? ConnectionToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new authentication lifetime, in seconds, applied to the connection.
+        /// </summary>
+        public int TokenLifetimeSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user id assigned to the SignalR client.
+        /// </summary>
+        public string? UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the JWT token whose claims will be added to the user claims.
+        /// </summary>
+        public string? IdToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the claim type list used to filter the claims in the <see cref="IdToken"/>.
+        /// </summary>
+        public string[]? ClaimTypeList { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

#### Summary
Adds serverless authentication-refresh support to the .NET isolated SignalR worker extension: a `[SignalRRefreshInput]` binding and `ServerlessHub` refresh APIs to extend a live connection's auth (and claims) without reconnecting.

#### Changes
- New `[SignalRRefreshInput]` input binding (maps to the host `signalRRefresh` binding); binds a `SignalRConnectionInfo` with the refreshed access token and `TokenLifetimeSeconds`.
- `ServerlessHub.RefreshConnectionAuthenticationAsync` / `GetConnectionClaimsAsync` for in-worker use by isolated hubs.
- `SignalRConnectionInfo.TokenLifetimeSeconds` added (advertised at negotiate for refresh scheduling).
- Bumped Management SDK and WebJobs extension dependencies.

#### Dependency
**[DO NOT MERGE]** Requires a `Microsoft.Azure.SignalR.Management` version exposing `RefreshConnectionAuthenticationAsync` / `GetConnectionClaimsAsync`, and the new WebJobs SignalR extension.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
