### PR TITLE
ci: add nightly scheduled build for main

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -5,6 +5,15 @@ trigger:
     - main
     - release/*
 
+schedules:
+# Ensure we build nightly to catch any new CVEs and report SDL often.
+- cron: "0 0 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+    - main
+  always: true
+
 # CI only, does not trigger on PRs.
 pr: none
 


### PR DESCRIPTION
Adds a nightly scheduled build for `main` to `dotnet-worker.official`.

`main`'s `eng/ci/official-build.yml` has no `schedules:` block, so the official pipeline only runs on push. The nightly SDL/CVE coverage was coming solely from the `v1.x` branch's copy of this file (Azure Pipelines evaluates YAML schedules per branch, from that branch's own file), whose schedule filter included both `main` and `v1.x`.

That `v1.x` schedule is being removed in #3476, so this restores the nightly run — scoped to `main` only.

- `cron: "0 0 * * *"` (00:00 UTC), matching the previous cadence
- `always: true` so it runs even without new commits