### PR TITLE
Onboard dependency restores to CFS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,10 @@
 registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
 @azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,10 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />
-    <add key="pre-release" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/pre-release/nuget/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/ci/templates/jobs/build-net-host.yml
+++ b/eng/ci/templates/jobs/build-net-host.yml
@@ -9,6 +9,9 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
+
   - task: DotnetCoreCLI@2
     displayName: Dotnet build
     inputs:

--- a/eng/ci/templates/official/jobs/build-host-artifacts-linux.yml
+++ b/eng/ci/templates/official/jobs/build-host-artifacts-linux.yml
@@ -29,6 +29,9 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
+
   - script: |
       sudo apt-get update
       sudo apt-get install -y clang zlib1g-dev

--- a/eng/ci/templates/official/jobs/build-host-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-host-artifacts-windows.yml
@@ -17,6 +17,9 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
+
   - task: DotnetCoreCLI@2
     displayName: Dotnet Publish
     inputs:

--- a/eng/ci/templates/steps/install-dotnet.yml
+++ b/eng/ci/templates/steps/install-dotnet.yml
@@ -1,5 +1,8 @@
 steps:
 
+- task: NuGetAuthenticate@1
+  displayName: Authenticate NuGet feeds
+
 # Our tests target net8.0
 - task: UseDotNet@2
   displayName: 'Install .NET8 SDK'

--- a/eng/ci/templates/steps/setup-e2e-tests.yml
+++ b/eng/ci/templates/steps/setup-e2e-tests.yml
@@ -21,6 +21,11 @@ steps:
   - template: /eng/ci/templates/steps/install-core-tools.yml@self
 
 - ${{ if not(parameters.SkipStorageEmulator) }}:
+  - task: npmAuthenticate@0
+    displayName: Authenticate npm feed
+    inputs:
+      workingFile: $(Build.SourcesDirectory)/.npmrc
+
   - task: UseNode@1
     inputs:
       version: 26.x

--- a/samples/FunctionApp/NuGet.Config
+++ b/samples/FunctionApp/NuGet.Config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/Azure.Functions.Sdk.Tests/ProjectCreatorExtensions.cs
+++ b/test/Azure.Functions.Sdk.Tests/ProjectCreatorExtensions.cs
@@ -17,7 +17,7 @@ internal static class ProjectCreatorExtensions
             KeyValuePair.Create("ImportDirectoryBuildProps", bool.FalseString),
             KeyValuePair.Create("ImportDirectoryPackagesProps", bool.FalseString),
             KeyValuePair.Create("ImportDirectoryBuildTargets", bool.FalseString),
-            KeyValuePair.Create("RestoreSources", "https://api.nuget.org/v3/index.json" )
+            KeyValuePair.Create("RestoreSources", "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json")
         ]);
 
     private static IDictionary<string, string>? CombineProperties(

--- a/test/E2ETests/E2EApps/E2EApp/NuGet.Config
+++ b/test/E2ETests/E2EApps/E2EApp/NuGet.Config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/E2ETests/E2EApps/E2EAspNetCoreApp/NuGet.Config
+++ b/test/E2ETests/E2EApps/E2EAspNetCoreApp/NuGet.Config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/E2ETests/NuGet.Config
+++ b/test/E2ETests/NuGet.Config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"/>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/Sdk.E2ETests/TestUtility.cs
+++ b/test/Sdk.E2ETests/TestUtility.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Functions.Sdk.E2ETests
         public static readonly string TestOutputDir = Path.Combine(Path.GetTempPath(), "FunctionsWorkerSdk.E2ETests");
         public static readonly string TestResourcesProjectsRoot = Path.Combine(TestRoot, "Resources", "Projects");
 
-        public static readonly string NuGetOrgPackages = "https://api.nuget.org/v3/index.json";
+        public static readonly string UpstreamPublicPackages = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json";
         public static readonly string NuGetPackageSource = LocalPackages;
         public static readonly string SdkVersion = "99.99.99-test";
         public static readonly string SdkBuildProj = Path.Combine(PathToRepoRoot, "build", "Sdk.slnf");
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.Sdk.E2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} -s {NuGetOrgPackages} -s {LocalPackages} -p:SdkVersion={SdkVersion}";
+            string dotnetArgs = $"restore {projectNameToTest} -s {UpstreamPublicPackages} -s {LocalPackages} -p:SdkVersion={SdkVersion}";
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Functions.Sdk.E2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} -s {NuGetOrgPackages} -s {LocalPackages} -p:SdkVersion={SdkVersion}";
+            string dotnetArgs = $"restore {projectNameToTest} -s {UpstreamPublicPackages} -s {LocalPackages} -p:SdkVersion={SdkVersion}";
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");

--- a/test/Sdk.E2ETests/TestUtility.cs
+++ b/test/Sdk.E2ETests/TestUtility.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.Sdk.E2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} -s {UpstreamPublicPackages} -s {LocalPackages} -p:SdkVersion={SdkVersion}";
+            string dotnetArgs = $"restore \"{projectNameToTest}\" -s \"{UpstreamPublicPackages}\" -s \"{LocalPackages}\" -p:SdkVersion={SdkVersion}";
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Functions.Sdk.E2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} -s {UpstreamPublicPackages} -s {LocalPackages} -p:SdkVersion={SdkVersion}";
+            string dotnetArgs = $"restore \"{projectNameToTest}\" -s \"{UpstreamPublicPackages}\" -s \"{LocalPackages}\" -p:SdkVersion={SdkVersion}";
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -17,6 +17,7 @@ Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 
 $startedCosmos = $false
 $startedStorage = $false
+$npmRegistry = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/"
 
 if (!$IsWindows -and !$IsLinux -and !$IsMacOs)
 {
@@ -92,12 +93,12 @@ if (!$SkipStorageEmulator)
     {
         if ($IsWindows)
         {
-            npm install -g azurite
+            npm install -g azurite --registry $npmRegistry
             Start-Process azurite.cmd -ArgumentList "--silent"
         }
         else
         {
-            sudo npm install -g azurite
+            sudo npm install -g azurite --registry $npmRegistry
             sudo mkdir azurite
             sudo azurite --silent --location azurite --debug azurite\debug.log &
         }

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -18,6 +18,7 @@ Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 $startedCosmos = $false
 $startedStorage = $false
 $npmRegistry = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/"
+$npmConfigPath = Join-Path (Split-Path -Parent $PSScriptRoot) ".npmrc"
 
 if (!$IsWindows -and !$IsLinux -and !$IsMacOs)
 {
@@ -93,12 +94,22 @@ if (!$SkipStorageEmulator)
     {
         if ($IsWindows)
         {
-            npm install -g azurite --registry $npmRegistry
+            $previousNpmConfig = $env:NPM_CONFIG_USERCONFIG
+            try
+            {
+                $env:NPM_CONFIG_USERCONFIG = $npmConfigPath
+                npm install -g azurite --registry $npmRegistry
+            }
+            finally
+            {
+                $env:NPM_CONFIG_USERCONFIG = $previousNpmConfig
+            }
+
             Start-Process azurite.cmd -ArgumentList "--silent"
         }
         else
         {
-            sudo npm install -g azurite --registry $npmRegistry
+            sudo env "NPM_CONFIG_USERCONFIG=$npmConfigPath" npm install -g azurite --registry $npmRegistry
             sudo mkdir azurite
             sudo azurite --silent --location azurite --debug azurite\debug.log &
         }


### PR DESCRIPTION
## Summary
- route root and nested NuGet restores, test-generated restores, and local E2E projects through `azfunc/public/upstream-public`
- authenticate all restore-capable Azure Pipelines jobs through the shared .NET setup template and standalone host jobs
- route Azurite's npm/npx installs through CFS with `npmAuthenticate@0`, an authenticated `.npmrc` selected for global installs, and explicit mappings for every scope in Azurite's resolved production dependency graph
- leave customer-facing publishing controls and package links unchanged; no Python package project is present

## Validation
- `dotnet restore DotNetWorker.sln --no-cache --nologo`
- restored the FunctionApp sample and both nested E2E applications using their updated NuGet configs
- `dotnet test test/Azure.Functions.Sdk.Tests/Azure.Functions.Sdk.Tests.csproj --no-restore --nologo --verbosity minimal` (562 passed)
- `dotnet build test/Sdk.E2ETests/Sdk.E2ETests.csproj --no-restore --nologo --verbosity minimal`
- verified `tools/start-emulators.ps1` sets `NPM_CONFIG_USERCONFIG` to the repository `.npmrc` for the global Azurite install
- compared `.npmrc` scope mappings with Azurite 3.36.0's resolved production lock graph and confirmed npm resolves all nine scopes to CFS