### PR TITLE
refactor(sdk): expand removed props and pin release config for generated extension project

### DIFF
--- a/src/Azure.Functions.Sdk/Targets/Extensions/Azure.Functions.Sdk.Extensions.props
+++ b/src/Azure.Functions.Sdk/Targets/Extensions/Azure.Functions.Sdk.Extensions.props
@@ -12,7 +12,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project>
 
   <PropertyGroup>
-    <_AzureFunctionsExtensionRemoveProps>TargetFramework;RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;UseCurrentRuntimeIdentifier;WebPublishMethod;PublishProfile;DeployOnBuild;PublishDir;OutDir;OutputPath;ManagePackageVersionsCentrally;</_AzureFunctionsExtensionRemoveProps>
+    <_AzureFunctionsExtensionRemoveProps>TargetFramework;TargetFrameworks;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;UseCurrentRuntimeIdentifier;PublishAot;PublishSingleFile;PublishReadyToRun;WebPublishMethod;PublishProfile;DeployOnBuild;PublishDir;OutDir;OutputPath;BaseIntermediateOutputPath;IntermediateOutputPath;ManagePackageVersionsCentrally;Configuration;Platform;</_AzureFunctionsExtensionRemoveProps>
     <_FunctionsExtensionsJsonName>extensions.json</_FunctionsExtensionsJsonName>
   </PropertyGroup>
 

--- a/src/Azure.Functions.Sdk/Targets/Inner/Azure.Functions.Sdk.Inner.props
+++ b/src/Azure.Functions.Sdk/Targets/Inner/Azure.Functions.Sdk.Inner.props
@@ -15,6 +15,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
     <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+    <Configuration Condition="'$(Configuration)' == ''">release</Configuration>
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -6,6 +6,7 @@
 
 ### Azure.Functions.Sdk <version>
 
+- fix: expand removed properties and pin `Configuration=release` when restoring/resolving the generated extension project (#3399)
 - feat: emit `AZFW0110` warning when the deprecated `FunctionsEnableWorkerIndexing` property is set (#3395)
 - feat: improve implicit package reference behavior (#3409)
   - now respects central package management


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #3399

The generated `azure_functions.g.csproj` represents the Functions host (fixed `net8.0`, its own `obj`/output), not the worker. When the SDK invokes `Restore` and `ResolveFunctionsExtensionFiles` on it, MSBuild forwards the outer project's global properties to the inner build by default, so `_AzureFunctionsExtensionRemoveProps` strips the ones that would break that isolation. The original list was inherited verbatim from the legacy Worker SDK and had never been audited against newer .NET restore/output knobs.

This scopes the audit to what the inner build actually runs (Restore + resolve only, never Build/Publish) and expands the list accordingly:

* Restore-graph globals: `TargetFrameworks`, `RuntimeIdentifiers` (only the singular forms were stripped before), and `PublishAot` (injects a RID + ILCompiler package into the restore graph).
* Obj/output redirects: `BaseIntermediateOutputPath`, `IntermediateOutputPath` (a stray global would collide with the computed `obj/azure_functions*` path), plus `Platform`.
* `Configuration` is now stripped from the outer and defaulted to `release` locally in `Azure.Functions.Sdk.Inner.props`, mirroring exactly how `TargetFramework` is handled (removed from the outer, declared on the inner). This keeps the inner obj/output layout stable regardless of the outer build configuration, restoring the behavior the legacy SDK got by forcing `Configuration=Release`.

Deliberately **not** added: `PublishTrimmed` and the existing publish-only entries (`PublishSingleFile`, `PublishReadyToRun`, etc.) only engage during Build/Publish, which we never invoke on the generated project. The pre-existing ones are left in place as cheap insurance in case a future change starts building the inner project.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

No test was added in this change. The property classifications are reasoned from the inner build's target dependencies (`ResolveReferences;GenerateBuildDependencyFile;GetCopyToOutputDirectoryItems`) rather than empirically proven. A follow-up isolation test that restores/resolves the generated project with each hostile global set (for example `-p:BaseIntermediateOutputPath=...`, `-p:RuntimeIdentifiers=...`) and asserts it still lands on `net8.0` in `obj/azure_functions*` would lock the denylist against future rot; happy to add it if desired.