### PR TITLE
fix(sdk): restore ZipDeploy publishing

### DIFF
--- a/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
+++ b/src/Azure.Functions.Sdk/Azure.Functions.Sdk.csproj
@@ -15,7 +15,7 @@
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix>$(BuildNumber)</VersionSuffix>
     <PolySharpExcludeGeneratedTypes>System.Runtime.CompilerServices.ModuleInitializerAttribute;System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute</PolySharpExcludeGeneratedTypes>
     <MetadataLoaderExtensionProject>$(RepoRoot)sdk/FunctionMetadataLoaderExtension/FunctionMetadataLoaderExtension.csproj</MetadataLoaderExtensionProject>

--- a/src/Azure.Functions.Sdk/Targets/Publish/Azure.Functions.Sdk.Publish.ZipDeploy.targets
+++ b/src/Azure.Functions.Sdk/Targets/Publish/Azure.Functions.Sdk.Publish.ZipDeploy.targets
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 <Project>
   <UsingTask TaskName="$(AzureFunctionsTaskNamespace).Publish.CreateFuncZipFile" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
-  <UsingTask TaskName="$(AzureFunctionsTaskNamespace).Publish.ZipDeploy" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
+  <UsingTask TaskName="$(AzureFunctionsTaskNamespace).Publish.FuncZipDeploy" AssemblyFile="$(AzureFunctionsSdkTasksAssembly)" />
 
   <PropertyGroup>
     <_DotNetPublishFiles>
@@ -33,7 +33,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <_ZipPublishUrl Condition="'$(_ZipPublishUrl)' == ''">https://$(DeployIisAppPath).scm.azurewebsites.net/</_ZipPublishUrl>
     </PropertyGroup>
 
-    <ZipDeploy ZipContentsPath="$(ZippedPublishContentsPath)" PublishUrl="$(_ZipPublishUrl)"
+    <FuncZipDeploy ZipContentsPath="$(ZippedPublishContentsPath)" PublishUrl="$(_ZipPublishUrl)"
       DeploymentUsername="$(UserName)" DeploymentPassword="$(Password)"
       UseBlobContainerDeploy="$(UseBlobContainerDeploy)"
       AllowInsecureRemoteConnections="$(PublishAllowInsecureRemoteConnections)"

--- a/src/Azure.Functions.Sdk/Tasks/Publish/CreateFuncZipFile.cs
+++ b/src/Azure.Functions.Sdk/Tasks/Publish/CreateFuncZipFile.cs
@@ -78,6 +78,7 @@ public sealed class CreateFuncZipFile(TimeProvider time) : Microsoft.Build.Utili
     {
         string zipFileName = ProjectName + _time.GetLocalNow().ToString("yyyyMMddHHmmssFFF") + ".zip";
         string destination = Path.Combine(PublishIntermediateTempPath, zipFileName);
+        Directory.CreateDirectory(PublishIntermediateTempPath);
         ZipFile.CreateFromDirectory(SourceFolder, destination);
 
         // Is the executable part of the zip file itself? If so, ensure it is marked executable on unix.

--- a/src/Azure.Functions.Sdk/Tasks/Publish/FuncZipDeploy.cs
+++ b/src/Azure.Functions.Sdk/Tasks/Publish/FuncZipDeploy.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Framework;
 
 namespace Azure.Functions.Sdk.Tasks.Publish;
 
-public sealed class ZipDeploy(IFileSystem fileSystem, DeploymentClient? client = null)
+public sealed class FuncZipDeploy(IFileSystem fileSystem, DeploymentClient? client = null)
     : Microsoft.Build.Utilities.Task, ICancelableTask, IDisposable
 {
     internal static readonly ProductInfoHeaderValue SdkUserAgentHeader = new(
@@ -27,7 +27,7 @@ public sealed class ZipDeploy(IFileSystem fileSystem, DeploymentClient? client =
 
     private HttpClient? _httpClient; // tracked for disposal, if created by this class.
 
-    public ZipDeploy()
+    public FuncZipDeploy()
         : this(new FileSystem())
     {
     }
@@ -167,4 +167,3 @@ public sealed class ZipDeploy(IFileSystem fileSystem, DeploymentClient? client =
         return true;
     }
 }
-

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -7,7 +7,3 @@
 ### Azure.Functions.Sdk 1.0.1
 
 - Fix ZipDeploy publishing on clean project trees (#3504)
-
-### Azure.Functions.Sdk 1.0.0
-
-- Support `FunctionsStartupAttribute` scanning (#3482)

--- a/src/Azure.Functions.Sdk/release_notes.md
+++ b/src/Azure.Functions.Sdk/release_notes.md
@@ -4,6 +4,10 @@
 - My change description (#PR/#issue)
 -->
 
+### Azure.Functions.Sdk 1.0.1
+
+- Fix ZipDeploy publishing on clean project trees (#3504)
+
 ### Azure.Functions.Sdk 1.0.0
 
 - Support `FunctionsStartupAttribute` scanning (#3482)

--- a/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Publish.cs
+++ b/test/Azure.Functions.Sdk.Tests/Integration/SdkEndToEndTests.Publish.cs
@@ -84,4 +84,30 @@ public partial class SdkEndToEndTests : MSBuildSdkTestBase
             "dotnet",
             "MyFunctionApp.dll");
     }
+
+    [Fact]
+    public void Publish_ZipDeploy_UsesFunctionsTask()
+    {
+        // Arrange
+        ProjectCreator project = ProjectCreator.Templates.AzureFunctionsProject(
+            GetTempCsproj(), targetFramework: "net8.0")
+            .Property("AssemblyName", "MyFunctionApp")
+            .WriteSourceFile("Program.cs", Resources.Program_Minimal_cs);
+        Dictionary<string, string> publishProperties = new()
+        {
+            ["PublishProtocol"] = "ZipDeploy",
+            ["PublishUrl"] = "not-an-absolute-url",
+            ["UserName"] = "test-user",
+            ["Password"] = "test-password",
+        };
+
+        // Act
+        BuildOutput output = project.Publish(build: true, restore: true, publishProperties);
+
+        // Assert
+        output.Should().BeFailed();
+        output.ErrorEvents.Should().ContainSingle()
+            .Which.Message.Should().Be(
+                "The publish url 'not-an-absolute-url' is invalid. Publish url must be an absolute HTTP or HTTPS url.");
+    }
 }

--- a/test/Azure.Functions.Sdk.Tests/Tasks/Publish/CreateFuncZipFileTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/Publish/CreateFuncZipFileTests.cs
@@ -76,12 +76,14 @@ public sealed class CreateFuncZipFileTests : IDisposable
         // arrange
         SetupZipFolder();
         CreateFuncZipFile task = CreateTask();
+        Directory.Exists(IntermediatePath).Should().BeFalse();
 
         // act
         bool result = task.Execute();
 
         // assert
         result.Should().BeTrue();
+        Directory.Exists(IntermediatePath).Should().BeTrue();
         VerifyZipFile(task.CreatedZipPath);
     }
 

--- a/test/Azure.Functions.Sdk.Tests/Tasks/Publish/FuncZipDeployTaskTests.cs
+++ b/test/Azure.Functions.Sdk.Tests/Tasks/Publish/FuncZipDeployTaskTests.cs
@@ -14,7 +14,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Azure.Functions.Sdk.Tasks.Publish.Tests;
 
-public sealed class ZipDeployTaskTests
+public sealed class FuncZipDeployTaskTests
 {
     private const string TestZipPath = @"C:\publish\app.zip";
     private const string TestPublishUrl = "https://functionapp.scm.test/";
@@ -30,7 +30,7 @@ public sealed class ZipDeployTaskTests
     public void Execute_ZipFileNotFound_ReturnsFalseAndLogsError()
     {
         // Arrange - file does not exist in MockFileSystem
-        using ZipDeploy task = CreateTask();
+        using FuncZipDeploy task = CreateTask();
 
         // Act
         bool result = task.Execute();
@@ -54,7 +54,7 @@ public sealed class ZipDeployTaskTests
         });
 
         DeploymentClient client = CreateDeploymentClient(handler);
-        using ZipDeploy task = CreateTask(client);
+        using FuncZipDeploy task = CreateTask(client);
 
         // Act
         bool result = task.Execute();
@@ -75,7 +75,7 @@ public sealed class ZipDeployTaskTests
     {
         // Arrange
         _fileSystem.AddFile(TestZipPath, new MockFileData("fake zip content"));
-        using ZipDeploy task = CreateTask();
+        using FuncZipDeploy task = CreateTask();
         task.PublishUrl = invalidUrl;
 
         // Act
@@ -102,7 +102,7 @@ public sealed class ZipDeployTaskTests
         });
 
         DeploymentClient client = CreateDeploymentClient(handler);
-        using ZipDeploy task = CreateTask(client);
+        using FuncZipDeploy task = CreateTask(client);
         task.PublishUrl = validUrl;
 
         // Act
@@ -128,7 +128,7 @@ public sealed class ZipDeployTaskTests
             Content = CreateStatusContent(status)
         });
         DeploymentClient client = CreateDeploymentClient(handler);
-        using ZipDeploy task = CreateTask(client);
+        using FuncZipDeploy task = CreateTask(client);
 
         // Act
         bool result = task.Execute();
@@ -153,7 +153,7 @@ public sealed class ZipDeployTaskTests
         mockClient
             .Setup(c => c.ZipDeployAsync(It.IsAny<ZipDeployRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(status);
-        using ZipDeploy task = CreateTask(mockClient.Object);
+        using FuncZipDeploy task = CreateTask(mockClient.Object);
 
         // Act
         bool result = task.Execute();
@@ -182,7 +182,7 @@ public sealed class ZipDeployTaskTests
             };
         });
         DeploymentClient client = CreateDeploymentClient(handler);
-        using ZipDeploy task = CreateTask(client);
+        using FuncZipDeploy task = CreateTask(client);
 
         // Act
         bool result = task.Execute();
@@ -219,7 +219,7 @@ public sealed class ZipDeployTaskTests
             };
         });
         DeploymentClient client = CreateDeploymentClient(handler);
-        using ZipDeploy task = CreateTask(client);
+        using FuncZipDeploy task = CreateTask(client);
         task.UseBlobContainerDeploy = useBlobContainer;
 
         // Act
@@ -253,7 +253,7 @@ public sealed class ZipDeployTaskTests
         mockClient
             .Setup(c => c.ZipDeployAsync(It.IsAny<ZipDeployRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(DeployStatus.Failed);
-        using ZipDeploy task = CreateTask(mockClient.Object);
+        using FuncZipDeploy task = CreateTask(mockClient.Object);
         task.PublishUrl = secretPublishUrl;
 
         // Act
@@ -286,7 +286,7 @@ public sealed class ZipDeployTaskTests
                 ct.ThrowIfCancellationRequested();
                 return Task.FromResult(DeployStatus.Success);
             });
-        using ZipDeploy task = CreateTask(mockClient.Object);
+        using FuncZipDeploy task = CreateTask(mockClient.Object);
 
         // Act
         task.Cancel();
@@ -304,7 +304,7 @@ public sealed class ZipDeployTaskTests
     public void Dispose_DoesNotThrow()
     {
         // Arrange
-        ZipDeploy task = CreateTask();
+        FuncZipDeploy task = CreateTask();
 
         // Act
         Action act = () => task.Dispose();
@@ -317,7 +317,7 @@ public sealed class ZipDeployTaskTests
     public void Dispose_MultipleDispose_DoesNotThrow()
     {
         // Arrange
-        ZipDeploy task = CreateTask();
+        FuncZipDeploy task = CreateTask();
         task.Dispose();
 
         // Act - dispose again
@@ -335,7 +335,7 @@ public sealed class ZipDeployTaskTests
     public void Properties_DefaultValues()
     {
         // Arrange & Act
-        using ZipDeploy task = new(_fileSystem)
+        using FuncZipDeploy task = new(_fileSystem)
         {
             BuildEngine = _buildEngine.Object,
         };
@@ -360,15 +360,15 @@ public sealed class ZipDeployTaskTests
     public void BuildHttpClient_UserAgentIsSet()
     {
         // Arrange
-        using ZipDeploy task = CreateTask();
+        using FuncZipDeploy task = CreateTask();
         task.DotnetSdkVersion = "10.0.100";
 
         // Act
         HttpClient client = task.BuildHttpClient(new Uri(TestPublishUrl));
 
         // Assert
-        client.DefaultRequestHeaders.UserAgent.Should().Contain(ZipDeploy.SdkUserAgentHeader);
-        client.DefaultRequestHeaders.UserAgent.Should().Contain(ZipDeploy.OsUserAgentHeader);
+        client.DefaultRequestHeaders.UserAgent.Should().Contain(FuncZipDeploy.SdkUserAgentHeader);
+        client.DefaultRequestHeaders.UserAgent.Should().Contain(FuncZipDeploy.OsUserAgentHeader);
         client.DefaultRequestHeaders.UserAgent.Should().Contain(new ProductInfoHeaderValue("Microsoft.NET.Sdk", "10.0.100"));
     }
 
@@ -393,7 +393,7 @@ public sealed class ZipDeployTaskTests
         return new DeploymentClient(httpClient);
     }
 
-    private ZipDeploy CreateTask(DeploymentClient? client = null)
+    private FuncZipDeploy CreateTask(DeploymentClient? client = null)
     {
         return new(_fileSystem, client)
         {


### PR DESCRIPTION
## Summary

- rename the Functions SDK deployment task to `FuncZipDeploy` to avoid the `Microsoft.NET.Sdk.Publish` task-name collision
- create `PublishIntermediateTempPath` before writing the deployment ZIP
- add focused unit and publish integration coverage for clean-tree ZipDeploy publishing
- update release notes and bump `Azure.Functions.Sdk` to 1.0.1

## Testing

- `dotnet test test\Azure.Functions.Sdk.Tests\Azure.Functions.Sdk.Tests.csproj --filter "FullyQualifiedName~FuncZipDeployTaskTests|FullyQualifiedName~CreateFuncZipFileTests|FullyQualifiedName~Publish_ZipDeploy_UsesFunctionsTask" --no-restore --logger "console;verbosity=minimal"`
- 27 tests passed on `net10.0`
- 27 tests passed on `net472`
- evaluated package version: `1.0.1`

Closes #3502
Closes #3503