### PR TITLE
test(analyzers): route ReferenceAssemblies restore through repo NuGet.Config

### DIFF
--- a/test/Sdk.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
+++ b/test/Sdk.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
@@ -11,6 +11,8 @@ using Microsoft.CodeAnalysis.Testing;
 using System.Collections.Immutable;
 using System.Threading;
 
+using Microsoft.Azure.Functions.Tests.Analyzers;
+
 namespace Sdk.Analyzers.Tests
 {
     public sealed class AsyncVoidAnalyzerTests
@@ -171,7 +173,7 @@ namespace FunctionApp4
 
         private static ReferenceAssemblies LoadRequiredDependencyAssemblies()
         {
-            var referenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+            var referenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                 new PackageIdentity("Microsoft.Azure.WebJobs.Extensions", "4.0.1"),
                 new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.1.0"),
                 new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage", "4.0.4")));

--- a/test/Sdk.Analyzers.Tests/BindingTypeNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/BindingTypeNotSupportedTests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using System.Collections.Immutable;
 
+using Microsoft.Azure.Functions.Tests.Analyzers;
+
 namespace Sdk.Analyzers.Tests
 {
     public class BindingTypeNotSupportedTests
@@ -51,7 +53,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                                         new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"))),
                 TestCode = testCode
             };
@@ -99,7 +101,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                                         new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"))),
                 TestCode = testCode
             };
@@ -148,7 +150,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                                         new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"))),
                 TestCode = testCode
             };

--- a/test/Sdk.Analyzers.Tests/DeferredBindingAttributeNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/DeferredBindingAttributeNotSupportedTests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using System.Collections.Immutable;
 
+using Microsoft.Azure.Functions.Tests.Analyzers;
+
 namespace Sdk.Analyzers.Tests
 {
     public class DeferredBindingAttributeNotSupportedTests
@@ -28,7 +30,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.12.1-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
@@ -57,7 +59,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.12.1-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
@@ -86,7 +88,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.12.1-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
@@ -118,7 +120,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.12.1-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),

--- a/test/Sdk.Analyzers.Tests/IterableBindingTypeExpectedForBlobContainerPathTests.cs
+++ b/test/Sdk.Analyzers.Tests/IterableBindingTypeExpectedForBlobContainerPathTests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using System.Collections.Immutable;
 
+using Microsoft.Azure.Functions.Tests.Analyzers;
+
 namespace Sdk.Analyzers.Tests
 {
     public class IterableBindingTypeExpectedForBlobContainerPathTests
@@ -32,7 +34,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
@@ -70,7 +72,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
@@ -107,7 +109,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
@@ -145,7 +147,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
@@ -181,7 +183,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
@@ -216,7 +218,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
@@ -251,7 +253,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
@@ -287,7 +289,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
@@ -323,7 +325,7 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
@@ -25,6 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(TestRoot)Shared/RepoReferenceAssemblies.cs" Link="Shared/RepoReferenceAssemblies.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\sdk\Sdk.Analyzers\Sdk.Analyzers.csproj" />
     <ProjectReference Include="..\..\sdk\Sdk\Sdk.csproj" />
     <ProjectReference Include="..\..\src\DotNetWorker\DotNetWorker.csproj" />

--- a/test/Sdk.Analyzers.Tests/WebJobsAttributesNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/WebJobsAttributesNotSupportedTests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using System.Collections.Immutable;
 
+using Microsoft.Azure.Functions.Tests.Analyzers;
+
 namespace Sdk.Analyzers.Tests
 {
     public class WebJobsAttributesNotSupportedTests
@@ -34,7 +36,7 @@ namespace FunctionApp
             var test = new AnalyzerTest
             {
                 // TODO: This needs to pull from a local source
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.WebJobs.Extensions", "4.0.1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
@@ -72,7 +74,7 @@ namespace FunctionApp
 }";
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
                     new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "5.0.1"),
@@ -110,7 +112,7 @@ namespace FunctionApp
 }";
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
                     new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "5.0.1"),
@@ -148,7 +150,7 @@ namespace GH258IsolatedReturnWebJobsAttr
             var test = new AnalyzerTest
             {
                 // TODO: This needs to pull from a local source
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"))),

--- a/test/Shared/RepoReferenceAssemblies.cs
+++ b/test/Shared/RepoReferenceAssemblies.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.IO;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.Azure.Functions.Tests.Analyzers
+{
+    /// <summary>
+    /// Shared helpers for wiring the Roslyn analyzer test harness to the repository's
+    /// NuGet.Config. Without this, <see cref="ReferenceAssemblies"/> resolves packages
+    /// using only the user/machine-level NuGet settings (which default to nuget.org),
+    /// causing package downloads from public feeds at test runtime. Routing resolution
+    /// through the repo NuGet.Config keeps package restore on the compliant feed.
+    /// </summary>
+    internal static class RepoReferenceAssemblies
+    {
+        private const string RepoRootMarker = ".reporoot";
+        private const string NuGetConfigFileName = "NuGet.Config";
+
+        private static readonly string s_repoNuGetConfigPath = ResolveRepoNuGetConfigPath();
+
+        /// <summary>
+        /// Configures the <see cref="ReferenceAssemblies"/> to resolve NuGet packages
+        /// through the repository's <c>NuGet.Config</c> rather than the machine defaults.
+        /// </summary>
+        public static ReferenceAssemblies WithRepoNuGetConfig(this ReferenceAssemblies referenceAssemblies)
+        {
+            return referenceAssemblies.WithNuGetConfigFilePath(s_repoNuGetConfigPath);
+        }
+
+        private static string ResolveRepoNuGetConfigPath()
+        {
+            string? current = AppContext.BaseDirectory;
+            while (current is not null && !File.Exists(Path.Combine(current, RepoRootMarker)))
+            {
+                current = Directory.GetParent(current)?.FullName;
+            }
+
+            if (current is null)
+            {
+                throw new InvalidOperationException(
+                    $"Could not locate the '{RepoRootMarker}' marker file by walking up from '{AppContext.BaseDirectory}'.");
+            }
+
+            return Path.Combine(current, NuGetConfigFileName);
+        }
+    }
+}

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/HttpResultAttributeExpectedTests.cs
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/HttpResultAttributeExpectedTests.cs
@@ -6,6 +6,7 @@ using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Mi
 using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.HttpResultAttributeExpectedAnalyzer, Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.CodeFixForHttpResultAttribute, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 using CodeFixVerifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.HttpResultAttributeExpectedAnalyzer, Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.CodeFixForHttpResultAttribute, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.Azure.Functions.Tests.Analyzers;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 
@@ -522,7 +523,7 @@ namespace AspNetIntegration
 
         private static ReferenceAssemblies LoadRequiredDependencyAssemblies()
         {
-            var referenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(
+            var referenceAssemblies = ReferenceAssemblies.Net.Net60.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                 new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.22.0"),
                 new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.17.4"),
                 new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/RegistrationExpectedInAspNetIntegrationTests.cs
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/RegistrationExpectedInAspNetIntegrationTests.cs
@@ -3,6 +3,7 @@ using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Mi
 using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.RegistrationExpectedInASPNetIntegration, Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.CodeFixForRegistrationInASPNetCoreIntegration, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 using CodeFixVerifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.RegistrationExpectedInASPNetIntegration, Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.CodeFixForRegistrationInASPNetCoreIntegration, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.Azure.Functions.Tests.Analyzers;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 
@@ -406,7 +407,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Tests
 
         private static ReferenceAssemblies LoadRequiredDependencyAssemblies()
         {
-            var referenceAssemblies = ReferenceAssemblies.Net.Net60.WithPackages(ImmutableArray.Create(
+            var referenceAssemblies = ReferenceAssemblies.Net.Net60.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.19.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.15.1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/Worker.Extensions.Http.AspNetCore.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/Worker.Extensions.Http.AspNetCore.Tests.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(TestRoot)Shared/RepoReferenceAssemblies.cs" Link="Shared/RepoReferenceAssemblies.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(ExtensionsRoot)Worker.Extensions.Http.AspNetCore/src/Worker.Extensions.Http.AspNetCore.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

Both `extensions.http.aspnetcore.official` (DefId 407) and `extensions.http.aspnetcore.public` (DefId 491) fail the CFS (Central Feed Services) `CFSClean` check. 1ES compliance telemetry (`NetworkViolationAudit`) shows the offending process is **not** a restore step — it is `testhost.exe` hitting `api.nuget.org` **at test runtime**, after restore has completed.

## Root cause

The Roslyn analyzer test harness resolves NuGet packages on demand via `ReferenceAssemblies.WithPackages(...)`. `ReferenceAssemblies.ResolveAsync` loads NuGet settings with `Settings.LoadSpecificSettings(root: null)`, so it reads only the **user/machine-level** config (which defaults to nuget.org) and **never walks up to the repo `NuGet.Config`**. The compliant feed configured at the repo root is therefore ignored, and package resolution goes straight to nuget.org — failing CFS regardless of what the repo `NuGet.Config` says.

## Fix

Add a shared `RepoReferenceAssemblies.WithRepoNuGetConfig()` extension (`test/Shared/RepoReferenceAssemblies.cs`) that:
- locates the repo root by walking up from `AppContext.BaseDirectory` to the existing `.reporoot` marker file, and
- wires the repo `NuGet.Config` into the harness via `ReferenceAssemblies.WithNuGetConfigFilePath(...)`.

Placed **before** `.WithPackages(...)` so the base reference-assembly package resolution is covered too. This routes all runtime package resolution through the compliant `azfunc/public/upstream-public` Azure Artifacts feed.

The same latent pattern existed in `Sdk.Analyzers.Tests` (identical inline `ReferenceAssemblies.Net.*.WithPackages(...)` usage). Both projects run in the **same** unit-test pipeline (`eng/ci/templates/jobs/run-unit-tests.yml`), so all 23 call sites across both projects are fixed in one change for consistency.

### Files
- **New:** `test/Shared/RepoReferenceAssemblies.cs` — shared helper
- Both test `.csproj` link the shared helper via `<Compile Include ... Link=.../>`
- `Worker.Extensions.Http.AspNetCore.Tests` — 2 sites
- `Sdk.Analyzers.Tests` — 21 sites

## Validation

- Both projects build clean; analyzer tests pass. (`ReferenceAssemblies` resolution failures surface as the analyzer test source failing to compile, so a green run is a meaningful signal.)
- CI restores authenticated (`install-dotnet.yml` → `NuGetAuthenticate@1`, included by both `official-build.yml` and `public-build.yml`), and the `azfunc/public` build identity holds Collaborator (ingest) rights on `upstream-public`, so any not-yet-ingested versions self-heal via save-from-upstream on first run.

## Notes
- The repo root `NuGet.Config` (added by #3475) is unchanged.
- `Microsoft.Azure.Functions.Worker.Extensions.Abstractions 5.0.0` is a pre-existing dead package identity in the Http test fixtures (max published version is 1.3.0). `ReferenceAssemblies` silently tolerates it. Left as-is — unrelated to CFS.