### PR TITLE
Update storage extensions

### DIFF
--- a/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Blob Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>6.8.1</VersionPrefix>
+    <VersionPrefix>6.8.2</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Storage.Blobs" Version="5.3.7" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Storage.Blobs" Version="5.3.8" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
+++ b/extensions/Worker.Extensions.Storage.Blobs/src/Worker.Extensions.Storage.Blobs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs</AssemblyName>

--- a/extensions/Worker.Extensions.Storage.Queues/src/Worker.Extensions.Storage.Queues.csproj
+++ b/extensions/Worker.Extensions.Storage.Queues/src/Worker.Extensions.Storage.Queues.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues</AssemblyName>

--- a/extensions/Worker.Extensions.Storage.Queues/src/Worker.Extensions.Storage.Queues.csproj
+++ b/extensions/Worker.Extensions.Storage.Queues/src/Worker.Extensions.Storage.Queues.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Queue Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>5.5.4</VersionPrefix>
+    <VersionPrefix>5.5.5</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.3.7" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.3.8" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Worker.Extensions.Storage/release_notes.md
+++ b/extensions/Worker.Extensions.Storage/release_notes.md
@@ -4,9 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Worker.Extensions.Storage <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Storage 6.8.2
 
-- <entry>
+- Update `Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues` to `5.5.5`
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs <version>
 

--- a/extensions/Worker.Extensions.Storage/release_notes.md
+++ b/extensions/Worker.Extensions.Storage/release_notes.md
@@ -6,11 +6,12 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage 6.8.2
 
+- Update `Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs` to `6.8.2`
 - Update `Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues` to `5.5.5`
 
-### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs 6.8.2
 
-- <entry>
+- Update `Microsoft.Azure.WebJobs.Extensions.Storage.Blobs` to `5.3.8`
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues 5.5.5
 

--- a/extensions/Worker.Extensions.Storage/release_notes.md
+++ b/extensions/Worker.Extensions.Storage/release_notes.md
@@ -12,6 +12,6 @@
 
 - <entry>
 
-### Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues 5.5.5
 
-- <entry>
+- Update `Microsoft.Azure.WebJobs.Extensions.Storage.Queues` to `5.3.8`

--- a/extensions/Worker.Extensions.Storage/release_notes.md
+++ b/extensions/Worker.Extensions.Storage/release_notes.md
@@ -6,13 +6,13 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage 6.8.2
 
-- Update `Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs` to `6.8.2`
-- Update `Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues` to `5.5.5`
+- Update `Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs` to `6.8.2` (#3470)
+- Update `Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues` to `5.5.5` (#3470)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs 6.8.2
 
-- Update `Microsoft.Azure.WebJobs.Extensions.Storage.Blobs` to `5.3.8`
+- Update `Microsoft.Azure.WebJobs.Extensions.Storage.Blobs` to `5.3.8` (#3470)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues 5.5.5
 
-- Update `Microsoft.Azure.WebJobs.Extensions.Storage.Queues` to `5.3.8`
+- Update `Microsoft.Azure.WebJobs.Extensions.Storage.Queues` to `5.3.8` (#3470)

--- a/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
+++ b/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.Storage</AssemblyName>

--- a/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
+++ b/extensions/Worker.Extensions.Storage/src/Worker.Extensions.Storage.csproj
@@ -6,7 +6,7 @@
     <Description>Azure Storage extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>6.8.1</VersionPrefix>
+    <VersionPrefix>6.8.2</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Update `Microsoft.Azure.WebJobs.Extensions.Storage.Blobs` and `Microsoft.Azure.WebJobs.Extensions.Storage.Queues` from 5.3.7 to 5.3.8.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional Information 

Updating this resulted in local error w/ core-tools `v4.12.1`: 

```
    Microsoft.Azure.WebJobs.Extensions.Storage.Queues: Could not load file or assembly
    'Microsoft.Extensions.Options, Version=10.0.0.0, Culture=neutral,
    PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.
[2026-07-21T21:53:16.958Z] A host error has occurred during startup operation 'b77ede21-...'.
[2026-07-21T21:53:16.958Z] Microsoft.Azure.WebJobs.Script: Error configuring services in an
    external startup class. Microsoft.Azure.WebJobs.Extensions.Storage.Queues: Could not load
    file or assembly 'Microsoft.Extensions.Options, Version=10.0.0.0'...
```

This is b/c 5.3.8 bumps dependencies and core-tools w/ the .NET 10 host has not been released yet. We will need to block this PR until core-tools `4.13.x` is available.