### PR TITLE
Fix: Register RequestAborted cancellation on function completion task

### DIFF
--- a/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsHttpContextExtensions.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/AspNetMiddleware/FunctionsHttpContextExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Http
         {
             var coordinator = context.RequestServices.GetRequiredService<IHttpCoordinator>();
             context.Request.Headers.TryGetValue(Constants.CorrelationHeader, out StringValues invocationId);
-            return coordinator.RunFunctionInvocationAsync(invocationId!); // will fail later if null.
+            return coordinator.RunFunctionInvocationAsync(invocationId!, context.RequestAborted);
         }
     }
 }

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/ContextReference.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/ContextReference.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
@@ -10,6 +11,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
     {
         private readonly TaskCompletionSource<bool> _functionStartTask = new();
         private readonly TaskCompletionSource<bool> _functionCompletionTask = new();
+
+        private CancellationTokenRegistration _cancellationRegistration;
 
         private TaskCompletionSource<HttpContext> _httpContextValueSource = new();
         private TaskCompletionSource<FunctionContext> _functionContextValueSource = new();
@@ -27,14 +30,24 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
 
         public TaskCompletionSource<FunctionContext> FunctionContextValueSource { get => _functionContextValueSource; set => _functionContextValueSource = value; }
 
-        internal Task InvokeFunctionAsync()
+        internal Task InvokeFunctionAsync(CancellationToken cancellationToken)
         {
             _functionStartTask.SetResult(true);
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                _cancellationRegistration = cancellationToken.Register(
+                    static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(),
+                    _functionCompletionTask);
+            }
+
             return _functionCompletionTask.Task;
         }
 
         internal void CompleteFunction()
         {
+            _cancellationRegistration.Dispose();
+
             if (_functionCompletionTask.Task.IsCompleted)
             {
                 return;

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/DefaultHttpCoordinator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Infrastructure;
@@ -124,14 +125,14 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
             }
         }
 
-        public Task RunFunctionInvocationAsync(string invocationId)
+        public Task RunFunctionInvocationAsync(string invocationId, CancellationToken cancellationToken = default)
         {
             if (!_contextReferenceList.TryGetValue(invocationId, out var contextReference))
             {
                 throw new InvalidOperationException($"Context for invocation id '{invocationId}' does not exist.");
             }
 
-            return contextReference.InvokeFunctionAsync();
+            return contextReference.InvokeFunctionAsync(cancellationToken);
         }
 
         // TODO:See about making this not public

--- a/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/IHttpCoordinator.cs
+++ b/extensions/Worker.Extensions.Http.AspNetCore/src/Coordinator/IHttpCoordinator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
@@ -29,8 +30,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore
         /// Signals the Functions middleware pipeline that it can continue with the specified invocation.
         /// </summary>
         /// <param name="invocationId">The invocation id.</param>
+        /// <param name="cancellationToken">Token to cancel the wait when the client disconnects.</param>
         /// <returns>A Task that completes when the function invocation is complete.</returns>
-        public Task RunFunctionInvocationAsync(string invocationId);
+        public Task RunFunctionInvocationAsync(string invocationId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Signals that the function invocation is complete. Allows the ASP.NET middleware pipeline to continue.

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/DefaultHttpCoordinatorTests.cs
@@ -374,6 +374,109 @@ namespace Worker.Extensions.Http.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task RunFunctionInvocationAsync_WhenCancelled_ThrowsTaskCanceledException()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+            var cts = new CancellationTokenSource();
+
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+
+            // Act
+            var invocationTask = _coordinator.RunFunctionInvocationAsync(invocationId, cts.Token);
+
+            await setHttpTask;
+            await setFunctionTask;
+
+            // Cancel the token (simulates client disconnect)
+            cts.Cancel();
+
+            // Assert - The invocation task should be cancelled
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await invocationTask);
+        }
+
+        [Fact]
+        public async Task RunFunctionInvocationAsync_WhenCancelledAfterCompletion_DoesNotThrow()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+            var cts = new CancellationTokenSource();
+
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            var invocationTask = _coordinator.RunFunctionInvocationAsync(invocationId, cts.Token);
+
+            await setHttpTask;
+            await setFunctionTask;
+
+            // Complete the function before cancelling
+            _coordinator.CompleteFunctionInvocation(invocationId);
+            await invocationTask;
+
+            // Act - Cancel after completion should be a no-op
+            cts.Cancel();
+
+            // Assert - Task already completed successfully
+            Assert.True(invocationTask.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task RunFunctionInvocationAsync_WhenCompletedAfterCancellation_RemainsInCancelledState()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+            var cts = new CancellationTokenSource();
+
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+            var invocationTask = _coordinator.RunFunctionInvocationAsync(invocationId, cts.Token);
+
+            await setHttpTask;
+            await setFunctionTask;
+
+            // Cancel first
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await invocationTask);
+
+            // Act - Complete after cancellation (simulates worker finishing after client disconnects)
+            _coordinator.CompleteFunctionInvocation(invocationId);
+
+            // Assert - Task should still be in cancelled state (TrySetResult returns false)
+            Assert.True(invocationTask.IsCanceled);
+        }
+
+        [Fact]
+        public async Task RunFunctionInvocationAsync_WithDefaultToken_CompletesNormally()
+        {
+            // Arrange
+            string invocationId = Guid.NewGuid().ToString();
+            var httpContext = new DefaultHttpContext();
+            var functionContext = CreateTestFunctionContext();
+
+            var setHttpTask = _coordinator.SetHttpContextAsync(invocationId, httpContext);
+            var setFunctionTask = _coordinator.SetFunctionContextAsync(invocationId, functionContext);
+
+            // Act - Use default token (no cancellation)
+            var invocationTask = _coordinator.RunFunctionInvocationAsync(invocationId);
+
+            await setHttpTask;
+            await setFunctionTask;
+
+            _coordinator.CompleteFunctionInvocation(invocationId);
+            await invocationTask;
+
+            // Assert
+            Assert.True(invocationTask.IsCompletedSuccessfully);
+        }
+
+        [Fact]
         public async Task SetHttpContextAsync_WhenHttpContextTaskFaulted_PropagatesOriginalException()
         {
             // Arrange


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Addresses the root cause of HTTP request retention when clients disconnect. PR #3415 (v2.1.1) improved cancellation during the context exchange phase, but the function completion wait (`_functionCompletionTask`) remained uncancellable — causing the ASP.NET Core pipeline to hold requests until function completion or timeout (up to 30 min).

This PR registers `HttpContext.RequestAborted` on `_functionCompletionTask` so the pipeline releases the connection immediately on client disconnect.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

**What this changes:**
- `ContextReference.InvokeFunctionAsync()` now accepts a `CancellationToken` and registers a callback that calls `TrySetCanceled()` on disconnect
- `IHttpCoordinator.RunFunctionInvocationAsync()` accepts an optional `CancellationToken`
- `FunctionsHttpContextExtensions.InvokeFunctionAsync()` passes `context.RequestAborted` through the call chain
- `ContextReference.CompleteFunction()` disposes the cancellation registration on normal completion

**What this does NOT change:**
- The function itself still runs to completion on the worker side — only the HTTP connection hold is released
- The `Try*` pattern on `TaskCompletionSource` ensures the race between cancellation and normal completion is safe
- No breaking changes for correctly-written consumers (ASP.NET Core already expects `OperationCanceledException` from endpoint delegates for disconnected clients)