### PR TITLE
feat(sdk): support FunctionsStartupAttribute scanning

### DIFF
--- a/src/Azure.Functions.Sdk/WebJobsReference.FromModule.cs
+++ b/src/Azure.Functions.Sdk/WebJobsReference.FromModule.cs
@@ -10,6 +10,9 @@ namespace Azure.Functions.Sdk;
 public sealed partial class WebJobsReference
 {
     private const string ExtensionsBinaryDirectoryPath = $@"./{Constants.ExtensionsOutputFolder}";
+    private const string FunctionsStartupAttributeType = "Microsoft.Azure.Functions.Extensions.DependencyInjection.FunctionsStartupAttribute";
+    private const string StringType = "System.String";
+    private const string TypeType = "System.Type";
     private const string WebJobsStartupAttributeType = "Microsoft.Azure.WebJobs.Hosting.WebJobsStartupAttribute";
 
     /// <summary>
@@ -26,8 +29,8 @@ public sealed partial class WebJobsReference
 
         foreach (CustomAttribute attribute in startupAttributes)
         {
-            attribute.GetArguments(out TypeDefinition typeDef, out string name);
-            name = GetName(name, typeDef);
+            GetStartupTypeAndName(attribute, out TypeDefinition typeDef, out string name);
+
             string assemblyQualifiedName = Assembly.CreateQualifiedName(
                 typeDef.Module.Assembly.FullName, typeDef.GetReflectionFullName());
             string fileName = Path.GetFileName(assembly.MainModule.FileName);
@@ -36,12 +39,40 @@ public sealed partial class WebJobsReference
         }
     }
 
+    private static void GetStartupTypeAndName(
+        CustomAttribute attribute,
+        out TypeDefinition startupType,
+        out string name)
+    {
+        IList<CustomAttributeArgument> arguments = attribute.ConstructorArguments;
+        if (arguments.Count == 1
+            && string.Equals(arguments[0].Type.FullName, TypeType, StringComparison.Ordinal))
+        {
+            startupType = (TypeDefinition)arguments[0].Value;
+            name = startupType.Name;
+            return;
+        }
+
+        if (arguments.Count == 2
+            && string.Equals(arguments[0].Type.FullName, TypeType, StringComparison.Ordinal)
+            && string.Equals(arguments[1].Type.FullName, StringType, StringComparison.Ordinal))
+        {
+            startupType = (TypeDefinition)arguments[0].Value;
+            name = GetName((string)arguments[1].Value, startupType);
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Unexpected constructor signature for startup attribute '{attribute.AttributeType.FullName}'.");
+    }
+
     private static bool IsWebJobsStartupAttributeType(TypeReference attributeType, ILogger logger)
     {
         try
         {
             return attributeType.CheckTypeInheritance(
-                type => string.Equals(type.FullName, WebJobsStartupAttributeType, StringComparison.OrdinalIgnoreCase));
+                type => string.Equals(type.FullName, WebJobsStartupAttributeType, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(type.FullName, FunctionsStartupAttributeType, StringComparison.OrdinalIgnoreCase));
         }
         catch (Exception ex) when (ex is FileNotFoundException or BadImageFormatException)
         {

--- a/test/Azure.Functions.Sdk.Tests/FunctionsAssemblyScannerTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/FunctionsAssemblyScannerTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Mono.Cecil;
+
 namespace Azure.Functions.Sdk.Tests;
 
 public class FunctionsAssemblyScannerTests
@@ -49,5 +51,81 @@ public class FunctionsAssemblyScannerTests
     {
         bool result = FunctionsAssemblyScanner.ShouldScanPackage(assembly);
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetWebJobsReferences_FunctionsStartupAttributeWithoutAttributeAssembly_IsDiscovered()
+    {
+        using TempDirectory directory = new();
+        string assemblyPath = Path.Combine(directory.Path, "FunctionsStartupConsumer.dll");
+        CreateStartupConsumerAssembly(assemblyPath);
+        FunctionsAssemblyScanner scanner = new();
+
+        WebJobsReference reference = scanner.GetWebJobsReferences(assemblyPath).Single();
+
+        reference.Name.Should().Be("ExternalFunctionsStartup");
+        reference.TypeName.Should().StartWith("Azure.Functions.Sdk.Tests.ExternalFunctionsStartup, FunctionsStartupConsumer");
+        reference.HintPath.Should().Be("./.azurefunctions/FunctionsStartupConsumer.dll");
+    }
+
+    [Fact]
+    public void GetWebJobsReferences_WebJobsStartupAttribute_UsesProvidedName()
+    {
+        using TempDirectory directory = new();
+        string assemblyPath = Path.Combine(directory.Path, "WebJobsStartupConsumer.dll");
+        CreateStartupConsumerAssembly(assemblyPath, "CustomExtension");
+        FunctionsAssemblyScanner scanner = new();
+
+        WebJobsReference reference = scanner.GetWebJobsReferences(assemblyPath).Single();
+
+        reference.Name.Should().Be("CustomExtension");
+        reference.TypeName.Should().StartWith("Azure.Functions.Sdk.Tests.ExternalFunctionsStartup, WebJobsStartupConsumer");
+        reference.HintPath.Should().Be("./.azurefunctions/WebJobsStartupConsumer.dll");
+    }
+
+    private static void CreateStartupConsumerAssembly(string assemblyPath, string? extensionName = null)
+    {
+        using AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition(Path.GetFileNameWithoutExtension(assemblyPath), new Version(1, 0)),
+            Path.GetFileNameWithoutExtension(assemblyPath),
+            ModuleKind.Dll);
+        ModuleDefinition module = assembly.MainModule;
+        TypeDefinition startupType = new(
+            "Azure.Functions.Sdk.Tests",
+            "ExternalFunctionsStartup",
+            Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(startupType);
+
+        bool isFunctionsStartup = extensionName is null;
+        AssemblyNameReference attributeAssembly = new(
+            isFunctionsStartup ? "Microsoft.Azure.Functions.Extensions" : "Microsoft.Azure.WebJobs.Host",
+            new Version(1, 0));
+        module.AssemblyReferences.Add(attributeAssembly);
+        TypeReference attributeType = new(
+            isFunctionsStartup
+                ? "Microsoft.Azure.Functions.Extensions.DependencyInjection"
+                : "Microsoft.Azure.WebJobs.Hosting",
+            isFunctionsStartup ? "FunctionsStartupAttribute" : "WebJobsStartupAttribute",
+            module,
+            attributeAssembly);
+        MethodReference constructor = new(".ctor", module.TypeSystem.Void, attributeType)
+        {
+            HasThis = true,
+        };
+        TypeReference systemType = module.ImportReference(typeof(Type));
+        constructor.Parameters.Add(new ParameterDefinition(systemType));
+        CustomAttribute attribute = new(constructor);
+        attribute.ConstructorArguments.Add(new CustomAttributeArgument(systemType, startupType));
+        if (extensionName is not null)
+        {
+            constructor.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+            attribute.ConstructorArguments.Add(
+                new CustomAttributeArgument(module.TypeSystem.String, extensionName));
+        }
+
+        assembly.CustomAttributes.Add(attribute);
+
+        assembly.Write(assemblyPath);
     }
 }


### PR DESCRIPTION
## Summary
- recognize FunctionsStartupAttribute during WebJobs assembly scanning without resolving its defining assembly
- decode supported startup attributes from their constructor signatures
- add cross-assembly regression coverage for FunctionsStartupAttribute and WebJobsStartupAttribute

## Testing
- dotnet test .\test\Azure.Functions.Sdk.Tests\Azure.Functions.Sdk.Tests.csproj --framework net10.0 --filter FullyQualifiedName~FunctionsAssemblyScannerTests --no-restore -p:IsTestProject=true
- dotnet test .\test\Azure.Functions.Sdk.Tests\Azure.Functions.Sdk.Tests.csproj --framework net472 --filter FullyQualifiedName~FunctionsAssemblyScannerTests --no-restore -p:IsTestProject=true