### PR TITLE
feat: add Kafka OAuth HTTPS CA settings

### DIFF
--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -4,6 +4,9 @@
 - My change description (#PR/#issue)
 -->
 
+- Add `HttpsCaLocation` and `HttpsCaPem` to Kafka trigger and output bindings for OAuth/OIDC token endpoint certificate validation (azure-functions-kafka-extension#649)
+- Update `Microsoft.Azure.WebJobs.Extensions.Kafka` dependency from 4.3.2 to 4.3.3
+
 ### Microsoft.Azure.Functions.Worker.Extensions.Kafka 4.3.0
 
 - **Breaking**: Remove `LeaderEpoch` from `KafkaRecord` — it is consumer fetch metadata, not stored record data (azure-functions-kafka-extension#639)

--- a/extensions/Worker.Extensions.Kafka/src/KafkaOutputAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaOutputAttribute.cs
@@ -219,6 +219,19 @@ namespace Microsoft.Azure.Functions.Worker
         public string OAuthBearerTokenEndpointUrl { get; set; }
 
         /// <summary>
+        /// File or directory path to CA certificates for verifying the OAuth/OIDC token endpoint certificate.
+        /// The special value "probe" uses the operating system's default certificate paths.
+        /// https.ca.location in librdkafka
+        /// </summary>
+        public string HttpsCaLocation { get; set; }
+
+        /// <summary>
+        /// CA certificate for verifying the OAuth/OIDC token endpoint certificate in PEM format.
+        /// https.ca.pem in librdkafka
+        /// </summary>
+        public string HttpsCaPem { get; set; }
+
+        /// <summary>
         /// OAuth Bearer extensions.
         /// Allow additional information to be provided to the broker.
         /// Comma-separated list of key=value pairs. E.g., "supportFeatureX=true,organizationId=sales-emea"

--- a/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
+++ b/extensions/Worker.Extensions.Kafka/src/KafkaTriggerAttribute.cs
@@ -205,6 +205,19 @@ namespace Microsoft.Azure.Functions.Worker
         public string OAuthBearerTokenEndpointUrl { get; set; }
 
         /// <summary>
+        /// File or directory path to CA certificates for verifying the OAuth/OIDC token endpoint certificate.
+        /// The special value "probe" uses the operating system's default certificate paths.
+        /// https.ca.location in librdkafka
+        /// </summary>
+        public string HttpsCaLocation { get; set; }
+
+        /// <summary>
+        /// CA certificate for verifying the OAuth/OIDC token endpoint certificate in PEM format.
+        /// https.ca.pem in librdkafka
+        /// </summary>
+        public string HttpsCaPem { get; set; }
+
+        /// <summary>
         /// OAuth Bearer extensions.
         /// Allow additional information to be provided to the broker.
         /// Comma-separated list of key=value pairs. E.g., "supportFeatureX=true,organizationId=sales-emea"

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Kafka" Version="4.3.2" />
+    <WebJobsExtension Include="Microsoft.Azure.WebJobs.Extensions.Kafka" Version="4.3.3" />
   </ItemGroup>
 
 </Project>

--- a/test/extensions/Worker.Extensions.Tests/Kafka/KafkaAttributeTests.cs
+++ b/test/extensions/Worker.Extensions.Tests/Kafka/KafkaAttributeTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Tests.Kafka
+{
+    public class KafkaAttributeTests
+    {
+        [Fact]
+        public void KafkaTriggerAttributeSupportsOAuthHttpsCaSettings()
+        {
+            var attribute = new KafkaTriggerAttribute("broker", "topic")
+            {
+                HttpsCaLocation = "ca-path",
+                HttpsCaPem = "ca-pem"
+            };
+
+            Assert.Equal("ca-path", attribute.HttpsCaLocation);
+            Assert.Equal("ca-pem", attribute.HttpsCaPem);
+        }
+
+        [Fact]
+        public void KafkaOutputAttributeSupportsOAuthHttpsCaSettings()
+        {
+            var attribute = new KafkaOutputAttribute("broker", "topic")
+            {
+                HttpsCaLocation = "ca-path",
+                HttpsCaPem = "ca-pem"
+            };
+
+            Assert.Equal("ca-path", attribute.HttpsCaLocation);
+            Assert.Equal("ca-pem", attribute.HttpsCaPem);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `HttpsCaLocation` and `HttpsCaPem` to Kafka trigger and output bindings for OAuth/OIDC token endpoint certificate validation.
- Update `Microsoft.Azure.WebJobs.Extensions.Kafka` from 4.3.2 to 4.3.3.
- Add corrected attribute tests covering both Kafka trigger and output bindings.

Supersedes #3491 and #3493.
Relates to Azure/azure-functions-kafka-extension#649.

## Testing

- `dotnet test test\extensions\Worker.Extensions.Tests\Worker.Extensions.Tests.csproj --filter FullyQualifiedName~KafkaAttributeTests --no-restore --verbosity minimal`