### PR TITLE
fix(sdk): reliably resolve extension restore sources

### DIFF
--- a/src/Azure.Functions.Sdk/Targets/Extensions/Azure.Functions.Sdk.Extensions.targets
+++ b/src/Azure.Functions.Sdk/Targets/Extensions/Azure.Functions.Sdk.Extensions.targets
@@ -80,9 +80,34 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <WriteExtensionProject Projects="@(_AzureFunctionsTargetFramework)" Packages="@(_ValidatedAzureFunctionPackageReference)" />
   </Target>
 
-  <Target Name="RestoreExtensionProject">
+  <!--
+    Restores the generated extension project. The generated project lives under the intermediate
+    (obj) directory, so we forward the outer project's fully-resolved restore sources to ensure the
+    inner restore uses the exact same feeds (including relative sources and prop-injected
+    RestoreAdditionalProjectSources, which would otherwise resolve against the wrong directory).
+
+    $(_OutputSources) is produced by NuGet's _GetRestoreSettings target. We depend on it explicitly
+    so the value is computed deterministically even when this target runs during build fallback
+    (see _VerifyRestoredFunctionsExtensions) or inside Visual Studio, where the outer Restore did not
+    run in the same MSBuild invocation.
+
+    Even though '$(_OutputSources)' is technically private, it has been stable for many versions of NuGet
+    and is the only way to deterministically forward the outer restore sources to an inner restore. The
+    alternative is to parse the outer project.assets.json, which is brittle and not guaranteed to be stable
+    across versions.
+
+    $(_FunctionsExtensionRestoreSources) is a single override seam. It allows for emergency escape hatch
+    if the behavior is not sufficient for some edge case. It is not intended to be used in normal scenarios,
+    and is not documented.
+  -->
+  <Target Name="RestoreExtensionProject" DependsOnTargets="_GetRestoreSettings">
+    <PropertyGroup>
+      <_FunctionsExtensionRestoreSources Condition="'$(_FunctionsExtensionRestoreSources)' == ''">$(_OutputSources)</_FunctionsExtensionRestoreSources>
+      <_FunctionsExtensionRestoreProps>IsRestoring=true</_FunctionsExtensionRestoreProps>
+      <_FunctionsExtensionRestoreProps Condition="'$(_FunctionsExtensionRestoreSources)' != ''">$(_FunctionsExtensionRestoreProps);RestoreSources=$(_FunctionsExtensionRestoreSources)</_FunctionsExtensionRestoreProps>
+    </PropertyGroup>
     <MSBuild Projects="@(_AzureFunctionsTargetFramework->'%(ProjectFile)')" Targets="Restore"
-      RemoveProperties="$(_AzureFunctionsExtensionRemoveProps)" Properties="IsRestoring=true;RestoreSources=$(_OutputSources)" />
+      RemoveProperties="$(_AzureFunctionsExtensionRemoveProps)" Properties="$(_FunctionsExtensionRestoreProps)" />
     <Touch Files="@(_AzureFunctionsTargetFramework->'%(MarkerFile)')" AlwaysCreate="True" />
   </Target>
 

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -6,6 +6,7 @@
 
 ### Azure.Functions.Sdk <version>
 
+- fix: reliably resolve extension restore sources (#3393)
 - feat: emit `AZFW0110` warning when the deprecated `FunctionsEnableWorkerIndexing` property is set (#3395)
 - feat: improve implicit package reference behavior (#3409)
   - now respects central package management


### PR DESCRIPTION
## Why

The new `Azure.Functions.Sdk` restores the generated extension project (which lives under `obj/`) by forwarding the outer project's fully-resolved NuGet restore sources via `$(_OutputSources)`. Issue #3393 asked whether relying on this NuGet-internal property is reliable and whether there is a better/public way to pass the resolved sources.

**Finding:** there is no public MSBuild property that exposes the *resolved* absolute source list. NuGet only exposes public *inputs* (`RestoreSources`, `RestoreAdditionalProjectSources`, `RestoreConfigFile`); forwarding those raw would be worse, since relative and prop-injected sources would resolve against the generated project's `obj/` directory instead of the real project. `$(_OutputSources)` is the same value NuGet feeds into its own restore graph and has been stable and used by the existing Worker SDK for years.

The real issue was a regression, not the property: `RestoreExtensionProject` used `$(_OutputSources)` but, unlike the old SDK, did not depend on NuGet's `_GetRestoreSettings` target that computes it. It only worked as a side effect of the outer `Restore`. On the build-fallback path (`_VerifyRestoredFunctionsExtensions`) and inside Visual Studio, `_GetRestoreSettings` had not run, so the value was empty and restore sources were silently dropped.

## What

- Add an explicit `DependsOnTargets="_GetRestoreSettings"` to `RestoreExtensionProject` so `$(_OutputSources)` is computed deterministically regardless of how the target is reached (restores parity with the old Worker SDK).
- Route the value through a single override seam, `$(_FunctionsExtensionRestoreSources)`, giving one place to intercept and a customer escape hatch if NuGet ever changes.
- Only apply the `RestoreSources` override when it is non-empty. In practice `_OutputSources` always contains at least nuget.org from the default config; the only genuinely-empty case is an intentional air-gapped setup that clears all package sources and relies on fallback folders. In that case we now skip the override and let the inner project resolve from its own (identical) config chain, rather than passing an empty `RestoreSources`.

## Notes for reviewers

- No hard "error if empty" was added (as floated in the original review thread), because after the `_GetRestoreSettings` fix the only remaining empty case is the legitimate air-gapped one, where an error would be a false positive.
- Validated by running the full `Azure.Functions.Sdk.Tests` integration suite (67 tests, net10.0), including `Target_GenerateFunctionsExtensionProject_NoPackageRefs`, which exercises the build-context path this fixes. All green.

Fixes: #3393

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)