### PR TITLE
Prepare Kafka extension 4.3.3 release

### DIFF
--- a/extensions/Worker.Extensions.Kafka/release_notes.md
+++ b/extensions/Worker.Extensions.Kafka/release_notes.md
@@ -4,6 +4,8 @@
 - My change description (#PR/#issue)
 -->
 
+### Microsoft.Azure.Functions.Worker.Extensions.Kafka 4.3.3
+
 - Add `HttpsCaLocation` and `HttpsCaPem` to Kafka trigger and output bindings for OAuth/OIDC token endpoint certificate validation (azure-functions-kafka-extension#649)
 - Update `Microsoft.Azure.WebJobs.Extensions.Kafka` dependency from 4.3.2 to 4.3.3
 

--- a/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
+++ b/extensions/Worker.Extensions.Kafka/src/Worker.Extensions.Kafka.csproj
@@ -6,7 +6,7 @@
     <Description>Kafka extensions for .NET isolated functions</Description>
 
     <!--Version information-->
-    <VersionPrefix>4.3.0</VersionPrefix>
+    <VersionPrefix>4.3.3</VersionPrefix>
 
     <!--Temporarily opting out of documentation. Pending documentation-->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary

- update `Microsoft.Azure.Functions.Worker.Extensions.Kafka` package version to 4.3.3
- finalize the 4.3.3 release notes for OAuth HTTPS CA settings and the WebJobs Kafka 4.3.3 dependency

## Testing

- Not run locally because this repository requires .NET SDK 10.0.400, which is not installed in the current environment.