### PR TITLE
Switch CI core tools install to Azure Functions CDN

### DIFF
--- a/eng/ci/templates/steps/install-core-tools.yml
+++ b/eng/ci/templates/steps/install-core-tools.yml
@@ -4,24 +4,34 @@ steps:
     $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
 
     if ($IsWindows) {
-      $os = "win"
+      $os = "Windows"
     }
     elseif ($IsMacOS) {
-      $os = "osx"
+      $os = "MacOS"
     }
     else {
-      $os = "linux"
+      $os = "Linux"
     }
 
-    # Resolve latest v4 version from the CLI feed (no auth required)
+    # Resolve latest v4 version and download URL from the CLI feed (no auth required)
     $cliFeedUrl = "https://functionscdn.azureedge.net/public/cli-feed-v4.json"
     $cliFeed = Invoke-RestMethod -Uri $cliFeedUrl
     $version = $cliFeed.tags.v4.release
     Write-Host "Latest Core Tools version: $version"
 
-    # Download from Azure Functions CDN
-    $fileName = "Azure.Functions.Cli.$os-$arch.$version.zip"
-    $coreToolsUrl = "https://functionscdn.azureedge.net/public/$version/$fileName"
+    $release = $cliFeed.releases.$version
+    if (-not $release) {
+      Write-Error "Could not find release '$version' in the CLI feed"
+      exit 1
+    }
+
+    $asset = $release.coreTools | Where-Object { $_.OS -eq $os -and $_.Architecture -eq $arch }
+    if (-not $asset) {
+      Write-Error "Could not find a Core Tools download for OS '$os' and arch '$arch'"
+      exit 1
+    }
+
+    $coreToolsUrl = $asset.downloadLink
     Write-Host "Downloading Azure Functions Core Tools from $coreToolsUrl"
 
     $zipPath = "$(Agent.TempDirectory)/Azure.Functions.Cli.zip"

--- a/eng/ci/templates/steps/install-core-tools.yml
+++ b/eng/ci/templates/steps/install-core-tools.yml
@@ -13,22 +13,15 @@ steps:
       $os = "linux"
     }
 
-    # GitHub API call for latest release
-    $releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest" -Headers @{ "User-Agent" = "PowerShell" }
-
-    $version = $releaseInfo.tag_name
+    # Resolve latest v4 version from the CLI feed (no auth required)
+    $cliFeedUrl = "https://functionscdn.azureedge.net/public/cli-feed-v4.json"
+    $cliFeed = Invoke-RestMethod -Uri $cliFeedUrl
+    $version = $cliFeed.tags.v4.release
     Write-Host "Latest Core Tools version: $version"
 
-    # Look for zip file matching os and arch
-    $pattern = "Azure\.Functions\.Cli\.$os-$arch\..*\.zip$"
-    $asset = $releaseInfo.assets | Where-Object { $_.name -match $pattern }
-
-    if (-not $asset) {
-      Write-Error "Could not find a Core Tools .zip for OS '$os' and arch '$arch'"
-      exit 1
-    }
-
-    $coreToolsUrl = $asset.browser_download_url
+    # Download from Azure Functions CDN
+    $fileName = "Azure.Functions.Cli.$os-$arch.$version.zip"
+    $coreToolsUrl = "https://functionscdn.azureedge.net/public/$version/$fileName"
     Write-Host "Downloading Azure Functions Core Tools from $coreToolsUrl"
 
     $zipPath = "$(Agent.TempDirectory)/Azure.Functions.Cli.zip"


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Replace GitHub API call (which requires auth and is rate-limited) with the Azure Functions CDN feed. The cli-feed-v4.json endpoint resolves the latest v4 version without authentication, and the zip download also comes from the CDN directly.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
