### PR TITLE
ci: use cdn.functions.azure.com for Core Tools CLI feed

### DIFF
--- a/eng/ci/templates/steps/install-core-tools.yml
+++ b/eng/ci/templates/steps/install-core-tools.yml
@@ -14,7 +14,7 @@ steps:
     }
 
     # Resolve latest v4 version and download URL from the CLI feed (no auth required)
-    $cliFeedUrl = "https://functionscdn.azureedge.net/public/cli-feed-v4.json"
+    $cliFeedUrl = "https://cdn.functions.azure.com/public/cli-feed-v4.json"
     $cliFeed = Invoke-RestMethod -Uri $cliFeedUrl
     $version = $cliFeed.tags.v4.release
     Write-Host "Latest Core Tools version: $version"


### PR DESCRIPTION
## Summary

The Azure Functions CDN host `functionscdn.azureedge.net` is being retired and replaced by `cdn.functions.azure.com`. This updates the Core Tools CLI feed URL used when installing Azure Functions Core Tools in CI.

## Changes

- `eng/ci/templates/steps/install-core-tools.yml`: change the CLI feed URL from `https://functionscdn.azureedge.net/public/cli-feed-v4.json` to `https://cdn.functions.azure.com/public/cli-feed-v4.json`.

This was the only reference to `functionscdn.azureedge.net` / `*.azureedge.net` in the repository. The new feed responds correctly and the `downloadLink` values it returns already point at the new host.

Companion change to the equivalent update in `Azure/azure-functions-mcp-extension`.