### PR TITLE
feat(sdk): warn to migrate to Azure.Functions.Sdk when targeting net11.0

### DIFF
--- a/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
+++ b/sdk/Sdk/Targets/Microsoft.Azure.Functions.Worker.Sdk.targets
@@ -99,6 +99,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <Message Condition="'$(_AzureFunctionsVersionNotSet)' == 'true'" Importance="normal" Text="AzureFunctionsVersion not configured in the project. Setting AzureFunctionsVersion to '$(_DefaultAzureFunctionsVersion)'." />
     <Warning Condition="'$(CheckEolAzureFunctionsVersion)' == 'true' AND '%(_SelectedFunctionVersion.InSupport)' == 'false'" Text="Azure Functions '%(Identity)' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/azure-functions-retired-versions for more information on the support policy." />
+    <Warning Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' == 'v11.0'" Text="Targeting .NET 11 is not supported by 'Microsoft.Azure.Functions.Worker.Sdk'. Migrate to the 'Azure.Functions.Sdk' MSBuild SDK, which supports .NET 11. See https://www.nuget.org/packages/Azure.Functions.Sdk#readme-body-tab for more information." />
     <Error Condition="'@(_SelectedFunctionVersion)' == ''" Text="The AzureFunctionsVersion value '$(AzureFunctionsVersion)' was not recognized. Allowed values are: @(_FunctionsVersion, ', ')." />
     <Error Condition="'$(_IsFunctionsSdkBuild)' == 'true'" Text="Microsoft.NET.Sdk.Functions package is meant to be used with in-proc function apps. Please remove the reference to this package in isolated function apps." />
     <Error Condition="'$(_ToolingSuffix)' == ''" Text="Invalid combination of TargetFramework and AzureFunctionsVersion is set." />

--- a/sdk/release_notes.md
+++ b/sdk/release_notes.md
@@ -7,6 +7,7 @@
 ### Microsoft.Azure.Functions.Worker.Sdk 2.0.7
 
 - Reversal of change to suppress generation of functions.metadata file
+- Emit a build warning directing users to the `Azure.Functions.Sdk` MSBuild SDK when targeting .NET 11 (#3435)
 
 ### Microsoft.Azure.Functions.Worker.Sdk.Generators <version>
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #3435

Adds a build warning in `Microsoft.Azure.Functions.Worker.Sdk` that fires when a project targets `net11.0` (`.NETCoreApp` / `v11.0`), directing users to migrate to the `Azure.Functions.Sdk` MSBuild SDK, which supports .NET 11. The warning links to the package's NuGet readme. The existing "Invalid combination of TargetFramework and AzureFunctionsVersion" error still fires for net11.0 (no tooling suffix exists), so the build fails with clear migration guidance alongside it.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The MSBuild condition was verified to fire for `net11.0` and remain silent for `net10.0`.