### PR TITLE
chore: bump generators implicit package to 1.4.0

### DIFF
--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.Analyzers.props
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.Analyzers.props
@@ -24,7 +24,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </_FuncSdkPackageReference>
-    <_FuncSdkPackageReference Include="Microsoft.Azure.Functions.Worker.Sdk.Generators" Version="1.3.6" IsImplicitlyDefined="true">
+    <_FuncSdkPackageReference Include="Microsoft.Azure.Functions.Worker.Sdk.Generators" Version="1.4.0" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </_FuncSdkPackageReference>

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.Analyzers.targets
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.Analyzers.targets
@@ -11,8 +11,30 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 <Project>
 
+  <UsingTask TaskName="$(AzureFunctionsTaskNamespace).ResolveWorkerPackageReference" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
+
   <PropertyGroup>
     <FunctionsGeneratedCodeNamespace Condition="'$(FunctionsGeneratedCodeNamespace)' == ''">$(RootNamespace.Replace("-", "_"))</FunctionsGeneratedCodeNamespace>
   </PropertyGroup>
+
+  <Target Name="_ConfigureWorkerSourceGen"
+    BeforeTargets="GenerateMSBuildEditorConfigFileCore;CoreCompile">
+    <PropertyGroup>
+      <!-- In multi-targeting, $(ProjectAssetsFile) may be empty in some paths, so we backfill it. -->
+      <_ProjectAssetsFile>$(ProjectAssetsFile)</_ProjectAssetsFile>
+      <_ProjectAssetsFile Condition="'$(_ProjectAssetsFile)' == ''">$(BaseIntermediateOutputPath)project.assets.json</_ProjectAssetsFile>
+    </PropertyGroup>
+
+    <ResolveWorkerPackageReference ProjectAssetsFile="$(_ProjectAssetsFile)" TargetFramework="$(TargetFramework)">
+      <Output TaskParameter="WorkerPackages" ItemName="_ResolvedWorkerPackages" />
+    </ResolveWorkerPackageReference>
+
+    <PropertyGroup Condition="'@(_ResolvedWorkerPackages)' == ''">
+      <FunctionsEnableMetadataSourceGen>false</FunctionsEnableMetadataSourceGen>
+      <FunctionsEnableExecutorSourceGen>false</FunctionsEnableExecutorSourceGen>
+      <FunctionsAutoRegisterGeneratedMetadataProvider>false</FunctionsAutoRegisterGeneratedMetadataProvider>
+      <FunctionsAutoRegisterGeneratedFunctionsExecutor>false</FunctionsAutoRegisterGeneratedFunctionsExecutor>
+    </PropertyGroup>
+  </Target>
 
 </Project>

--- a/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
+++ b/src/Azure.Functions.Sdk/Targets/Azure.Functions.Sdk.targets
@@ -64,21 +64,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       Resource="Error_UsingIncompatibleSdk" Arguments="Microsoft.NET.Sdk.Functions" />
   </Target>
 
-  <!--
-    The Azure Functions worker package is no longer added implicitly. It must be referenced by the
-    project (directly or transitively) so NuGet can resolve the highest version required by the
-    dependency graph. This target runs post-restore (after package assets are resolved) and warns
-    when no 'Microsoft.Azure.Functions.Worker.Core' assembly is present in the resolved closure.
-  -->
-  <Target Name="_ValidateWorkerPackageReference"
-    AfterTargets="ResolvePackageAssets"
-    Condition="'$(DesignTimeBuild)' != 'true'">
-    <PropertyGroup>
-      <_FunctionsHasWorkerCoreReference>@(ResolvedCompileFileDefinitions->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.Azure.Functions.Worker.Core'))</_FunctionsHasWorkerCoreReference>
-    </PropertyGroup>
-    <FuncSdkLog Condition="'$(_FunctionsHasWorkerCoreReference)' != 'true'" Resource="Warning_WorkerPackageNotReferenced" />
-  </Target>
-
   <Target Name="_FunctionsCheckForCoreTools">
     <Exec Command="func --version" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_FuncCliExitCode" />

--- a/src/Azure.Functions.Sdk/Tasks/ResolveWorkerPackageReference.cs
+++ b/src/Azure.Functions.Sdk/Tasks/ResolveWorkerPackageReference.cs
@@ -1,0 +1,164 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
+using Microsoft.Build.Framework;
+using NuGet.LibraryModel;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+
+namespace Azure.Functions.Sdk.Tasks;
+
+public class ResolveWorkerPackageReference(IFileSystem fileSystem)
+    : Microsoft.Build.Utilities.Task, ICancelableTask, IDisposable
+{
+    private const string WorkerPackageId = "Microsoft.Azure.Functions.Worker";
+
+    private readonly CancellationTokenSource _cts = new();
+    private readonly IFileSystem _fileSystem = Throw.IfNull(fileSystem);
+
+    public ResolveWorkerPackageReference()
+        : this(new FileSystem())
+    {
+    }
+
+    [Required]
+    public string ProjectAssetsFile { get; set; } = string.Empty;
+
+    public string? TargetFramework { get; set; }
+
+    [Output]
+    public ITaskItem[] WorkerPackages { get; private set; } = [];
+
+    public void Cancel()
+    {
+        _cts.Cancel();
+    }
+
+    public void Dispose()
+    {
+        _cts.Dispose();
+    }
+
+    public override bool Execute()
+    {
+        if (!TryGetLockFile(out LockFile? lockFile))
+        {
+            return !_cts.IsCancellationRequested;
+        }
+
+        List<ITaskItem> workerPackages = [];
+        NuGetFramework? currentFramework = TryParseFramework(TargetFramework);
+        foreach (LockFileTarget target in lockFile!.Targets)
+        {
+            if (_cts.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(target.RuntimeIdentifier))
+            {
+                // Skip RID-specific targets to avoid duplicates.
+                continue;
+            }
+
+            if (!IsCurrentTargetFramework(target, currentFramework))
+            {
+                continue;
+            }
+
+            LockFileTargetLibrary? library = target.Libraries.FirstOrDefault(IsWorkerPackage);
+            if (library is null)
+            {
+                continue;
+            }
+
+            Microsoft.Build.Utilities.TaskItem item = new(library.Name!)
+            {
+                Version = library.Version?.ToNormalizedString() ?? string.Empty,
+                TargetFramework = target.TargetFramework.ToString(),
+            };
+
+            workerPackages.Add(item);
+
+            // If a specific TFM was requested, there is at most one relevant package entry.
+            if (currentFramework is not null)
+            {
+                break;
+            }
+        }
+
+        WorkerPackages = [.. workerPackages];
+
+        if (WorkerPackages.Length == 0)
+        {
+            Log.LogMessage(LogMessage.Warning_WorkerPackageNotReferenced);
+        }
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private bool TryGetLockFile([NotNullWhen(true)] out LockFile? lockFile)
+    {
+        if (_cts.IsCancellationRequested)
+        {
+            lockFile = null;
+            return false;
+        }
+
+        if (!_fileSystem.File.Exists(ProjectAssetsFile))
+        {
+            // Don't fail when assets are missing. This can happen in DTB before restore.
+            Log.LogMessage(
+                Microsoft.Build.Framework.MessageImportance.Low,
+                "Project assets file '{0}' was not found.",
+                ProjectAssetsFile);
+
+            lockFile = null;
+            WorkerPackages = [];
+            Log.LogMessage(LogMessage.Warning_WorkerPackageNotReferenced);
+            return false;
+        }
+
+        using FileSystemStream stream = _fileSystem.File.OpenRead(ProjectAssetsFile);
+        lockFile = LockFile.Read(ProjectAssetsFile, stream, new MSBuildNugetLogger(Log));
+        return true;
+    }
+
+    private static bool IsWorkerPackage(LockFileTargetLibrary library)
+    {
+        return library.Type == LibraryType.Package
+            && library.Name is not null
+            && string.Equals(library.Name, WorkerPackageId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static NuGetFramework? TryParseFramework(string? value)
+    {
+        string? framework = value?.Trim();
+        if (string.IsNullOrWhiteSpace(framework))
+        {
+            return null;
+        }
+
+        try
+        {
+            return NuGetFramework.Parse(framework!);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsCurrentTargetFramework(LockFileTarget target, NuGetFramework? currentFramework)
+    {
+        if (currentFramework is null)
+        {
+            return true;
+        }
+
+        return target.TargetFramework is not null
+            && target.TargetFramework.Equals(currentFramework);
+    }
+}

--- a/src/Azure.Functions.Sdk/Tasks/ResolveWorkerPackageReference.cs
+++ b/src/Azure.Functions.Sdk/Tasks/ResolveWorkerPackageReference.cs
@@ -117,7 +117,6 @@ public class ResolveWorkerPackageReference(IFileSystem fileSystem)
 
             lockFile = null;
             WorkerPackages = [];
-            Log.LogMessage(LogMessage.Warning_WorkerPackageNotReferenced);
             return false;
         }
 

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -9,6 +9,7 @@
 - fix: no longer add `Microsoft.Azure.Functions.Worker` as an implicit package reference, which caused silent version downgrades and runtime `MissingMethodException` failures (#3450)
   - reference `Microsoft.Azure.Functions.Worker` explicitly in your project
   - emit `AZFW0111` warning when no worker package is found after restore
+  - source generators are skipped if this package is missing
 - fix: expand removed properties and pin `Configuration=release` when restoring/resolving the generated extension project (#3399)
 - fix: reliably resolve extension restore sources (#3393)
 - feat: emit `AZFW0110` warning when the deprecated `FunctionsEnableWorkerIndexing` property is set (#3395)

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
@@ -320,19 +320,17 @@ public partial class SdkEndToEndTests
         ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
             GetTempCsproj(), targetFramework: "net8.0", includeWorkerPackage: false)
             .Property("AssemblyName", "MyFunctionApp")
-            .WriteSourceFile("Program.cs", "public class Program { public static void Main() { } }");
+            .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);
 
         // Act
         BuildOutput output = project.Build(restore: true);
 
         // Assert - build succeeds, but the SDK warns that no worker package was found after restore.
         output.Should().BeSuccessful();
-        output.WarningEvents
-            .Where(x => x.Code == LogMessage.Warning_WorkerPackageNotReferenced.Code)
-            .Should().NotBeEmpty()
+        output.WarningEvents.Should().Contain(x => x.Code == LogMessage.Warning_WorkerPackageNotReferenced.Code)
             .And.AllSatisfy(warning => warning.Should()
                 .BeSdkMessage(LogMessage.Warning_WorkerPackageNotReferenced)
-                .And.HaveSender("FuncSdkLog"));
+                .And.HaveSender("ResolveWorkerPackageReference"));
     }
 
     [Fact]

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Build.cs
@@ -328,9 +328,8 @@ public partial class SdkEndToEndTests
         // Assert - build succeeds, but the SDK warns that no worker package was found after restore.
         output.Should().BeSuccessful();
         output.WarningEvents.Should().Contain(x => x.Code == LogMessage.Warning_WorkerPackageNotReferenced.Code)
-            .And.AllSatisfy(warning => warning.Should()
-                .BeSdkMessage(LogMessage.Warning_WorkerPackageNotReferenced)
-                .And.HaveSender("ResolveWorkerPackageReference"));
+            .Which.Should().BeSdkMessage(LogMessage.Warning_WorkerPackageNotReferenced)
+            .And.HaveSender("ResolveWorkerPackageReference");
     }
 
     [Fact]

--- a/test/Azure.Functions.Sdk.Tests/Tasks/ResolveWorkerPackageReferenceTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/ResolveWorkerPackageReferenceTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Azure.Functions.Sdk.Tests;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities.ProjectCreation;
+
+namespace Azure.Functions.Sdk.Tasks.Tests;
+
+public sealed class ResolveWorkerPackageReferenceTests : IDisposable
+{
+    private readonly TempDirectory _temp = new();
+    private readonly Lazy<ProjectCollection> _collection = new(() => TestHelpers.CreateBinaryLoggerCollection());
+
+    public void Dispose()
+    {
+        if (_collection.IsValueCreated)
+        {
+            _collection.Value.Dispose();
+        }
+
+        _temp.Dispose();
+    }
+
+    [Fact]
+    public void LockFileDoesNotExist_EmitsWarning_AndReturnsNoPackage()
+    {
+        // Arrange
+        Mock<IBuildEngine> buildEngine = new();
+        ResolveWorkerPackageReference task = CreateTask("C:/missing/project.assets.json", buildEngine.Object, new MockFileSystem());
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();
+        task.WorkerPackages.Should().BeEmpty();
+        buildEngine.VerifyLog(LogMessage.Warning_WorkerPackageNotReferenced);
+    }
+
+    [Fact]
+    public void WorkerPackageMissing_EmitsWarning_AndReturnsNoPackage()
+    {
+        // Arrange
+        string assetsFile = RestoreProject(includeWorkerPackage: false);
+        Mock<IBuildEngine> buildEngine = new();
+        ResolveWorkerPackageReference task = CreateTask(assetsFile, buildEngine.Object);
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();
+        task.WorkerPackages.Should().BeEmpty();
+        buildEngine.VerifyLog(LogMessage.Warning_WorkerPackageNotReferenced);
+    }
+
+    [Fact]
+    public void WorkerPackagePresent_ReturnsResolvedPackage_AndNoWarning()
+    {
+        // Arrange
+        string assetsFile = RestoreProject(includeWorkerPackage: true);
+        Mock<IBuildEngine> buildEngine = new();
+        ResolveWorkerPackageReference task = CreateTask(assetsFile, buildEngine.Object);
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();
+        task.WorkerPackages.Should().Contain(x =>
+            string.Equals(x.ItemSpec, NugetPackage.Worker.Name, StringComparison.OrdinalIgnoreCase));
+
+        buildEngine.Verify(m => m.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()), Times.Never);
+    }
+
+    [Fact]
+    public void WorkerPackagePresent_MultiTarget_ResolvesCurrentTfmOnly()
+    {
+        // Arrange
+        string assetsFile = RestoreProject(
+            includeWorkerPackage: true,
+            targetFramework: null,
+            configure: project => project.TargetFrameworks(["net8.0", "net481"]));
+
+        Mock<IBuildEngine> buildEngine = new();
+        ResolveWorkerPackageReference task = CreateTask(assetsFile, buildEngine.Object);
+        task.TargetFramework = "net8.0";
+
+        // Act
+        bool result = task.Execute();
+
+        // Assert
+        result.Should().BeTrue();
+        task.WorkerPackages.Should().ContainSingle();
+        task.WorkerPackages[0].ItemSpec.Should().Be(NugetPackage.Worker.Name);
+        task.WorkerPackages[0].GetMetadata("TargetFramework").Should().Be("net8.0");
+        buildEngine.Verify(m => m.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()), Times.Never);
+    }
+
+    private static ResolveWorkerPackageReference CreateTask(
+        string assetsFile,
+        IBuildEngine buildEngine,
+        IFileSystem? fileSystem = null)
+    {
+        return new ResolveWorkerPackageReference(fileSystem ?? new FileSystem())
+        {
+            BuildEngine = buildEngine,
+            ProjectAssetsFile = assetsFile,
+        };
+    }
+
+    private string RestoreProject(
+        bool includeWorkerPackage,
+        string? targetFramework = "net8.0",
+        Action<ProjectCreator>? configure = null)
+    {
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            path: _temp.GetRandomCsproj(),
+            targetFramework: targetFramework,
+            projectCollection: _collection.Value,
+            includeWorkerPackage: includeWorkerPackage)
+            .CustomAction(configure)
+            .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);
+
+        project.Restore().Should().BeSuccessful();
+        project.TryGetPropertyValue("ProjectAssetsFile", out string? value);
+        value.Should().NotBeNullOrEmpty();
+        return value!;
+    }
+}

--- a/test/Azure.Functions.Sdk.Tests/Tasks/ResolveWorkerPackageReferenceTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/ResolveWorkerPackageReferenceTests.cs
@@ -26,11 +26,11 @@ public sealed class ResolveWorkerPackageReferenceTests : IDisposable
     }
 
     [Fact]
-    public void LockFileDoesNotExist_EmitsWarning_AndReturnsNoPackage()
+    public void LockFileDoesNotExist_NoWarning_AndReturnsNoPackage()
     {
         // Arrange
         Mock<IBuildEngine> buildEngine = new();
-        ResolveWorkerPackageReference task = CreateTask("C:/missing/project.assets.json", buildEngine.Object, new MockFileSystem());
+        ResolveWorkerPackageReference task = CreateTask("./does/not/exist/project.assets.json", buildEngine.Object, new MockFileSystem());
 
         // Act
         bool result = task.Execute();
@@ -38,7 +38,6 @@ public sealed class ResolveWorkerPackageReferenceTests : IDisposable
         // Assert
         result.Should().BeTrue();
         task.WorkerPackages.Should().BeEmpty();
-        buildEngine.VerifyLog(LogMessage.Warning_WorkerPackageNotReferenced);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Quick bump to this package, had to do in a separate PR so that `1.4.0` was published to nuget.org first.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
