### PR TITLE
test: modernize analyzer testing packages

### DIFF
--- a/test/Sdk.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
+++ b/test/Sdk.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
@@ -8,7 +8,6 @@ using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<Micr
 using CodeFixVerifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.AsyncVoidAnalyzer, Microsoft.Azure.Functions.Worker.Sdk.Analyzers.AsyncVoidCodeFixProvider, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using System.Collections.Immutable;
 using System.Threading;
 
 using Microsoft.Azure.Functions.Tests.Analyzers;
@@ -47,9 +46,9 @@ namespace FunctionApp4
             };
 
             var expectedDiagnosticResult = AnalyzerVerifier
-                                                .Diagnostic(DiagnosticId)
-                                                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
-                                                .WithSpan(11, 34, 11, 37);  // 11th line, 34th character(Run method)
+                .Diagnostic(DiagnosticId)
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(11, 34, 11, 37);  // 11th line, 34th character(Run method)
 
             test.ExpectedDiagnostics.Add(expectedDiagnosticResult);
 
@@ -173,10 +172,12 @@ namespace FunctionApp4
 
         private static ReferenceAssemblies LoadRequiredDependencyAssemblies()
         {
-            var referenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+            var referenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+            [
                 new PackageIdentity("Microsoft.Azure.WebJobs.Extensions", "4.0.1"),
                 new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.1.0"),
-                new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage", "4.0.4")));
+                new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage", "4.0.4"),
+            ]);
 
             return referenceAssemblies;
         }

--- a/test/Sdk.Analyzers.Tests/BindingTypeNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/BindingTypeNotSupportedTests.cs
@@ -53,8 +53,8 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
-                                        new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"))),
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                    [new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0")]),
                 TestCode = testCode
             };
 
@@ -101,8 +101,8 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
-                                        new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"))),
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                    [new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0")]),
                 TestCode = testCode
             };
 
@@ -150,8 +150,8 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
-                                        new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"))),
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                    [new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0")]),
                 TestCode = testCode
             };
 

--- a/test/Sdk.Analyzers.Tests/DeferredBindingAttributeNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/DeferredBindingAttributeNotSupportedTests.cs
@@ -6,7 +6,6 @@ using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Mi
 using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.DeferredBindingAttributeNotSupported, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using System.Collections.Immutable;
 
 using Microsoft.Azure.Functions.Tests.Analyzers;
 
@@ -30,10 +29,12 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.12.1-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"),
+                ]),
 
                 TestCode = testCode
             };
@@ -59,10 +60,12 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.12.1-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"),
+                ]),
 
                 TestCode = testCode
             };
@@ -88,18 +91,20 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.12.1-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"),
+                ]),
 
                 TestCode = testCode
             };
 
             test.ExpectedDiagnostics.Add(Verify.Diagnostic()
-                                        .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
-                                        .WithSpan(6, 22, 6, 45)
-                                        .WithArguments("SupportsDeferredBindingAttribute"));
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(6, 22, 6, 45)
+                .WithArguments("SupportsDeferredBindingAttribute"));
 
             await test.RunAsync();
         }
@@ -120,18 +125,20 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.12.1-preview1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.9.0-preview1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.2.0-preview1"),
+                ]),
 
                 TestCode = testCode
             };
 
             test.ExpectedDiagnostics.Add(Verify.Diagnostic()
-                                        .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
-                                        .WithSpan(6, 22, 6, 45)
-                                        .WithArguments("SupportsDeferredBindingAttribute"));
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(6, 22, 6, 45)
+                .WithArguments("SupportsDeferredBindingAttribute"));
 
             await test.RunAsync();
         }

--- a/test/Sdk.Analyzers.Tests/IterableBindingTypeExpectedForBlobContainerPathTests.cs
+++ b/test/Sdk.Analyzers.Tests/IterableBindingTypeExpectedForBlobContainerPathTests.cs
@@ -6,7 +6,6 @@ using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Mi
 using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.IterableBindingTypeExpectedForBlobContainerPath, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using System.Collections.Immutable;
 
 using Microsoft.Azure.Functions.Tests.Analyzers;
 
@@ -34,19 +33,21 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };
 
             test.ExpectedDiagnostics.Add(Verify.Diagnostic()
-                            .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
-                            .WithSpan(10, 76, 10, 83)
-                            .WithArguments("string"));
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(10, 76, 10, 83)
+                .WithArguments("string"));
 
             await test.RunAsync();
         }
@@ -72,19 +73,21 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };
 
             test.ExpectedDiagnostics.Add(Verify.Diagnostic()
-                            .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
-                            .WithSpan(11, 76, 11, 83)
-                            .WithArguments("System.IO.Stream"));
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(11, 76, 11, 83)
+                .WithArguments("System.IO.Stream"));
 
             await test.RunAsync();
         }
@@ -109,19 +112,21 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };
 
             test.ExpectedDiagnostics.Add(Verify.Diagnostic()
-                            .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
-                            .WithSpan(10, 76, 10, 83)
-                            .WithArguments("byte[]"));
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(10, 76, 10, 83)
+                .WithArguments("byte[]"));
 
             await test.RunAsync();
         }
@@ -147,11 +152,13 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };
@@ -183,11 +190,13 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };
@@ -218,11 +227,13 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };
@@ -253,11 +264,13 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };
@@ -289,11 +302,13 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };
@@ -325,11 +340,13 @@ namespace Sdk.Analyzers.Tests
 
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.18.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.13.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs", "6.0.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.3.0"),
+                ]),
 
                 TestCode = testCode
             };

--- a/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
+++ b/test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj
@@ -16,10 +16,10 @@
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
     <!--Transitive packages promoted due to CVEs:-->
-    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/test/Sdk.Analyzers.Tests/WebJobsAttributesNotSupportedTests.cs
+++ b/test/Sdk.Analyzers.Tests/WebJobsAttributesNotSupportedTests.cs
@@ -6,7 +6,6 @@ using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Mi
 using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Microsoft.Azure.Functions.Worker.Sdk.Analyzers.WebJobsAttributesNotSupported, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using System.Collections.Immutable;
 
 using Microsoft.Azure.Functions.Tests.Analyzers;
 
@@ -36,12 +35,14 @@ namespace FunctionApp
             var test = new AnalyzerTest
             {
                 // TODO: This needs to pull from a local source
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.WebJobs.Extensions", "4.0.1"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Abstractions", "1.1.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Http", "3.0.12"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Http", "3.0.12"),
+                ]),
 
                 TestCode = testCode
             };
@@ -74,11 +75,13 @@ namespace FunctionApp
 }";
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
                     new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "5.0.1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"),
+                ]),
 
                 TestCode = testCode
             };
@@ -112,11 +115,13 @@ namespace FunctionApp
 }";
             var test = new AnalyzerTest
             {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
                     new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "5.0.1"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"),
+                ]),
 
                 TestCode = testCode
             };
@@ -150,10 +155,12 @@ namespace GH258IsolatedReturnWebJobsAttr
             var test = new AnalyzerTest
             {
                 // TODO: This needs to pull from a local source
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithRepoNuGetConfig().WithPackages(ImmutableArray.Create(
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithRepoNuGetConfig().WithPackages(
+                [
                     new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.10.0"),
                     new PackageIdentity("Microsoft.Azure.Functions.Worker.Sdk", "1.7.0"),
-                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"))),
+                    new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.Timer", "4.0.1"),
+                ]),
 
                 TestCode = testCode
             };

--- a/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
+++ b/test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Kafka" Version="4.1.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.SignalRService" Version="2.0.1" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.11.0" PrivateAssets="all" />
@@ -38,7 +38,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="Moq" Version="4.20.71" />
     <!--Transitive packages promoted due to CVEs:-->
-    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/test/Sdk.Generator.Tests/TestHelpers.cs
+++ b/test/Sdk.Generator.Tests/TestHelpers.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.Testing;
 using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.Azure.Functions.Worker.Core;
 using System.Reflection;
 using System.Collections.Generic;

--- a/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/Worker.Extensions.Http.AspNetCore.Tests.csproj
+++ b/test/extensions/Worker.Extensions.Http.AspNetCore.Tests/Worker.Extensions.Http.AspNetCore.Tests.csproj
@@ -11,13 +11,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- replace obsolete framework-specific Roslyn analyzer testing packages with the generic 1.1.4 packages
- update analyzer test reference assemblies from .NET 5 to .NET 10
- align `System.Formats.Asn1` dependencies and remove the obsolete verifier namespace import

## Tests
- `dotnet test test/Sdk.Analyzers.Tests/Sdk.Analyzers.Tests.csproj`
- `dotnet test test/Sdk.Generator.Tests/Sdk.Generator.Tests.csproj`
- `dotnet test test/extensions/Worker.Extensions.Http.AspNetCore.Tests/Worker.Extensions.Http.AspNetCore.Tests.csproj`