### PR TITLE
fix: repair Kafka attribute tests

### DIFF
--- a/test/extensions/Worker.Extensions.Tests/Kafka/KafkaAttributeTests.cs
+++ b/test/extensions/Worker.Extensions.Tests/Kafka/KafkaAttributeTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-    }
-}
+using Xunit;
+
 namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Kafka
 {
     public class KafkaAttributeTests


### PR DESCRIPTION
## Summary

- remove stray closing braces from the new Kafka attribute test file
- add the missing xUnit import

## Validation

- focused Kafka attribute tests: 2 passed
- Worker.Extensions.Tests: 235 passed
- dotnet build: succeeded