### PR TITLE
build(sdk): release Azure.Functions.Sdk 1.0.0

### DIFF
--- a/samples/FunctionApp.MSBuildSdk/FunctionApp.MSBuildSdk.csproj
+++ b/samples/FunctionApp.MSBuildSdk/FunctionApp.MSBuildSdk.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Azure.Functions.Sdk/0.4.0">
+﻿<Project Sdk="Azure.Functions.Sdk/0.5.0">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Microsoft.Azure.Functions.Worker already included by the SDK. -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
   </ItemGroup>
 

--- a/samples/FunctionApp.MSBuildSdk/README.md
+++ b/samples/FunctionApp.MSBuildSdk/README.md
@@ -14,10 +14,14 @@ Minimal getting-started project:
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="[WORKER_VERSION]" />
+  </ItemGroup>
 </Project>
 ```
 
-This will automatically include the base package-references needed for the dotnet isolated worker runtime.
+The worker runtime package must be referenced explicitly.
 
 ## What is different?
 

--- a/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
+++ b/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
@@ -16,6 +16,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>$(BuildNumber)</VersionSuffix>
     <PolySharpExcludeGeneratedTypes>System.Runtime.CompilerServices.ModuleInitializerAttribute;System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute</PolySharpExcludeGeneratedTypes>
     <MetadataLoaderExtensionProject>$(RepoRoot)sdk/FunctionMetadataLoaderExtension/FunctionMetadataLoaderExtension.csproj</MetadataLoaderExtensionProject>
     <BeforePack>$(BeforePack);GetReleaseNotes</BeforePack>

--- a/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
+++ b/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
@@ -15,8 +15,7 @@
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>$(BuildNumber)</VersionSuffix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <PolySharpExcludeGeneratedTypes>System.Runtime.CompilerServices.ModuleInitializerAttribute;System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute</PolySharpExcludeGeneratedTypes>
     <MetadataLoaderExtensionProject>$(RepoRoot)sdk/FunctionMetadataLoaderExtension/FunctionMetadataLoaderExtension.csproj</MetadataLoaderExtensionProject>
     <BeforePack>$(BeforePack);GetReleaseNotes</BeforePack>

--- a/src/Azure.Functions.Sdk/README.md
+++ b/src/Azure.Functions.Sdk/README.md
@@ -95,6 +95,11 @@ To migrate, make the following project file changes:
 
 > **Note:** The `FunctionsEnableWorkerIndexing` property is deprecated with `Azure.Functions.Sdk`. Worker indexing is always enabled, so setting this property has no effect and emits [AZFW0110](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/docs/sdk-rules/AZFW0110.md). Remove it from your project file.
 
+## Known Gaps
+
+- Attributes derived from `WebJobsStartupAttribute` are not supported. Only direct uses of `WebJobsStartupAttribute` and `FunctionsStartupAttribute` are recognized.
+- `ExtensionInformationAttribute` metadata from project-to-project references is not used.
+
 ## Generated Extension Project (`azure_functions.g.csproj`)
 
 During restore, the SDK generates a helper project named `azure_functions.g.csproj` in your `obj/` directory. This project is used to resolve the function extension assemblies required by the Azure Functions host. It is restored automatically and its outputs are included in your build and publish output.

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -4,18 +4,6 @@
 - My change description (#PR/#issue)
 -->
 
-### Azure.Functions.Sdk 0.5.0
+### Azure.Functions.Sdk 1.0.0
 
-- fix: no longer add `Microsoft.Azure.Functions.Worker` as an implicit package reference, which caused silent version downgrades and runtime `MissingMethodException` failures (#3450)
-  - reference `Microsoft.Azure.Functions.Worker` explicitly in your project
-  - emit `AZFW0111` warning when no worker package is found after restore
-  - source generators are skipped if this package is missing
-- fix: expand removed properties and pin `Configuration=release` when restoring/resolving the generated extension project (#3399)
-- fix: reliably resolve extension restore sources (#3393)
-- feat: emit `AZFW0110` warning when the deprecated `FunctionsEnableWorkerIndexing` property is set (#3395)
-- fix: redact sensitive information (credentials and query strings) from ZipDeploy publish logs (#3398)
-- feat: improve implicit package reference behavior (#3409)
-  - now respects central package management
-- fix: re-generate worker.config.json on publish without build (#3408)
-- fix: Perform atomic write in WriteExtensionProject (#3407)
-- fix: avoid zip-file conflicts (#3406)
+- Support `FunctionsStartupAttribute` scanning (#3482)


### PR DESCRIPTION
## Summary
- release `Azure.Functions.Sdk` as stable version 1.0.0
- reset release notes for 1.0.0 with `FunctionsStartupAttribute` scanning support from #3482
- document known migration gaps for startup attribute inheritance and project-to-project extension metadata

## Validation
- verified the evaluated package version is `1.0.0` even when `BuildNumber` contains a preview value