### PR TITLE
fix(grpc): avoid capturing ambient SynchronizationContext in worker stream loops

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -14,4 +14,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Grpc <version>
 
-- <entry>
+- Ensured gRPC worker background stream loops do not capture an ambient SynchronizationContext, preventing a worker hang when the application uses a single-threaded context (e.g. Nito.AsyncEx AsyncContext).

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,4 +14,4 @@
 
 ### Microsoft.Azure.Functions.Worker.Grpc <version>
 
-- Ensured gRPC worker background stream loops do not capture an ambient SynchronizationContext, preventing a worker hang when the application uses a single-threaded context (e.g. Nito.AsyncEx AsyncContext).
+- Ensured gRPC worker background stream loops do not capture an ambient SynchronizationContext, preventing a worker hang when the application uses a single-threaded context (e.g. Nito.AsyncEx AsyncContext). (#3455)

--- a/src/DotNetWorker.Grpc/GrpcWorkerClientFactory.cs
+++ b/src/DotNetWorker.Grpc/GrpcWorkerClientFactory.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Functions.Worker.Grpc
 
                 var eventStream = _grpcClient.EventStream(cancellationToken: token);
 
-                await SendStartStreamMessageAsync(eventStream.RequestStream);
+                await SendStartStreamMessageAsync(eventStream.RequestStream).ConfigureAwait(false);
 
                 _ = StartWriterAsync(eventStream.RequestStream);
                 _ = StartReaderAsync(eventStream.ResponseStream);
@@ -81,24 +81,24 @@ namespace Microsoft.Azure.Functions.Worker.Grpc
                     StartStream = str
                 };
 
-                await requestStream.WriteAsync(startStream);
+                await requestStream.WriteAsync(startStream).ConfigureAwait(false);
             }
 
             public ValueTask SendMessageAsync(StreamingMessage message) => _outputWriter.WriteAsync(message);
 
             private async Task StartWriterAsync(IClientStreamWriter<StreamingMessage> requestStream)
             {
-                await foreach (StreamingMessage rpcWriteMsg in _outputReader.ReadAllAsync())
+                await foreach (StreamingMessage rpcWriteMsg in _outputReader.ReadAllAsync().ConfigureAwait(false))
                 {
-                    await requestStream.WriteAsync(rpcWriteMsg);
+                    await requestStream.WriteAsync(rpcWriteMsg).ConfigureAwait(false);
                 }
             }
 
             private async Task StartReaderAsync(IAsyncStreamReader<StreamingMessage> responseStream)
             {
-                while (await responseStream.MoveNext())
+                while (await responseStream.MoveNext().ConfigureAwait(false))
                 {
-                    await _processor!.ProcessMessageAsync(responseStream.Current);
+                    await _processor!.ProcessMessageAsync(responseStream.Current).ConfigureAwait(false);
                 }
             }
 

--- a/src/DotNetWorker.Grpc/NativeHostIntegration/NativeWorkerClient.cs
+++ b/src/DotNetWorker.Grpc/NativeHostIntegration/NativeWorkerClient.cs
@@ -43,15 +43,15 @@ namespace Microsoft.Azure.Functions.Worker.Grpc.NativeHostIntegration
 
         private async Task ProcessInbound()
         {
-            await foreach (StreamingMessage msg in _inbound.Reader.ReadAllAsync())
+            await foreach (StreamingMessage msg in _inbound.Reader.ReadAllAsync().ConfigureAwait(false))
             {
-                await _messageProcessor.ProcessMessageAsync(msg);
+                await _messageProcessor.ProcessMessageAsync(msg).ConfigureAwait(false);
             }
         }
 
         private async Task ProcessOutbound()
         {
-            await foreach (StreamingMessage msg in _outputChannelReader.ReadAllAsync())
+            await foreach (StreamingMessage msg in _outputChannelReader.ReadAllAsync().ConfigureAwait(false))
             {
                 NativeMethods.SendStreamingMessage(msg);
             }

--- a/test/DotNetWorker.Tests/GrpcWorkerClientContinuationTests.cs
+++ b/test/DotNetWorker.Tests/GrpcWorkerClientContinuationTests.cs
@@ -1,0 +1,221 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Grpc;
+using Microsoft.Azure.Functions.Worker.Grpc.Messages;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+public class GrpcWorkerClientContinuationTests
+{
+    [Fact]
+    public void StartWriterAsyncContinuationDoesNotRequireOriginalSynchronizationContext()
+    {
+        SynchronizationContext originalContext = SynchronizationContext.Current;
+        using var context = new DroppingSingleThreadSynchronizationContext();
+
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+
+            Channel<StreamingMessage> channel = Channel.CreateUnbounded<StreamingMessage>();
+            var outputChannel = new GrpcHostChannel(channel);
+            object client = CreateGrpcWorkerClient(outputChannel);
+            var requestStream = new FakeClientStreamWriter();
+
+            Task writerTask = StartWriterAsync(client, requestStream);
+
+            var firstMessage = new StreamingMessage { RequestId = "1" };
+            var secondMessage = new StreamingMessage { RequestId = "2" };
+
+            Assert.True(channel.Writer.TryWrite(firstMessage));
+            TaskCompletionSource<bool> firstWrite = WaitFor(requestStream.FirstWriteStarted.Task, "The first write did not start.");
+
+            context.Shutdown();
+            firstWrite.SetResult(true);
+
+            Assert.True(channel.Writer.TryWrite(secondMessage));
+            channel.Writer.Complete();
+
+            TaskCompletionSource<bool> secondWrite = WaitFor(requestStream.SecondWriteStarted.Task, "The second write did not start after the context was shut down.");
+            secondWrite.SetResult(true);
+
+            WaitFor(writerTask, "The production write loop did not drain both messages.");
+
+            Assert.Collection(requestStream.WrittenMessages,
+                message => Assert.Same(firstMessage, message),
+                message => Assert.Same(secondMessage, message));
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(originalContext);
+        }
+    }
+
+    private static object CreateGrpcWorkerClient(GrpcHostChannel outputChannel)
+    {
+        Type clientType = typeof(GrpcWorkerClientFactory).GetNestedType("GrpcWorkerClient", BindingFlags.NonPublic);
+        Assert.NotNull(clientType);
+
+        var startupOptions = new GrpcWorkerStartupOptions
+        {
+            HostEndpoint = new Uri("http://localhost:5000"),
+            WorkerId = "test-worker",
+            GrpcMaxMessageLength = 1024
+        };
+
+        object client = Activator.CreateInstance(
+            clientType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object[] { outputChannel, startupOptions, new NoOpMessageProcessor() },
+            culture: null);
+
+        Assert.NotNull(client);
+        return client;
+    }
+
+    private static Task StartWriterAsync(object client, IClientStreamWriter<StreamingMessage> requestStream)
+    {
+        MethodInfo method = client.GetType().GetMethod("StartWriterAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        // This drives the real StartWriterAsync loop; reverting its ConfigureAwait(false) calls makes this test hang/fail.
+        return (Task)method.Invoke(client, new object[] { requestStream });
+    }
+
+    private static T WaitFor<T>(Task<T> task, string message)
+    {
+        Assert.True(task.Wait(TimeSpan.FromSeconds(2)), message);
+        return task.GetAwaiter().GetResult();
+    }
+
+    private static void WaitFor(Task task, string message)
+    {
+        Assert.True(task.Wait(TimeSpan.FromSeconds(2)), message);
+        task.GetAwaiter().GetResult();
+    }
+
+    private sealed class FakeClientStreamWriter : IClientStreamWriter<StreamingMessage>
+    {
+        private readonly List<StreamingMessage> _writtenMessages = new();
+        private readonly object _syncLock = new();
+        private int _writeCount;
+
+        public TaskCompletionSource<TaskCompletionSource<bool>> FirstWriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<TaskCompletionSource<bool>> SecondWriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public WriteOptions WriteOptions { get; set; }
+
+        public IReadOnlyList<StreamingMessage> WrittenMessages
+        {
+            get
+            {
+                lock (_syncLock)
+                {
+                    return _writtenMessages.ToArray();
+                }
+            }
+        }
+
+        public Task CompleteAsync() => Task.CompletedTask;
+
+        public Task WriteAsync(StreamingMessage message)
+        {
+            var write = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int writeCount;
+
+            lock (_syncLock)
+            {
+                _writtenMessages.Add(message);
+                writeCount = ++_writeCount;
+            }
+
+            if (writeCount == 1)
+            {
+                FirstWriteStarted.SetResult(write);
+            }
+            else if (writeCount == 2)
+            {
+                SecondWriteStarted.SetResult(write);
+            }
+
+            return write.Task;
+        }
+    }
+
+    private sealed class NoOpMessageProcessor : IMessageProcessor
+    {
+        public Task ProcessMessageAsync(StreamingMessage request) => Task.CompletedTask;
+    }
+
+    private sealed class DroppingSingleThreadSynchronizationContext : SynchronizationContext, IDisposable
+    {
+        private readonly BlockingCollection<(SendOrPostCallback Callback, object State)> _workItems = new();
+        private readonly Thread _thread;
+        private int _shutdown;
+
+        public DroppingSingleThreadSynchronizationContext()
+        {
+            _thread = new Thread(RunOnDedicatedThread)
+            {
+                IsBackground = true,
+                Name = nameof(DroppingSingleThreadSynchronizationContext)
+            };
+
+            _thread.Start();
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            if (Volatile.Read(ref _shutdown) == 1)
+            {
+                return;
+            }
+
+            try
+            {
+                _workItems.Add((d, state));
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        public void Shutdown()
+        {
+            if (Interlocked.Exchange(ref _shutdown, 1) == 0)
+            {
+                _workItems.CompleteAdding();
+            }
+        }
+
+        public void Dispose()
+        {
+            Shutdown();
+            _thread.Join(TimeSpan.FromSeconds(2));
+            _workItems.Dispose();
+        }
+
+        private void RunOnDedicatedThread()
+        {
+            SetSynchronizationContext(this);
+
+            foreach ((SendOrPostCallback callback, object state) in _workItems.GetConsumingEnumerable())
+            {
+                callback(state);
+            }
+        }
+    }
+}

--- a/test/DotNetWorker.Tests/GrpcWorkerClientContinuationTests.cs
+++ b/test/DotNetWorker.Tests/GrpcWorkerClientContinuationTests.cs
@@ -6,60 +6,82 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Grpc;
 using Microsoft.Azure.Functions.Worker.Grpc.Messages;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Azure.Functions.Worker.Tests;
 
 public class GrpcWorkerClientContinuationTests
 {
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(2);
+
     [Fact]
-    public void StartWriterAsyncContinuationDoesNotRequireOriginalSynchronizationContext()
+    public async Task StartWriterAsyncIncompleteWriteContinuationDoesNotRequireOriginalSynchronizationContext()
     {
-        SynchronizationContext originalContext = SynchronizationContext.Current;
+        using ServiceProvider provider = CreateServiceProvider();
+        GrpcHostChannel outputChannel = provider.GetRequiredService<GrpcHostChannel>();
+        object client = CreateGrpcWorkerClient(outputChannel);
+        var requestStream = new PendingWriteClientStreamWriter();
         using var context = new DroppingSingleThreadSynchronizationContext();
 
-        try
-        {
-            SynchronizationContext.SetSynchronizationContext(context);
+        Task writerTask = StartWriterAsyncWithNoSynchronizationContext(client, requestStream);
 
-            Channel<StreamingMessage> channel = Channel.CreateUnbounded<StreamingMessage>();
-            var outputChannel = new GrpcHostChannel(channel);
-            object client = CreateGrpcWorkerClient(outputChannel);
-            var requestStream = new FakeClientStreamWriter();
+        var firstMessage = new StreamingMessage { RequestId = "1" };
 
-            Task writerTask = StartWriterAsync(client, requestStream);
+        await context.Run(() => Assert.True(outputChannel.Channel.Writer.TryWrite(firstMessage))).WaitAsync(Timeout);
 
-            var firstMessage = new StreamingMessage { RequestId = "1" };
-            var secondMessage = new StreamingMessage { RequestId = "2" };
+        TaskCompletionSource<bool> firstWrite = await WaitForAsync(requestStream.FirstWritePending.Task, "The first write did not start.");
+        WriteRecord firstWriteRecord = requestStream.GetWrite(0);
+        Assert.Same(firstMessage, firstWriteRecord.Message);
+        Assert.Same(context, firstWriteRecord.SynchronizationContext);
 
-            Assert.True(channel.Writer.TryWrite(firstMessage));
-            TaskCompletionSource<bool> firstWrite = WaitFor(requestStream.FirstWriteStarted.Task, "The first write did not start.");
+        context.Shutdown();
+        firstWrite.SetResult(true);
+        outputChannel.Channel.Writer.Complete();
 
-            context.Shutdown();
-            firstWrite.SetResult(true);
+        await WaitForAsync(writerTask, "The production write loop did not complete after the pending write completed.");
+    }
 
-            Assert.True(channel.Writer.TryWrite(secondMessage));
-            channel.Writer.Complete();
+    [Fact]
+    public async Task StartWriterAsyncSecondReadContinuationDoesNotRequireOriginalSynchronizationContext()
+    {
+        using ServiceProvider provider = CreateServiceProvider();
+        GrpcHostChannel outputChannel = provider.GetRequiredService<GrpcHostChannel>();
+        object client = CreateGrpcWorkerClient(outputChannel);
+        var requestStream = new CompletedWriteClientStreamWriter();
+        using var context = new DroppingSingleThreadSynchronizationContext();
 
-            TaskCompletionSource<bool> secondWrite = WaitFor(requestStream.SecondWriteStarted.Task, "The second write did not start after the context was shut down.");
-            secondWrite.SetResult(true);
+        Task writerTask = StartWriterAsyncWithNoSynchronizationContext(client, requestStream);
 
-            WaitFor(writerTask, "The production write loop did not drain both messages.");
+        var firstMessage = new StreamingMessage { RequestId = "1" };
+        var secondMessage = new StreamingMessage { RequestId = "2" };
 
-            Assert.Collection(requestStream.WrittenMessages,
-                message => Assert.Same(firstMessage, message),
-                message => Assert.Same(secondMessage, message));
-        }
-        finally
-        {
-            SynchronizationContext.SetSynchronizationContext(originalContext);
-        }
+        await context.Run(() => Assert.True(outputChannel.Channel.Writer.TryWrite(firstMessage))).WaitAsync(Timeout);
+
+        WriteRecord firstWriteRecord = await WaitForAsync(requestStream.FirstWriteStarted.Task, "The first write did not start.");
+        Assert.Same(firstMessage, firstWriteRecord.Message);
+        Assert.Same(context, firstWriteRecord.SynchronizationContext);
+
+        context.Shutdown();
+        WriteMessageWithNoSynchronizationContext(outputChannel, secondMessage);
+
+        WriteRecord secondWriteRecord = await WaitForAsync(requestStream.SecondWriteStarted.Task, "The second write did not start after the context was shut down.");
+        Assert.Same(secondMessage, secondWriteRecord.Message);
+        Assert.Null(secondWriteRecord.SynchronizationContext);
+
+        await WaitForAsync(writerTask, "The production write loop did not complete after the channel was completed.");
+    }
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.RegisterOutputChannel();
+        return services.BuildServiceProvider();
     }
 
     private static object CreateGrpcWorkerClient(GrpcHostChannel outputChannel)
@@ -85,74 +107,142 @@ public class GrpcWorkerClientContinuationTests
         return client;
     }
 
+    private static Task StartWriterAsyncWithNoSynchronizationContext(object client, IClientStreamWriter<StreamingMessage> requestStream)
+    {
+        SynchronizationContext originalContext = SynchronizationContext.Current;
+
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext(null);
+            Task writerTask = StartWriterAsync(client, requestStream);
+            Assert.False(writerTask.IsCompleted, "The production write loop should park at the first empty channel read.");
+            return writerTask;
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(originalContext);
+        }
+    }
+
     private static Task StartWriterAsync(object client, IClientStreamWriter<StreamingMessage> requestStream)
     {
         MethodInfo method = client.GetType().GetMethod("StartWriterAsync", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
-
-        // This drives the real StartWriterAsync loop; reverting its ConfigureAwait(false) calls makes this test hang/fail.
         return (Task)method.Invoke(client, new object[] { requestStream });
     }
 
-    private static T WaitFor<T>(Task<T> task, string message)
+    private static void WriteMessageWithNoSynchronizationContext(GrpcHostChannel outputChannel, StreamingMessage message)
     {
-        Assert.True(task.Wait(TimeSpan.FromSeconds(2)), message);
-        return task.GetAwaiter().GetResult();
+        SynchronizationContext originalContext = SynchronizationContext.Current;
+
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext(null);
+            Assert.True(outputChannel.Channel.Writer.TryWrite(message));
+            outputChannel.Channel.Writer.Complete();
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(originalContext);
+        }
     }
 
-    private static void WaitFor(Task task, string message)
+    private static async Task<T> WaitForAsync<T>(Task<T> task, string message)
     {
-        Assert.True(task.Wait(TimeSpan.FromSeconds(2)), message);
-        task.GetAwaiter().GetResult();
+        Task completedTask = await Task.WhenAny(task, Task.Delay(Timeout));
+        Assert.True(ReferenceEquals(task, completedTask), message);
+        return await task;
     }
 
-    private sealed class FakeClientStreamWriter : IClientStreamWriter<StreamingMessage>
+    private static async Task WaitForAsync(Task task, string message)
     {
-        private readonly List<StreamingMessage> _writtenMessages = new();
+        Task completedTask = await Task.WhenAny(task, Task.Delay(Timeout));
+        Assert.True(ReferenceEquals(task, completedTask), message);
+        await task;
+    }
+
+    private abstract class RecordingClientStreamWriter : IClientStreamWriter<StreamingMessage>
+    {
+        private readonly List<WriteRecord> _writes = new();
         private readonly object _syncLock = new();
-        private int _writeCount;
 
-        public TaskCompletionSource<TaskCompletionSource<bool>> FirstWriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<WriteRecord> FirstWriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public TaskCompletionSource<TaskCompletionSource<bool>> SecondWriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<WriteRecord> SecondWriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public WriteOptions WriteOptions { get; set; }
-
-        public IReadOnlyList<StreamingMessage> WrittenMessages
-        {
-            get
-            {
-                lock (_syncLock)
-                {
-                    return _writtenMessages.ToArray();
-                }
-            }
-        }
 
         public Task CompleteAsync() => Task.CompletedTask;
 
         public Task WriteAsync(StreamingMessage message)
         {
-            var write = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            WriteRecord record = RecordWrite(message);
+            return WriteCoreAsync(record);
+        }
+
+        public WriteRecord GetWrite(int index)
+        {
+            lock (_syncLock)
+            {
+                return _writes[index];
+            }
+        }
+
+        protected abstract Task WriteCoreAsync(WriteRecord record);
+
+        private WriteRecord RecordWrite(StreamingMessage message)
+        {
+            var record = new WriteRecord(message, SynchronizationContext.Current);
             int writeCount;
 
             lock (_syncLock)
             {
-                _writtenMessages.Add(message);
-                writeCount = ++_writeCount;
+                _writes.Add(record);
+                writeCount = _writes.Count;
             }
 
             if (writeCount == 1)
             {
-                FirstWriteStarted.SetResult(write);
+                FirstWriteStarted.SetResult(record);
             }
             else if (writeCount == 2)
             {
-                SecondWriteStarted.SetResult(write);
+                SecondWriteStarted.SetResult(record);
             }
 
-            return write.Task;
+            return record;
         }
+    }
+
+    private sealed class PendingWriteClientStreamWriter : RecordingClientStreamWriter
+    {
+        private readonly TaskCompletionSource<bool> _firstWrite = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<TaskCompletionSource<bool>> FirstWritePending { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override Task WriteCoreAsync(WriteRecord record)
+        {
+            FirstWritePending.SetResult(_firstWrite);
+            return _firstWrite.Task;
+        }
+    }
+
+    private sealed class CompletedWriteClientStreamWriter : RecordingClientStreamWriter
+    {
+        protected override Task WriteCoreAsync(WriteRecord record) => Task.CompletedTask;
+    }
+
+    private sealed class WriteRecord
+    {
+        public WriteRecord(StreamingMessage message, SynchronizationContext synchronizationContext)
+        {
+            Message = message;
+            SynchronizationContext = synchronizationContext;
+        }
+
+        public StreamingMessage Message { get; }
+
+        public SynchronizationContext SynchronizationContext { get; }
     }
 
     private sealed class NoOpMessageProcessor : IMessageProcessor
@@ -175,6 +265,26 @@ public class GrpcWorkerClientContinuationTests
             };
 
             _thread.Start();
+        }
+
+        public Task Run(Action action)
+        {
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            Post(_ =>
+            {
+                try
+                {
+                    action();
+                    completion.SetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            }, null);
+
+            return completion.Task;
         }
 
         public override void Post(SendOrPostCallback d, object state)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #3454

<!-- The .NET isolated worker's single outbound gRPC write pump can hang
indefinitely (never recovering on its own) when it captures a short-lived,
application-installed single-threaded SynchronizationContext (e.g. Nito.AsyncEx
AsyncContext) that is then disposed; the host eventually fails the invocation
once its configured functionTimeout elapses. -->

### Summary

The worker's single process-level outbound gRPC write pump
(`GrpcWorkerClient.StartWriterAsync`) awaits without `ConfigureAwait(false)`.
Under a specific but real combination of conditions it captures a short-lived,
application-installed single-threaded `SynchronizationContext` (for example
**Nito.AsyncEx `AsyncContext`**). When that context is torn down, the pump's
captured continuation is posted to the now-dead context, silently dropped, and
never resumes. Because this is the **only** outbound pump, the worker stops
sending *all* messages to the host — including `InvocationResponse` — so the
invocation **hangs indefinitely** (the worker never recovers on its own) and
the host eventually fails it once the **configured `functionTimeout`** elapses.

### Root cause

The hang requires four conditions to line up — the missing `ConfigureAwait(false)`
is only one of them, which is why it is intermittent:

1. **Synchronous continuations** — the outbound channel is created with
   `AllowSynchronousContinuations = true` (the SDK default), so a writer can
   resume the pump's parked read-continuation *inline* on the writing thread.
2. **An app single-threaded context** — the outbound gRPC channel is shared by
   both `InvocationResponse` and forwarded `RpcLog` messages. When application
   code runs under a single-threaded, *derived* `SynchronizationContext`
   (e.g. `AsyncContext`) and writes a **log** on that thread, `TryWrite`
   inline-resumes the write pump onto that context.
   - Note: the pump does **not** capture at its first suspension — that happens
     on the thread pool at `ReadAllAsync()` where `Current == null`. Capture
     occurs only *after* the inline resume described here moves the pump onto
     the app context.
3. **No `ConfigureAwait(false)`** — now running on the app context, the pump's
   next `await requestStream.WriteAsync(...)` captures that context as its
   continuation target. (This is what the fix removes.)
4. **The context is disposed first** — the short-lived context completes and is
   disposed before the awaited write finishes. When the write completes, the
   continuation is `Post`-ed to the dead context; the post throws internally and
   is swallowed, so the continuation is physically lost and the pump stalls
   permanently.

Higher log volume from the affected thread increases the probability of the
inline wake-up in (2), which is why the failure is intermittent and correlates
with logging activity.

### Fix

Add `ConfigureAwait(false)` to the awaits in the worker's background stream
loops so continuations resume on the thread pool:

- `GrpcWorkerClientFactory.GrpcWorkerClient`: `StartAsync` →
  `SendStartStreamMessageAsync`; `SendStartStreamMessageAsync` → `WriteAsync`;
  `StartWriterAsync` (channel enumeration + per-message `WriteAsync`);
  `StartReaderAsync` (`MoveNext` + `ProcessMessageAsync`).
- `NativeWorkerClient`: `ProcessInbound` (channel enumeration +
  `ProcessMessageAsync`) and `ProcessOutbound` (channel enumeration).

**Regression safety:** these loops only do channel reads, gRPC stream I/O,
native sends, and message dispatch — none reads `SynchronizationContext.Current`
or thread-static state, so removing the accidental capture is
behavior-preserving and is the intended scheduling for background loops.
`ChannelReaderExtensions.ReadAllAsync` already uses `ConfigureAwait(false)`
internally; the missing piece was the consuming `await foreach` at the call
sites (required on all TFMs since net6.0+ binds the BCL `ReadAllAsync`).
`SendMessageAsync` is a `ValueTask` passthrough with no local await and is
unchanged.

### Tests

Adds `GrpcWorkerClientContinuationTests`, which constructs the real internal
`GrpcWorkerClient` and drives the actual private `StartWriterAsync` under a
single-threaded `SynchronizationContext` that is shut down mid-loop. It
asserts both queued messages still drain. The test **fails (times out) if the
`ConfigureAwait(false)` calls are removed from production**, so it guards
against regression of the exact hang.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
