### PR TITLE
ci: remove nightly scheduled build for v1.x

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,10 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"/>
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -21,16 +21,6 @@ trigger:
     - v1.x
     - release/*
 
-schedules:
-# Ensure we build nightly to catch any new CVEs and report SDL often.
-- cron: "0 0 * * *"
-  displayName: Nightly Build
-  branches:
-    include:
-    - main
-    - v1.x
-  always: true
-
 # CI only, does not trigger on PRs.
 pr: none
 

--- a/eng/ci/templates/jobs/build-net-host.yml
+++ b/eng/ci/templates/jobs/build-net-host.yml
@@ -9,6 +9,9 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
+
   - task: DotnetCoreCLI@2
     displayName: Dotnet build
     inputs:

--- a/eng/ci/templates/official/jobs/build-host-artifacts-linux.yml
+++ b/eng/ci/templates/official/jobs/build-host-artifacts-linux.yml
@@ -26,6 +26,9 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
+
   - script: |
       sudo apt-get install clang zlib1g-dev
     displayName: Install dependencies

--- a/eng/ci/templates/official/jobs/build-host-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-host-artifacts-windows.yml
@@ -17,6 +17,9 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
+
   - task: DotnetCoreCLI@2
     displayName: Dotnet Publish
     inputs:

--- a/eng/ci/templates/steps/install-dotnet.yml
+++ b/eng/ci/templates/steps/install-dotnet.yml
@@ -1,5 +1,8 @@
 steps:
 
+- task: NuGetAuthenticate@1
+  displayName: Authenticate NuGet feeds
+
 - task: UseDotNet@2 # Needed by our projects and CI steps
   displayName: Install .NET 6
   inputs:

--- a/eng/ci/templates/steps/setup-e2e-tests.yml
+++ b/eng/ci/templates/steps/setup-e2e-tests.yml
@@ -20,6 +20,12 @@ parameters:
 
 steps:
 
+- ${{ if not(parameters.SkipStorageEmulator) }}:
+  - task: npmAuthenticate@0
+    displayName: Authenticate npm feed
+    inputs:
+      workingFile: $(Build.SourcesDirectory)/.npmrc
+
 - task: PowerShell@2
   displayName: 'Setup E2E tests'
   inputs:

--- a/samples/FunctionApp/NuGet.Config
+++ b/samples/FunctionApp/NuGet.Config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/E2ETests/E2EApps/E2EApp/NuGet.Config
+++ b/test/E2ETests/E2EApps/E2EApp/NuGet.Config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/E2ETests/E2EApps/E2EAspNetCoreApp/NuGet.Config
+++ b/test/E2ETests/E2EApps/E2EAspNetCoreApp/NuGet.Config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/E2ETests/NuGet.Config
+++ b/test/E2ETests/NuGet.Config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"/>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/SdkE2ETests/TestUtility.cs
+++ b/test/SdkE2ETests/TestUtility.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
         public static readonly string TestOutputDir = Path.Combine(Path.GetTempPath(), "FunctionsWorkerSdkE2ETests");
         public static readonly string TestResourcesProjectsRoot = Path.Combine(TestRoot, "Resources", "Projects");
 
-        public static readonly string NuGetOrgPackages = "https://api.nuget.org/v3/index.json";
+        public static readonly string UpstreamPublicPackages = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json";
         public static readonly string NuGetPackageSource = LocalPackages;
         public static readonly string SdkVersion = "99.99.99-test";
         public static readonly string SdkBuildProj = Path.Combine(PathToRepoRoot, "build", "Sdk.slnf");
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} -s {NuGetOrgPackages} -s {LocalPackages} -p:SdkVersion={SdkVersion}";
+            string dotnetArgs = $"restore \"{projectNameToTest}\" -s \"{UpstreamPublicPackages}\" -s \"{LocalPackages}\" -p:SdkVersion={SdkVersion}";
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Functions.SdkE2ETests
 
             // Restore
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Restoring...");
-            string dotnetArgs = $"restore {projectNameToTest} -s {NuGetOrgPackages} -s {LocalPackages} -p:SdkVersion={SdkVersion}";
+            string dotnetArgs = $"restore \"{projectNameToTest}\" -s \"{UpstreamPublicPackages}\" -s \"{LocalPackages}\" -p:SdkVersion={SdkVersion}";
             int? exitCode = await new ProcessWrapper().RunProcess(DotNetExecutable, dotnetArgs, projectFileDirectory, testOutputHelper: outputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
             outputHelper.WriteLine($"[{DateTime.UtcNow:O}] Done.");

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -17,6 +17,8 @@ Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 
 $startedCosmos = $false
 $startedStorage = $false
+$npmRegistry = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/"
+$npmConfigPath = Join-Path (Split-Path -Parent $PSScriptRoot) ".npmrc"
 
 if (!$IsWindows -and !$IsLinux -and !$IsMacOs)
 {
@@ -92,12 +94,22 @@ if (!$SkipStorageEmulator)
     {
         if ($IsWindows)
         {
-            npm install -g azurite
+            $previousNpmConfig = $env:NPM_CONFIG_USERCONFIG
+            try
+            {
+                $env:NPM_CONFIG_USERCONFIG = $npmConfigPath
+                npm install -g azurite --registry $npmRegistry
+            }
+            finally
+            {
+                $env:NPM_CONFIG_USERCONFIG = $previousNpmConfig
+            }
+
             Start-Process azurite.cmd -ArgumentList "--silent"
         }
         else
         {
-            sudo npm install -g azurite
+            sudo env "NPM_CONFIG_USERCONFIG=$npmConfigPath" npm install -g azurite --registry $npmRegistry
             sudo mkdir azurite
             sudo azurite --silent --location azurite --debug azurite\debug.log &
         }


### PR DESCRIPTION
This PR makes two CI changes on the `v1.x` branch:

## 1. Remove nightly scheduled build

Removes the nightly `schedules:` block from `eng/ci/official-build.yml`. The `dotnet-worker.official` pipeline (ADO azfunc/internal, definitionId 349) had been running nightly against `refs/heads/v1.x` at 00:00 UTC even though `main`'s YAML has no schedules — Azure Pipelines evaluates YAML schedules per branch from that branch's own file. Deleting this block stops those nightly runs. `trigger:` and `pr: none` are left intact.

## 2. Onboard dependency restores to CFS

Ports the CFS onboarding from main (#3475) to `v1.x`, adapted to the v1.x pipeline structure:

- Route NuGet restores (root, samples, and E2E apps) through `azfunc/public/upstream-public` by replacing all package sources with the single `upstream-public` feed.
- Add root `.npmrc` mapping npm + all Azurite dependency scopes to the CFS npm registry.
- Route Azurite's npm install through CFS in `tools/start-emulators.ps1` (CFS registry + authenticated `.npmrc` via `NPM_CONFIG_USERCONFIG`).
- Authenticate restore-capable CI jobs: `NuGetAuthenticate@1` in the .NET build/host jobs and `install-dotnet` steps; `npmAuthenticate@0` (against `.npmrc`) before the E2E setup step that installs Azurite.
- Point `SdkE2ETests` restore sources at `upstream-public`.

v1.x-specific adaptations vs. #3475: the `ProjectCreatorExtensions.cs` change was dropped (that project doesn't exist on v1.x), and `npmAuthenticate` was placed before the PowerShell "Setup E2E tests" step (v1.x installs Azurite via `start-emulators.ps1` rather than inline `npx`).