### PR TITLE
fix(sdk): remove implicit Worker package reference

### DIFF
--- a/docs/sdk-rules/AZFW0111.md
+++ b/docs/sdk-rules/AZFW0111.md
@@ -1,0 +1,49 @@
+# AZFW0111: Azure Functions worker package not referenced
+
+| Item | Value |
+| - | - |
+| **Rule ID** | AZFW0111 |
+| **Category** | Sdk |
+| **Severity** | Warning |
+
+## Cause
+
+After restore, no `Microsoft.Azure.Functions.Worker.Core` assembly was found in the project's resolved
+package graph.
+
+## Rule Description
+
+Earlier versions of `Azure.Functions.Sdk` added `Microsoft.Azure.Functions.Worker` as an *implicit*
+direct package reference. Because it was a direct reference, NuGet pinned it to the SDK-provided version
+and silently downgraded higher versions requested by transitive dependencies (for example, OpenTelemetry
+integration packages). The version mismatch was not reported at restore, but caused runtime failures such
+as `System.MissingMethodException`.
+
+The SDK no longer adds this implicit reference. Instead, the worker package must be referenced by the
+project — directly or through a package that depends on it — so NuGet resolves the highest version the
+dependency graph requires. This target validates that a worker package is present after restore and warns
+when it is missing.
+
+## How to Fix
+
+Add a reference to `Microsoft.Azure.Functions.Worker` (or a package that depends on it, such as
+`Microsoft.Azure.Functions.Worker.Grpc`):
+
+```diff
+  <ItemGroup>
++   <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+  </ItemGroup>
+```
+
+## When to Suppress Warnings
+
+Suppress this warning only if the project intentionally does not produce a runnable Azure Functions app
+(for example, a shared library that is consumed by a function app). Suppress it by adding `AZFW0111` to
+`NoWarn`:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);AZFW0111</NoWarn>
+</PropertyGroup>
+```

--- a/docs/sdk-rules/index.md
+++ b/docs/sdk-rules/index.md
@@ -15,3 +15,4 @@ Rules emitted by [Azure.Functions.Sdk](../../src/Azure.Functions.Sdk/README.md) 
 | [AZFW0108](AZFW0108.md) | ExtensionsNotRestored | Warning | Extension bundle was not restored prior to build. |
 | [AZFW0109](AZFW0109.md) | GeneratedProjectShouldNotBeBuilt | Warning | The generated `azure_functions.g.csproj` is being built directly. |
 | [AZFW0110](AZFW0110.md) | FunctionsEnableWorkerIndexingDeprecated | Warning | The `FunctionsEnableWorkerIndexing` property is deprecated and has no effect. |
+| [AZFW0111](AZFW0111.md) | WorkerPackageNotReferenced | Warning | No Azure Functions worker package was found after restore. |

--- a/src/Azure.Functions.Sdk/LogMessage.cs
+++ b/src/Azure.Functions.Sdk/LogMessage.cs
@@ -78,6 +78,12 @@ internal readonly struct LogMessage
         = new(nameof(Strings.AZFW0110_Warning_FunctionsEnableWorkerIndexingDeprecated));
 
     /// <summary>
+    /// Log message for when the Azure Functions worker package is not available after restore.
+    /// </summary>
+    public static readonly LogMessage Warning_WorkerPackageNotReferenced
+        = new(nameof(Strings.AZFW0111_Warning_WorkerPackageNotReferenced));
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="LogMessage"/> struct.
     /// Parses the <see cref="Level"/> and <see cref="Code"/> properties from the given <paramref name="id"/>.
     /// LogMessages must:
@@ -167,6 +173,7 @@ internal readonly struct LogMessage
             nameof(Warning_ExtensionsNotRestored) => Warning_ExtensionsNotRestored,
             nameof(Warning_GeneratedProjectShouldNotBeBuilt) => Warning_GeneratedProjectShouldNotBeBuilt,
             nameof(Warning_FunctionsEnableWorkerIndexingDeprecated) => Warning_FunctionsEnableWorkerIndexingDeprecated,
+            nameof(Warning_WorkerPackageNotReferenced) => Warning_WorkerPackageNotReferenced,
             _ => throw new ArgumentException($"Log message with id '{id}' not found.", nameof(id)),
         };
     }

--- a/src/Azure.Functions.Sdk/README.md
+++ b/src/Azure.Functions.Sdk/README.md
@@ -14,8 +14,9 @@ Set the `Sdk` attribute on your project's `<Project>` element:
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="[WORKER_VERSION]" />
     <!-- Include extension packages or other packages as necessary. -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="[EXT_VERSION]" />
   </ItemGroup>
 
 </Project>
@@ -24,12 +25,23 @@ Set the `Sdk` attribute on your project's `<Project>` element:
 The SDK automatically provides:
 
 - `Microsoft.NET.Sdk.Worker` (the underlying worker SDK)
-- `Microsoft.Azure.Functions.Worker` package reference
 - `AzureFunctionsVersion` set to `v4`
 - Source generators and analyzers for function metadata
 - Azure Functions tooling integration (`dotnet run` launches the Functions host)
 
-You only need to add your trigger and binding extension packages.
+You need to add a reference to `Microsoft.Azure.Functions.Worker` (the worker runtime) along with your
+trigger and binding extension packages:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="[WORKER_VERSION]" />
+  <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="[EXT_VERSION]" />
+</ItemGroup>
+```
+
+> **Note:** The worker package is referenced explicitly (not implicitly by the SDK) so that NuGet can
+> resolve the highest version required by your dependency graph. If it is missing after restore, the SDK
+> emits [AZFW0111](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/docs/sdk-rules/AZFW0111.md).
 
 ## Migrating from Microsoft.Azure.Functions.Worker.Sdk
 
@@ -60,9 +72,8 @@ To migrate, make the following project file changes:
 
 1. **Change the `Sdk` attribute** from `Microsoft.NET.Sdk` to `Azure.Functions.Sdk/<version>`.
 2. **Remove the `Microsoft.Azure.Functions.Worker.Sdk` package reference** — it is now the SDK itself.
-3. **Remove the `Microsoft.Azure.Functions.Worker` package reference** — it is included implicitly by the SDK.
-4. **Remove `OutputType`** — the worker SDK sets this automatically.
-5. **Remove `AzureFunctionsVersion`** — the SDK defaults to `v4`.
+3. **Remove `OutputType`** — the worker SDK sets this automatically.
+4. **Remove `AzureFunctionsVersion`** — the SDK defaults to `v4`.
 
 ```xml
 <!-- After: Azure.Functions.Sdk -->
@@ -73,6 +84,7 @@ To migrate, make the following project file changes:
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
   </ItemGroup>
 

--- a/src/Azure.Functions.Sdk/Strings.resx
+++ b/src/Azure.Functions.Sdk/Strings.resx
@@ -150,6 +150,9 @@
   <data name="AZFW0110_Warning_FunctionsEnableWorkerIndexingDeprecated" xml:space="preserve">
     <value>The 'FunctionsEnableWorkerIndexing' property is deprecated and no longer has any effect. Worker indexing is always enabled with Azure.Functions.Sdk. Please remove this property from your project.</value>
   </data>
+  <data name="AZFW0111_Warning_WorkerPackageNotReferenced" xml:space="preserve">
+    <value>No Azure Functions worker package was found after restore. Add a package reference to 'Microsoft.Azure.Functions.Worker' (or a package that depends on it) so the worker runtime is available.</value>
+  </data>
   <data name="Deploy_AsyncDeployment" xml:space="preserve">
     <value>Asynchronous deployment. Polling status at {0}</value>
   </data>

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.props
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.props
@@ -27,10 +27,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </ItemGroup>
 
   <ItemGroup>
-    <_FuncSdkPackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Update="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" Condition="Exists('local.settings.json')" />
   </ItemGroup>
 

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
@@ -64,6 +64,21 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       Resource="Error_UsingIncompatibleSdk" Arguments="Microsoft.NET.Sdk.Functions" />
   </Target>
 
+  <!--
+    The Azure Functions worker package is no longer added implicitly. It must be referenced by the
+    project (directly or transitively) so NuGet can resolve the highest version required by the
+    dependency graph. This target runs post-restore (after package assets are resolved) and warns
+    when no 'Microsoft.Azure.Functions.Worker.Core' assembly is present in the resolved closure.
+  -->
+  <Target Name="_ValidateWorkerPackageReference"
+    AfterTargets="ResolvePackageAssets"
+    Condition="'$(DesignTimeBuild)' != 'true'">
+    <PropertyGroup>
+      <_FunctionsHasWorkerCoreReference>@(ResolvedCompileFileDefinitions->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.Azure.Functions.Worker.Core'))</_FunctionsHasWorkerCoreReference>
+    </PropertyGroup>
+    <FuncSdkLog Condition="'$(_FunctionsHasWorkerCoreReference)' != 'true'" Resource="Warning_WorkerPackageNotReferenced" />
+  </Target>
+
   <Target Name="_FunctionsCheckForCoreTools">
     <Exec Command="func --version" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_FuncCliExitCode" />

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -6,11 +6,12 @@
 
 ### Azure.Functions.Sdk <version>
 
+- fix: no longer add `Microsoft.Azure.Functions.Worker` as an implicit package reference, which caused silent version downgrades and runtime `MissingMethodException` failures (#3450)
+  - reference `Microsoft.Azure.Functions.Worker` explicitly in your project
+  - emit `AZFW0111` warning when no worker package is found after restore
 - feat: emit `AZFW0110` warning when the deprecated `FunctionsEnableWorkerIndexing` property is set (#3395)
 - feat: improve implicit package reference behavior (#3409)
   - now respects central package management
-  - no longer emits a warning when manually overriding
-  - update `Microsoft.Azure.Functions.Worker` to `2.52.0`
 - fix: re-generate worker.config.json on publish without build (#3408)
 - fix: Perform atomic write in WriteExtensionProject (#3407)
 - fix: avoid zip-file conflicts (#3406)

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
@@ -314,10 +314,13 @@ public partial class SdkEndToEndTests
     [Fact]
     public void Build_MissingWorkerPackage_Warning()
     {
-        // Arrange - a project without any worker package reference.
+        // Arrange - a project without any worker package reference. A trivial entry point is
+        // provided so the build has something to compile; the worker package is intentionally
+        // absent to trigger the post-restore validation.
         ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
             GetTempCsproj(), targetFramework: "net8.0", includeWorkerPackage: false)
-            .Property("AssemblyName", "MyFunctionApp");
+            .Property("AssemblyName", "MyFunctionApp")
+            .WriteSourceFile("Program.cs", "public class Program { public static void Main() { } }");
 
         // Act
         BuildOutput output = project.Build(restore: true);

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
@@ -322,7 +322,8 @@ public partial class SdkEndToEndTests
         // Act
         BuildOutput output = project.Build(restore: true);
 
-        // Assert - the SDK warns that no worker package was found after restore.
+        // Assert - build succeeds, but the SDK warns that no worker package was found after restore.
+        output.Should().BeSuccessful();
         output.WarningEvents
             .Where(x => x.Code == LogMessage.Warning_WorkerPackageNotReferenced.Code)
             .Should().NotBeEmpty()

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
@@ -312,6 +312,26 @@ public partial class SdkEndToEndTests
     }
 
     [Fact]
+    public void Build_MissingWorkerPackage_Warning()
+    {
+        // Arrange - a project without any worker package reference.
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            GetTempCsproj(), targetFramework: "net8.0", includeWorkerPackage: false)
+            .Property("AssemblyName", "MyFunctionApp");
+
+        // Act
+        BuildOutput output = project.Build(restore: true);
+
+        // Assert - the SDK warns that no worker package was found after restore.
+        output.WarningEvents
+            .Where(x => x.Code == LogMessage.Warning_WorkerPackageNotReferenced.Code)
+            .Should().NotBeEmpty()
+            .And.AllSatisfy(warning => warning.Should()
+                .BeSdkMessage(LogMessage.Warning_WorkerPackageNotReferenced)
+                .And.HaveSender("FuncSdkLog"));
+    }
+
+    [Fact]
     public void Build_FunctionsEnableWorkerIndexing_Deprecated_Warning()
     {
         // Arrange

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Items.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Items.cs
@@ -60,15 +60,15 @@ public partial class SdkEndToEndTests
     {
         // Arrange
         ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
-            GetTempCsproj());
+            GetTempCsproj(), includeWorkerPackage: false);
 
         // Act
         project.TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem>? items);
 
-        // Assert
-        items.Should().ContainSingle(x => x.EvaluatedInclude == "Microsoft.Azure.Functions.Worker")
-            .Which.Should().HaveMetadata("IsImplicitlyDefined", "true");
+        // Assert - the worker package is no longer added implicitly by the SDK.
+        items.Should().NotContain(x => x.EvaluatedInclude == "Microsoft.Azure.Functions.Worker");
 
+        // Analyzers and generators remain implicit (dev-time only, PrivateAssets=all).
         items.Should().ContainSingle(x => x.EvaluatedInclude == "Microsoft.Azure.Functions.Worker.Sdk.Analyzers")
             .Which.Should().HaveMetadata("IsImplicitlyDefined", "true")
             .And.HaveMetadata("PrivateAssets", "all");
@@ -79,47 +79,21 @@ public partial class SdkEndToEndTests
     }
 
     [Fact]
-    public void Item_ExplicitPackageReference_OverridesImplicit()
+    public void Item_WorkerPackageReference_IsNotImplicit()
     {
-        // Arrange
-        string explicitVersion = "99.0.0";
+        // Arrange - the template adds an explicit worker reference by default.
         ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
-            GetTempCsproj())
-            .ItemPackageReference("Microsoft.Azure.Functions.Worker", explicitVersion);
+            GetTempCsproj());
 
         // Act
         project.TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem>? items);
 
-        // Assert - only one entry for Worker (no duplicate = no warning), using explicit version
+        // Assert - the worker reference comes from the project, not the SDK.
         items.Where(x => x.EvaluatedInclude == "Microsoft.Azure.Functions.Worker")
             .Should().ContainSingle()
             .Which.Should()
-            .HaveMetadata("Version", explicitVersion)
+            .HaveMetadata("Version", NugetPackage.Worker.Version)
             .And.NotHaveMetadata("IsImplicitlyDefined");
-    }
-
-    [Fact]
-    public void Item_CpmPackageVersion_OverridesImplicitVersion()
-    {
-        // Arrange
-        string cpmVersion = "99.0.0";
-        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
-            GetTempCsproj(),
-            globalProperties: new Dictionary<string, string>
-            {
-                { "ManagePackageVersionsCentrally", "true" },
-            })
-            .ItemInclude("PackageVersion", "Microsoft.Azure.Functions.Worker",
-                metadata: new Dictionary<string, string?> { { "Version", cpmVersion } });
-
-        // Act
-        project.TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem>? items);
-
-        // Assert
-        items.Should().ContainSingle(x => x.EvaluatedInclude == "Microsoft.Azure.Functions.Worker")
-            .Which.Should()
-            .HaveMetadata("IsImplicitlyDefined", "true")
-            .And.HaveMetadata("Version", cpmVersion);
     }
 
     [Fact]

--- a/test/Azure.Functions.Sdk.Tests/NugetPackage.cs
+++ b/test/Azure.Functions.Sdk.Tests/NugetPackage.cs
@@ -10,6 +10,9 @@ public record NugetPackage(string Name, string Version)
     public static readonly NugetPackage SystemTextJson = new(
         Name: "System.Text.Json", Version: "10.0.1");
 
+    public static readonly NugetPackage Worker = new(
+        Name: "Microsoft.Azure.Functions.Worker", Version: "2.52.0");
+
     public static readonly WorkerPackage ServiceBus = new(
         Name: "Microsoft.Azure.Functions.Worker.Extensions.ServiceBus",
         Version: "5.23.0",

--- a/test/Azure.Functions.Sdk.Tests/ProjectCreatorExtensions.cs
+++ b/test/Azure.Functions.Sdk.Tests/ProjectCreatorExtensions.cs
@@ -67,16 +67,23 @@ internal static class ProjectCreatorExtensions
             string? targetFramework = "net8.0",
             ProjectCollection? projectCollection = null,
             IDictionary<string, string>? globalProperties = null,
+            bool includeWorkerPackage = true,
             Action<ProjectCreator>? configure = null)
         {
-            return ProjectCreator.Create(
+            ProjectCreator project = ProjectCreator.Create(
                 path: path,
                 projectCollection: projectCollection,
                 sdk: "Azure.Functions.Sdk/99.99.99",
                 globalProperties: GetGlobalProperties(globalProperties))
                 .PropertyGroup()
-                .Property("TargetFramework", targetFramework)
-                .CustomAction(configure);
+                .Property("TargetFramework", targetFramework);
+
+            if (includeWorkerPackage)
+            {
+                project.ItemPackageReference(NugetPackage.Worker);
+            }
+
+            return project.CustomAction(configure);
         }
 
         public ProjectCreator NetCoreProject(


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #3450

`Azure.Functions.Sdk` added `Microsoft.Azure.Functions.Worker` as an *implicit direct* `PackageReference`. Because it was a direct reference, NuGet pinned that version and silently downgraded higher versions requested by transitive dependencies (for example, OpenTelemetry integration packages that need a newer `Worker.Core`). The `IsImplicitlyDefined="true"` flag suppressed the usual NU1605 downgrade warning, so the mismatch surfaced only at runtime as a `System.MissingMethodException`.

This PR removes the implicit Worker reference so `Microsoft.Azure.Functions.Worker.Core` flows in transitively and NuGet's "highest wins" rule resolves the version the dependency graph actually requires. Analyzers and generators (dev-time only, `PrivateAssets=all`) intentionally stay implicit since they cause no runtime mismatch.

Because the SDK no longer guarantees a worker package is present, a post-restore guard is added: the new `_ValidateWorkerPackageReference` target runs after `ResolvePackageAssets` and emits the new **AZFW0111** warning when no `Worker.Core` assembly is found in the resolved closure. It runs only on the outer/user project (not the generated extensions project) and is skipped during design-time builds.

**Breaking change for consumers:** function app projects must now reference `Microsoft.Azure.Functions.Worker` explicitly (directly, or transitively via a package that depends on it). Package is in preview, breaking changes are allowed.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation updated in this PR (README, `docs/sdk-rules/AZFW0111.md`, `docs/sdk-rules/index.md`)
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Test coverage:
* Rewrote the implicit-package test to assert Worker is no longer implicit; removed the two obsolete override tests; added `Item_WorkerPackageReference_IsNotImplicit`.
* Added `Build_MissingWorkerPackage_Warning` verifying AZFW0111 fires when no worker package is referenced.
* Template gained an `includeWorkerPackage` toggle (default true) plus a `NugetPackage.Worker` constant.
* Full `Azure.Functions.Sdk.Tests` suite passes on net10.0 (67 integration + 189 unit).