### PR TITLE
ci: migrate pipelines to Windows 2025 image

### DIFF
--- a/eng/ci/host/official-build.yml
+++ b/eng/ci/host/official-build.yml
@@ -33,7 +33,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/host/public-build.yml
+++ b/eng/ci/host/public-build.yml
@@ -36,7 +36,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -46,7 +46,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -36,7 +36,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/eng/ci/templates/jobs/run-integration-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-integration-tests-windows.yml
@@ -15,7 +15,7 @@ jobs:
 
   pool:
     name: ${{ parameters.poolName }}
-    image: 1es-windows-2022
+    image: 1es-windows-2025-min
     os: windows
     ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
       demands:

--- a/eng/ci/templates/jobs/run-unit-tests.yml
+++ b/eng/ci/templates/jobs/run-unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
         imageName: '1es-ubuntu-24.04-min'
         osName: 'linux'
       windows:
-        imageName: '1es-windows-2022'
+        imageName: '1es-windows-2025-min'
         osName: 'windows'
 
   templateContext:

--- a/eng/ci/templates/official/jobs/build-artifacts.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts.yml
@@ -13,7 +13,7 @@ jobs:
 
   pool:
     name: 1es-pool-azfunc
-    image: 1es-windows-2022
+    image: 1es-windows-2025-min
     os: windows
     ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
       demands:

--- a/extensions/Worker.Extensions.Abstractions/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Abstractions/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Abstractions/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Abstractions/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.CosmosDB/ci/official-build.yml
+++ b/extensions/Worker.Extensions.CosmosDB/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.CosmosDB/ci/public-build.yml
+++ b/extensions/Worker.Extensions.CosmosDB/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.EventGrid/ci/official-build.yml
+++ b/extensions/Worker.Extensions.EventGrid/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.EventGrid/ci/public-build.yml
+++ b/extensions/Worker.Extensions.EventGrid/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.EventHubs/ci/official-build.yml
+++ b/extensions/Worker.Extensions.EventHubs/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.EventHubs/ci/public-build.yml
+++ b/extensions/Worker.Extensions.EventHubs/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Http.AspNetCore/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Http.AspNetCore/ci/official-build.yml
@@ -36,7 +36,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -44,7 +44,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Http.AspNetCore/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Http.AspNetCore/ci/public-build.yml
@@ -44,7 +44,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -52,7 +52,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Http/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Http/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Http/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Http/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Kafka/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Kafka/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Kafka/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Kafka/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.RabbitMQ/ci/official-build.yml
+++ b/extensions/Worker.Extensions.RabbitMQ/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.RabbitMQ/ci/public-build.yml
+++ b/extensions/Worker.Extensions.RabbitMQ/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Rpc/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Rpc/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Rpc/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Rpc/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.SendGrid/ci/official-build.yml
+++ b/extensions/Worker.Extensions.SendGrid/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.SendGrid/ci/public-build.yml
+++ b/extensions/Worker.Extensions.SendGrid/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.ServiceBus/ci/official-build.yml
+++ b/extensions/Worker.Extensions.ServiceBus/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.ServiceBus/ci/public-build.yml
+++ b/extensions/Worker.Extensions.ServiceBus/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.SignalRService/ci/official-build.yml
+++ b/extensions/Worker.Extensions.SignalRService/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.SignalRService/ci/public-build.yml
+++ b/extensions/Worker.Extensions.SignalRService/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Storage.Blobs/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Storage.Blobs/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Storage.Blobs/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Storage.Blobs/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Storage.Queues/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Storage.Queues/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Storage.Queues/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Storage.Queues/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Storage/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Storage/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Storage/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Storage/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Tables/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Tables/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Tables/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Tables/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Timer/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Timer/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Timer/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Timer/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:

--- a/extensions/Worker.Extensions.Warmup/ci/official-build.yml
+++ b/extensions/Worker.Extensions.Warmup/ci/official-build.yml
@@ -35,7 +35,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -43,7 +43,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     stages:

--- a/extensions/Worker.Extensions.Warmup/ci/public-build.yml
+++ b/extensions/Worker.Extensions.Warmup/ci/public-build.yml
@@ -42,7 +42,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:
@@ -50,7 +50,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1es-pool-azfunc-public
-        image: 1es-windows-2022
+        image: 1es-windows-2025-min
         os: windows
 
     settings:


### PR DESCRIPTION
## Summary
- migrate all pipeline references from `1es-windows-2022` to `1es-windows-2025-min`
- update shared CI templates and extension build pipelines

## Validation
- confirmed all 79 references across 43 YAML files use the new image
- confirmed no `1es-windows-2022` references remain