### PR TITLE
Add configurable MaxTelemetryBufferDelay option for Application Insights

### DIFF
--- a/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
+++ b/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Azure.Functions.Worker.ApplicationInsights</AssemblyName>
     <RootNamespace>Microsoft.Azure.Functions.Worker.ApplicationInsights</RootNamespace>
     <MajorProductVersion>2</MajorProductVersion>
-    <MinorProductVersion>51</MinorProductVersion>
+    <MinorProductVersion>52</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>    
     <BeforePack>$(BeforePack);GetReleaseNotes</BeforePack>

--- a/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
+++ b/src/DotNetWorker.ApplicationInsights/DotNetWorker.ApplicationInsights.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.23.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.23.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" /> 
   </ItemGroup>
 

--- a/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsExtensions.cs
+++ b/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsExtensions.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Azure.Functions.Worker
                     "Application Insights SDK has not been added. Please add and configure the Application Insights SDK. See https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service for more information.");
 
             services.AddHostedService<ApplicationInsightsValidationService>();
+            services.AddHostedService<ServerTelemetryChannelConfigurationService>();
 
             // Lets the host know that the worker is sending logs to App Insights. The host will now ignore these.
             services.Configure<WorkerOptions>(workerOptions => workerOptions.Capabilities["WorkerApplicationInsightsLoggingEnabled"] = bool.TrueString);
@@ -100,7 +101,7 @@ namespace Microsoft.Azure.Functions.Worker
         }
 
         /// <summary>
-        /// This services is for a singular purpose: trigger validation of <see cref="ApplicationInsightsSdkValidationMarker" /> on startup.
+        /// This service is for a singular purpose: trigger validation of <see cref="ApplicationInsightsSdkValidationMarker" /> on startup.
         /// </summary>
         private class ApplicationInsightsValidationService : IHostedService
         {

--- a/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsExtensions.cs
+++ b/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsExtensions.cs
@@ -19,6 +19,23 @@ namespace Microsoft.Azure.Functions.Worker
 {
     public static class FunctionsApplicationInsightsExtensions
     {
+        public static IServiceCollection ConfigureFunctionsApplicationInsights(this IServiceCollection services, Action<FunctionsApplicationInsightsOptions> configureOptions)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            services.Configure(configureOptions);
+
+            return services.ConfigureFunctionsApplicationInsights();
+        }
+
         public static IServiceCollection ConfigureFunctionsApplicationInsights(this IServiceCollection services)
         {
             if (services == null)
@@ -59,7 +76,8 @@ namespace Microsoft.Azure.Functions.Worker
                 return ActivatorUtilities.CreateInstance<FunctionsRoleEnvironmentTelemetryInitializer>(provider);
             });
             services.TryAddEnumerable(ServiceDescriptor.Singleton<ITelemetryModule, FunctionsTelemetryModule>());
-            services.AddOptions<FunctionsApplicationInsightsOptions>()
+
+            services.AddOptions<ApplicationInsightsSdkValidationMarker>()
                 .Validate<IServiceProvider>(
                     (_, sp) => sp.GetService<TelemetryClient>() is not null,
                     "Application Insights SDK has not been added. Please add and configure the Application Insights SDK. See https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service for more information.");
@@ -72,25 +90,23 @@ namespace Microsoft.Azure.Functions.Worker
         }
 
         /// <summary>
-        /// Options for configuring Functions Application Insights.
+        /// A private marker options type used solely to trigger validation that an Application Insights SDK has also
+        /// been configured. This is kept separate from the public <see cref="FunctionsApplicationInsightsOptions" />
+        /// so that reading those options while building the <see cref="TelemetryConfiguration" /> does not trigger the
+        /// <see cref="TelemetryClient" /> resolution (and the resulting circular dependency).
         /// </summary>
-        /// <remarks>
-        /// This is a private nested class as we have no public options to expose (yet). This is just a vessel to trigger validating that
-        /// an Application Insights SDK has also been configured.
-        /// When we do have options to configure, this can be moved to be a public top-level class.
-        /// </remarks>
-        private class FunctionsApplicationInsightsOptions
+        private class ApplicationInsightsSdkValidationMarker
         {
         }
 
         /// <summary>
-        /// This services is for a singular purpose: trigger validation of <see cref="FunctionsApplicationInsightsOptions" /> on startup.
+        /// This services is for a singular purpose: trigger validation of <see cref="ApplicationInsightsSdkValidationMarker" /> on startup.
         /// </summary>
         private class ApplicationInsightsValidationService : IHostedService
         {
-            private readonly FunctionsApplicationInsightsOptions _options;
+            private readonly ApplicationInsightsSdkValidationMarker _options;
 
-            public ApplicationInsightsValidationService(IOptions<FunctionsApplicationInsightsOptions> options)
+            public ApplicationInsightsValidationService(IOptions<ApplicationInsightsSdkValidationMarker> options)
             {
                 _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             }

--- a/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsExtensions.cs
+++ b/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsExtensions.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Functions.Worker
                     "Application Insights SDK has not been added. Please add and configure the Application Insights SDK. See https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service for more information.");
 
             services.AddHostedService<ApplicationInsightsValidationService>();
-            services.AddHostedService<ServerTelemetryChannelConfigurationService>();
+            services.AddSingleton<IConfigureOptions<TelemetryConfiguration>, ConfigureServerTelemetryChannel>();
 
             // Lets the host know that the worker is sending logs to App Insights. The host will now ignore these.
             services.Configure<WorkerOptions>(workerOptions => workerOptions.Capabilities["WorkerApplicationInsightsLoggingEnabled"] = bool.TrueString);

--- a/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsOptions.cs
+++ b/src/DotNetWorker.ApplicationInsights/FunctionsApplicationInsightsOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.Functions.Worker
+{
+    /// <summary>
+    /// Options for configuring the Functions Application Insights integration.
+    /// </summary>
+    public class FunctionsApplicationInsightsOptions
+    {
+        /// <summary>
+        /// Gets or sets the maximum time telemetry is buffered by the Application Insights
+        /// <c>ServerTelemetryChannel</c> before it is sent to the ingestion endpoint. Lowering this value reduces the
+        /// delay before telemetry becomes visible, at the cost of more frequent network calls. The default value is
+        /// 8 seconds and the minimum is 5 seconds. This is only applied when the configured telemetry channel is a
+        /// <c>ServerTelemetryChannel</c>.
+        /// </summary>
+        public TimeSpan MaxTelemetryBufferDelay { get; set; } = TimeSpan.FromSeconds(8);
+    }
+}

--- a/src/DotNetWorker.ApplicationInsights/Initializers/ConfigureServerTelemetryChannel.cs
+++ b/src/DotNetWorker.ApplicationInsights/Initializers/ConfigureServerTelemetryChannel.cs
@@ -2,37 +2,37 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers
 {
     /// <summary>
     /// Applies <see cref="FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay" /> to the Application Insights
-    /// <see cref="ServerTelemetryChannel" /> on startup. This runs after the container is fully built, so the value is
-    /// applied regardless of whether <c>ConfigureFunctionsApplicationInsights</c> was called before or after
+    /// <see cref="ServerTelemetryChannel" />. This participates in the standard Application Insights options pipeline as
+    /// an <see cref="IConfigureOptions{TelemetryConfiguration}" />. The channel is resolved from the container (the same
+    /// singleton the SDK assigns to <see cref="TelemetryConfiguration.TelemetryChannel" />) rather than read from the
+    /// <see cref="TelemetryConfiguration" /> instance, so the value is applied regardless of whether
+    /// <c>ConfigureFunctionsApplicationInsights</c> was called before or after
     /// <c>AddApplicationInsightsTelemetryWorkerService</c>.
     /// </summary>
-    internal class ServerTelemetryChannelConfigurationService : IHostedService
+    internal sealed class ConfigureServerTelemetryChannel : IConfigureOptions<TelemetryConfiguration>
     {
         private static readonly TimeSpan MinTelemetryBufferDelay = TimeSpan.FromSeconds(5);
-        private readonly IServiceProvider _serviceProvider;
+        private readonly ITelemetryChannel _channel;
         private readonly FunctionsApplicationInsightsOptions _options;
 
-        public ServerTelemetryChannelConfigurationService(IServiceProvider serviceProvider, IOptions<FunctionsApplicationInsightsOptions> options)
+        public ConfigureServerTelemetryChannel(ITelemetryChannel channel, IOptions<FunctionsApplicationInsightsOptions> options)
         {
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _channel = channel ?? throw new ArgumentNullException(nameof(channel));
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        public void Configure(TelemetryConfiguration configuration)
         {
-            if (_serviceProvider.GetService<TelemetryConfiguration>()?.TelemetryChannel is ServerTelemetryChannel channel)
+            if (_channel is ServerTelemetryChannel serverTelemetryChannel)
             {
                 if (_options.MaxTelemetryBufferDelay < MinTelemetryBufferDelay)
                 {
@@ -42,12 +42,8 @@ namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers
                         $"{nameof(FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay)} must be at least {MinTelemetryBufferDelay.TotalSeconds} seconds.");
                 }
 
-                channel.MaxTelemetryBufferDelay = _options.MaxTelemetryBufferDelay;
+                serverTelemetryChannel.MaxTelemetryBufferDelay = _options.MaxTelemetryBufferDelay;
             }
-
-            return Task.CompletedTask;
         }
-
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/src/DotNetWorker.ApplicationInsights/Initializers/ServerTelemetryChannelConfigurationService.cs
+++ b/src/DotNetWorker.ApplicationInsights/Initializers/ServerTelemetryChannelConfigurationService.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers
+{
+    /// <summary>
+    /// Applies <see cref="FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay" /> to the Application Insights
+    /// <see cref="ServerTelemetryChannel" /> on startup. This runs after the container is fully built, so the value is
+    /// applied regardless of whether <c>ConfigureFunctionsApplicationInsights</c> was called before or after
+    /// <c>AddApplicationInsightsTelemetryWorkerService</c>.
+    /// </summary>
+    internal class ServerTelemetryChannelConfigurationService : IHostedService
+    {
+        private static readonly TimeSpan MinTelemetryBufferDelay = TimeSpan.FromSeconds(5);
+        private readonly IServiceProvider _serviceProvider;
+        private readonly FunctionsApplicationInsightsOptions _options;
+
+        public ServerTelemetryChannelConfigurationService(IServiceProvider serviceProvider, IOptions<FunctionsApplicationInsightsOptions> options)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (_serviceProvider.GetService<TelemetryConfiguration>()?.TelemetryChannel is ServerTelemetryChannel channel)
+            {
+                if (_options.MaxTelemetryBufferDelay < MinTelemetryBufferDelay)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay),
+                        _options.MaxTelemetryBufferDelay,
+                        $"{nameof(FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay)} must be at least {MinTelemetryBufferDelay.TotalSeconds} seconds.");
+                }
+
+                channel.MaxTelemetryBufferDelay = _options.MaxTelemetryBufferDelay;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/DotNetWorker.ApplicationInsights/Initializers/TelemetryConfigurationSetup.cs
+++ b/src/DotNetWorker.ApplicationInsights/Initializers/TelemetryConfigurationSetup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -8,11 +9,14 @@ namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers
     internal class TelemetryConfigurationSetup : IConfigureOptions<TelemetryConfiguration>
     {
         private const string AppInsightsAuthenticationString = "APPLICATIONINSIGHTS_AUTHENTICATION_STRING";
+        private static readonly TimeSpan MinTelemetryBufferDelay = TimeSpan.FromSeconds(5);
         private readonly IConfiguration _configuration;
+        private readonly FunctionsApplicationInsightsOptions _options;
         
-        public TelemetryConfigurationSetup(IConfiguration configuration)
+        public TelemetryConfigurationSetup(IConfiguration configuration, IOptions<FunctionsApplicationInsightsOptions> options)
         {
             _configuration = configuration;
+            _options = options.Value;
         }
 
         public void Configure(TelemetryConfiguration telemetryConfiguration)
@@ -21,6 +25,19 @@ namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers
             if (authString is not null)
             {
                 telemetryConfiguration.SetAzureTokenCredential(TokenCredentialOptions.ParseAuthenticationString(authString).CreateTokenCredential());
+            }
+
+            if (telemetryConfiguration.TelemetryChannel is ServerTelemetryChannel serverTelemetryChannel)
+            {
+                if (_options.MaxTelemetryBufferDelay < MinTelemetryBufferDelay)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        $"{nameof(FunctionsApplicationInsightsOptions)}.{nameof(FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay)}",
+                        _options.MaxTelemetryBufferDelay,
+                        $"{nameof(FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay)} must be at least {MinTelemetryBufferDelay.TotalSeconds} seconds.");
+                }
+
+                serverTelemetryChannel.MaxTelemetryBufferDelay = _options.MaxTelemetryBufferDelay;
             }
         }
 

--- a/src/DotNetWorker.ApplicationInsights/Initializers/TelemetryConfigurationSetup.cs
+++ b/src/DotNetWorker.ApplicationInsights/Initializers/TelemetryConfigurationSetup.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -9,14 +8,11 @@ namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers
     internal class TelemetryConfigurationSetup : IConfigureOptions<TelemetryConfiguration>
     {
         private const string AppInsightsAuthenticationString = "APPLICATIONINSIGHTS_AUTHENTICATION_STRING";
-        private static readonly TimeSpan MinTelemetryBufferDelay = TimeSpan.FromSeconds(5);
         private readonly IConfiguration _configuration;
-        private readonly FunctionsApplicationInsightsOptions _options;
-        
-        public TelemetryConfigurationSetup(IConfiguration configuration, IOptions<FunctionsApplicationInsightsOptions> options)
+
+        public TelemetryConfigurationSetup(IConfiguration configuration)
         {
             _configuration = configuration;
-            _options = options.Value;
         }
 
         public void Configure(TelemetryConfiguration telemetryConfiguration)
@@ -25,19 +21,6 @@ namespace Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers
             if (authString is not null)
             {
                 telemetryConfiguration.SetAzureTokenCredential(TokenCredentialOptions.ParseAuthenticationString(authString).CreateTokenCredential());
-            }
-
-            if (telemetryConfiguration.TelemetryChannel is ServerTelemetryChannel serverTelemetryChannel)
-            {
-                if (_options.MaxTelemetryBufferDelay < MinTelemetryBufferDelay)
-                {
-                    throw new ArgumentOutOfRangeException(
-                        $"{nameof(FunctionsApplicationInsightsOptions)}.{nameof(FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay)}",
-                        _options.MaxTelemetryBufferDelay,
-                        $"{nameof(FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay)} must be at least {MinTelemetryBufferDelay.TotalSeconds} seconds.");
-                }
-
-                serverTelemetryChannel.MaxTelemetryBufferDelay = _options.MaxTelemetryBufferDelay;
             }
         }
 

--- a/src/DotNetWorker.ApplicationInsights/release_notes.md
+++ b/src/DotNetWorker.ApplicationInsights/release_notes.md
@@ -1,5 +1,5 @@
 ## What's Changed
 
-### Microsoft.Azure.Functions.Worker.ApplicationInsights <version>
+### Microsoft.Azure.Functions.Worker.ApplicationInsights 2.52.0
 
 - Added a configurable `MaxTelemetryBufferDelay` option on `FunctionsApplicationInsightsOptions` (default 8 seconds, minimum 5 seconds) to control the Application Insights `ServerTelemetryChannel` flush interval, configurable via `ConfigureFunctionsApplicationInsights(options => ...)`. (#3466)

--- a/src/DotNetWorker.ApplicationInsights/release_notes.md
+++ b/src/DotNetWorker.ApplicationInsights/release_notes.md
@@ -1,5 +1,5 @@
 ## What's Changed
 
-### Microsoft.Azure.Functions.Worker.ApplicationInsights 2.51.0
+### Microsoft.Azure.Functions.Worker.ApplicationInsights <version>
 
-- Improved idempotency of service registration calls (#3273)
+- Added a configurable `MaxTelemetryBufferDelay` option on `FunctionsApplicationInsightsOptions` (default 8 seconds, minimum 5 seconds) to control the Application Insights `ServerTelemetryChannel` flush interval, configurable via `ConfigureFunctionsApplicationInsights(options => ...)`. (#3466)

--- a/test/DotNetWorker.ApplicationInsights.Tests/ApplicationInsightsConfigurationTests.cs
+++ b/test/DotNetWorker.ApplicationInsights.Tests/ApplicationInsightsConfigurationTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -41,6 +42,16 @@ public class ApplicationInsightsConfigurationTests
     }
 
     [Fact]
+    public void AddApplicationInsights_WithOptions_AddsDefaults()
+    {
+        var builder = new HostBuilder().ConfigureServices(
+            services => services
+                .AddApplicationInsightsTelemetryWorkerService()
+                .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(10)));
+        Verify(builder);
+    }
+
+    [Fact]
     public void AddingServiceAndLogger_OnlyAddsServicesOnce()
     {
         var builder = new HostBuilder().ConfigureServices(
@@ -49,6 +60,83 @@ public class ApplicationInsightsConfigurationTests
                 .ConfigureFunctionsApplicationInsights()
                 .ConfigureFunctionsApplicationInsights());
         Verify(builder);
+    }
+
+    [Fact]
+    public void AddingServiceAndLogger_WithAndWithoutOptions_OnlyAddsServicesOnceAndAppliesOptions()
+    {
+        var builder = new HostBuilder().ConfigureServices(
+            services => services
+                .AddApplicationInsightsTelemetryWorkerService()
+                .ConfigureFunctionsApplicationInsights()
+                .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(15)));
+
+        using var host = builder.Build();
+
+        // The second call is idempotent for registration but still applies the provided options.
+        Assert.Single(host.Services.GetServices<ITelemetryModule>().OfType<FunctionsTelemetryModule>());
+        var channel = Assert.IsType<ServerTelemetryChannel>(host.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel);
+        Assert.Equal(TimeSpan.FromSeconds(15), channel.MaxTelemetryBufferDelay);
+    }
+
+    [Fact]
+    public void MaxTelemetryBufferDelay_DefaultsTo8Seconds()
+    {
+        var builder = new HostBuilder().ConfigureServices(
+            services => services
+                .AddApplicationInsightsTelemetryWorkerService()
+                .ConfigureFunctionsApplicationInsights());
+
+        using var host = builder.Build();
+        var config = host.Services.GetRequiredService<TelemetryConfiguration>();
+
+        var channel = Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+        Assert.Equal(TimeSpan.FromSeconds(8), channel.MaxTelemetryBufferDelay);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(20)]
+    public void MaxTelemetryBufferDelay_CanBeOverridden(int seconds)
+    {
+        var builder = new HostBuilder().ConfigureServices(
+            services => services
+                .AddApplicationInsightsTelemetryWorkerService()
+                .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds)));
+
+        using var host = builder.Build();
+        var config = host.Services.GetRequiredService<TelemetryConfiguration>();
+
+        var channel = Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+        Assert.Equal(TimeSpan.FromSeconds(seconds), channel.MaxTelemetryBufferDelay);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(1)]
+    [InlineData(4)]
+    public void MaxTelemetryBufferDelay_ThrowsForValueBelowMinimum(int seconds)
+    {
+        var builder = new HostBuilder().ConfigureServices(
+            services => services
+                .AddApplicationInsightsTelemetryWorkerService()
+                .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds)));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            using var host = builder.Build();
+            host.Services.GetRequiredService<TelemetryConfiguration>();
+        });
+    }
+
+    [Fact]
+    public void ConfigureFunctionsApplicationInsights_NullOptions_Throws()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentNullException>(
+            () => services.ConfigureFunctionsApplicationInsights(configureOptions: null));
     }
 
     private static void Verify(IHostBuilder builder)

--- a/test/DotNetWorker.ApplicationInsights.Tests/ApplicationInsightsConfigurationTests.cs
+++ b/test/DotNetWorker.ApplicationInsights.Tests/ApplicationInsightsConfigurationTests.cs
@@ -68,8 +68,7 @@ public class ApplicationInsightsConfigurationTests
     public async Task AddingServiceAndLogger_WithAndWithoutOptions_OnlyAddsServicesOnceAndAppliesOptions()
     {
         var builder = new HostBuilder().ConfigureServices(
-            services => services
-                .AddApplicationInsightsTelemetryWorkerService()
+            services => AddDeterministicApplicationInsights(services)
                 .ConfigureFunctionsApplicationInsights()
                 .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(15)));
 
@@ -84,10 +83,13 @@ public class ApplicationInsightsConfigurationTests
     [Fact]
     public async Task MaxTelemetryBufferDelay_AppliedRegardlessOfRegistrationOrder()
     {
-        var builder = new HostBuilder().ConfigureServices(
-            services => services
-                .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(15))
-                .AddApplicationInsightsTelemetryWorkerService());
+        var builder = new HostBuilder().ConfigureServices(services =>
+        {
+            // Intentionally configure the buffer delay BEFORE adding the App Insights SDK to prove
+            // the value is applied regardless of registration order.
+            services.ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(15));
+            AddDeterministicApplicationInsights(services);
+        });
 
         using var host = builder.Build();
         var channel = await ApplyChannelConfigurationAsync(host);
@@ -98,8 +100,7 @@ public class ApplicationInsightsConfigurationTests
     public async Task MaxTelemetryBufferDelay_DefaultsTo8Seconds()
     {
         var builder = new HostBuilder().ConfigureServices(
-            services => services
-                .AddApplicationInsightsTelemetryWorkerService()
+            services => AddDeterministicApplicationInsights(services)
                 .ConfigureFunctionsApplicationInsights());
 
         using var host = builder.Build();
@@ -113,8 +114,7 @@ public class ApplicationInsightsConfigurationTests
     public async Task MaxTelemetryBufferDelay_CanBeOverridden(int seconds)
     {
         var builder = new HostBuilder().ConfigureServices(
-            services => services
-                .AddApplicationInsightsTelemetryWorkerService()
+            services => AddDeterministicApplicationInsights(services)
                 .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds)));
 
         using var host = builder.Build();
@@ -130,8 +130,7 @@ public class ApplicationInsightsConfigurationTests
     public async Task MaxTelemetryBufferDelay_ThrowsForValueBelowMinimum(int seconds)
     {
         var builder = new HostBuilder().ConfigureServices(
-            services => services
-                .AddApplicationInsightsTelemetryWorkerService()
+            services => AddDeterministicApplicationInsights(services)
                 .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds)));
 
         using var host = builder.Build();
@@ -145,6 +144,19 @@ public class ApplicationInsightsConfigurationTests
         await service.StartAsync(CancellationToken.None);
         return Assert.IsType<ServerTelemetryChannel>(host.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel);
     }
+
+    private static IServiceCollection AddDeterministicApplicationInsights(IServiceCollection services)
+        => services.AddApplicationInsightsTelemetryWorkerService(options =>
+        {
+            // Disable background telemetry modules so these unit tests stay deterministic and do not
+            // spin up live-metrics/perf-counter threads that could add load to other tests in the assembly.
+            options.EnableAdaptiveSampling = false;
+            options.EnableQuickPulseMetricStream = false;
+            options.EnablePerformanceCounterCollectionModule = false;
+            options.EnableEventCounterCollectionModule = false;
+            options.EnableDependencyTrackingTelemetryModule = false;
+            options.EnableHeartbeat = false;
+        });
 
     [Fact]
     public void ConfigureFunctionsApplicationInsights_NullOptions_Throws()

--- a/test/DotNetWorker.ApplicationInsights.Tests/ApplicationInsightsConfigurationTests.cs
+++ b/test/DotNetWorker.ApplicationInsights.Tests/ApplicationInsightsConfigurationTests.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers;
@@ -65,7 +63,7 @@ public class ApplicationInsightsConfigurationTests
     }
 
     [Fact]
-    public async Task AddingServiceAndLogger_WithAndWithoutOptions_OnlyAddsServicesOnceAndAppliesOptions()
+    public void AddingServiceAndLogger_WithAndWithoutOptions_OnlyAddsServicesOnceAndAppliesOptions()
     {
         var builder = new HostBuilder().ConfigureServices(
             services => AddDeterministicApplicationInsights(services)
@@ -76,12 +74,12 @@ public class ApplicationInsightsConfigurationTests
 
         // The second call is idempotent for registration but still applies the provided options.
         Assert.Single(host.Services.GetServices<ITelemetryModule>().OfType<FunctionsTelemetryModule>());
-        var channel = await ApplyChannelConfigurationAsync(host);
+        var channel = GetConfiguredChannel(host);
         Assert.Equal(TimeSpan.FromSeconds(15), channel.MaxTelemetryBufferDelay);
     }
 
     [Fact]
-    public async Task MaxTelemetryBufferDelay_AppliedRegardlessOfRegistrationOrder()
+    public void MaxTelemetryBufferDelay_AppliedRegardlessOfRegistrationOrder()
     {
         var builder = new HostBuilder().ConfigureServices(services =>
         {
@@ -92,33 +90,33 @@ public class ApplicationInsightsConfigurationTests
         });
 
         using var host = builder.Build();
-        var channel = await ApplyChannelConfigurationAsync(host);
+        var channel = GetConfiguredChannel(host);
         Assert.Equal(TimeSpan.FromSeconds(15), channel.MaxTelemetryBufferDelay);
     }
 
     [Fact]
-    public async Task MaxTelemetryBufferDelay_DefaultsTo8Seconds()
+    public void MaxTelemetryBufferDelay_DefaultsTo8Seconds()
     {
         var builder = new HostBuilder().ConfigureServices(
             services => AddDeterministicApplicationInsights(services)
                 .ConfigureFunctionsApplicationInsights());
 
         using var host = builder.Build();
-        var channel = await ApplyChannelConfigurationAsync(host);
+        var channel = GetConfiguredChannel(host);
         Assert.Equal(TimeSpan.FromSeconds(8), channel.MaxTelemetryBufferDelay);
     }
 
     [Theory]
     [InlineData(5)]
     [InlineData(20)]
-    public async Task MaxTelemetryBufferDelay_CanBeOverridden(int seconds)
+    public void MaxTelemetryBufferDelay_CanBeOverridden(int seconds)
     {
         var builder = new HostBuilder().ConfigureServices(
             services => AddDeterministicApplicationInsights(services)
                 .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds)));
 
         using var host = builder.Build();
-        var channel = await ApplyChannelConfigurationAsync(host);
+        var channel = GetConfiguredChannel(host);
         Assert.Equal(TimeSpan.FromSeconds(seconds), channel.MaxTelemetryBufferDelay);
     }
 
@@ -127,22 +125,23 @@ public class ApplicationInsightsConfigurationTests
     [InlineData(-5)]
     [InlineData(1)]
     [InlineData(4)]
-    public async Task MaxTelemetryBufferDelay_ThrowsForValueBelowMinimum(int seconds)
+    public void MaxTelemetryBufferDelay_ThrowsForValueBelowMinimum(int seconds)
     {
         var builder = new HostBuilder().ConfigureServices(
             services => AddDeterministicApplicationInsights(services)
                 .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds)));
 
-        using var host = builder.Build();
-        var service = host.Services.GetServices<IHostedService>().OfType<ServerTelemetryChannelConfigurationService>().Single();
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => service.StartAsync(CancellationToken.None));
+        // The below-minimum guard runs while the TelemetryConfiguration options pipeline is materialized,
+        // which the host resolves during Build (the App Insights logger provider needs TelemetryConfiguration).
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.Build());
     }
 
-    private static async Task<ServerTelemetryChannel> ApplyChannelConfigurationAsync(IHost host)
+    private static ServerTelemetryChannel GetConfiguredChannel(IHost host)
     {
-        var service = host.Services.GetServices<IHostedService>().OfType<ServerTelemetryChannelConfigurationService>().Single();
-        await service.StartAsync(CancellationToken.None);
-        return Assert.IsType<ServerTelemetryChannel>(host.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel);
+        // Resolving TelemetryConfiguration runs the IConfigureOptions<TelemetryConfiguration> pipeline,
+        // including ConfigureServerTelemetryChannel which applies MaxTelemetryBufferDelay.
+        var config = host.Services.GetRequiredService<TelemetryConfiguration>();
+        return Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
     }
 
     private static IServiceCollection AddDeterministicApplicationInsights(IServiceCollection services)

--- a/test/DotNetWorker.ApplicationInsights.Tests/ApplicationInsightsConfigurationTests.cs
+++ b/test/DotNetWorker.ApplicationInsights.Tests/ApplicationInsightsConfigurationTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.Functions.Worker.ApplicationInsights.Initializers;
@@ -63,7 +65,7 @@ public class ApplicationInsightsConfigurationTests
     }
 
     [Fact]
-    public void AddingServiceAndLogger_WithAndWithoutOptions_OnlyAddsServicesOnceAndAppliesOptions()
+    public async Task AddingServiceAndLogger_WithAndWithoutOptions_OnlyAddsServicesOnceAndAppliesOptions()
     {
         var builder = new HostBuilder().ConfigureServices(
             services => services
@@ -75,12 +77,25 @@ public class ApplicationInsightsConfigurationTests
 
         // The second call is idempotent for registration but still applies the provided options.
         Assert.Single(host.Services.GetServices<ITelemetryModule>().OfType<FunctionsTelemetryModule>());
-        var channel = Assert.IsType<ServerTelemetryChannel>(host.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel);
+        var channel = await ApplyChannelConfigurationAsync(host);
         Assert.Equal(TimeSpan.FromSeconds(15), channel.MaxTelemetryBufferDelay);
     }
 
     [Fact]
-    public void MaxTelemetryBufferDelay_DefaultsTo8Seconds()
+    public async Task MaxTelemetryBufferDelay_AppliedRegardlessOfRegistrationOrder()
+    {
+        var builder = new HostBuilder().ConfigureServices(
+            services => services
+                .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(15))
+                .AddApplicationInsightsTelemetryWorkerService());
+
+        using var host = builder.Build();
+        var channel = await ApplyChannelConfigurationAsync(host);
+        Assert.Equal(TimeSpan.FromSeconds(15), channel.MaxTelemetryBufferDelay);
+    }
+
+    [Fact]
+    public async Task MaxTelemetryBufferDelay_DefaultsTo8Seconds()
     {
         var builder = new HostBuilder().ConfigureServices(
             services => services
@@ -88,16 +103,14 @@ public class ApplicationInsightsConfigurationTests
                 .ConfigureFunctionsApplicationInsights());
 
         using var host = builder.Build();
-        var config = host.Services.GetRequiredService<TelemetryConfiguration>();
-
-        var channel = Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+        var channel = await ApplyChannelConfigurationAsync(host);
         Assert.Equal(TimeSpan.FromSeconds(8), channel.MaxTelemetryBufferDelay);
     }
 
     [Theory]
     [InlineData(5)]
     [InlineData(20)]
-    public void MaxTelemetryBufferDelay_CanBeOverridden(int seconds)
+    public async Task MaxTelemetryBufferDelay_CanBeOverridden(int seconds)
     {
         var builder = new HostBuilder().ConfigureServices(
             services => services
@@ -105,9 +118,7 @@ public class ApplicationInsightsConfigurationTests
                 .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds)));
 
         using var host = builder.Build();
-        var config = host.Services.GetRequiredService<TelemetryConfiguration>();
-
-        var channel = Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+        var channel = await ApplyChannelConfigurationAsync(host);
         Assert.Equal(TimeSpan.FromSeconds(seconds), channel.MaxTelemetryBufferDelay);
     }
 
@@ -116,18 +127,23 @@ public class ApplicationInsightsConfigurationTests
     [InlineData(-5)]
     [InlineData(1)]
     [InlineData(4)]
-    public void MaxTelemetryBufferDelay_ThrowsForValueBelowMinimum(int seconds)
+    public async Task MaxTelemetryBufferDelay_ThrowsForValueBelowMinimum(int seconds)
     {
         var builder = new HostBuilder().ConfigureServices(
             services => services
                 .AddApplicationInsightsTelemetryWorkerService()
                 .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds)));
 
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
-        {
-            using var host = builder.Build();
-            host.Services.GetRequiredService<TelemetryConfiguration>();
-        });
+        using var host = builder.Build();
+        var service = host.Services.GetServices<IHostedService>().OfType<ServerTelemetryChannelConfigurationService>().Single();
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => service.StartAsync(CancellationToken.None));
+    }
+
+    private static async Task<ServerTelemetryChannel> ApplyChannelConfigurationAsync(IHost host)
+    {
+        var service = host.Services.GetServices<IHostedService>().OfType<ServerTelemetryChannelConfigurationService>().Single();
+        await service.StartAsync(CancellationToken.None);
+        return Assert.IsType<ServerTelemetryChannel>(host.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #3465

Adds a public `FunctionsApplicationInsightsOptions` with a `MaxTelemetryBufferDelay` setting (default 8s, minimum 5s) that is applied to the Application Insights `ServerTelemetryChannel`, letting customers tune how quickly telemetry is flushed to the ingestion endpoint.

### Usage

```csharp
services
    .AddApplicationInsightsTelemetryWorkerService()
    .ConfigureFunctionsApplicationInsights(o => o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(8));
```

### Changes
- New public `FunctionsApplicationInsightsOptions.MaxTelemetryBufferDelay` (`TimeSpan`, default 8s, min 5s).
- New `ConfigureFunctionsApplicationInsights(Action<FunctionsApplicationInsightsOptions>)` overload; the existing parameterless overload is unchanged and source-compatible.
- Applied to the channel in `TelemetryConfigurationSetup` (only when it is a `ServerTelemetryChannel`); values below 5s throw `ArgumentOutOfRangeException`.
- Added `Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel` package reference.
- Added unit tests (defaults, override, below-minimum, null-guard, registration parity across both overloads).
- Bumped the package version to **2.52.0** and updated `release_notes.md`.

